### PR TITLE
build(stacks): optimize fastapi-next Docker builds

### DIFF
--- a/stacks/fastapi-next/backend/.dockerignore
+++ b/stacks/fastapi-next/backend/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+.git
+.env

--- a/stacks/fastapi-next/backend/Dockerfile
+++ b/stacks/fastapi-next/backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # {{ project_name }} backend — FastAPI. Image bakes source + dev deps so the
 # same image serves the app (default command) and the `tools` profile
 # (ruff/mypy/pytest, command overridden at call time).
@@ -6,8 +7,15 @@ FROM python:3.12-slim
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 
+# Deps first for layer caching. The BuildKit cache mount keeps pip's download
+# cache OUT of the image while avoiding re-downloads when this layer busts, so a
+# pyproject change re-resolves without re-fetching every unchanged wheel. The
+# editable install runs before `COPY . .` (setuptools maps zero packages now);
+# its egg-link picks up app/ once the source is copied below — see the
+# [tool.pytest.ini_options] note in pyproject.toml.
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir -e ".[dev]"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -e ".[dev]"
 
 COPY . .
 

--- a/stacks/fastapi-next/frontend/.dockerignore
+++ b/stacks/fastapi-next/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+npm-debug.log*
+.git

--- a/stacks/fastapi-next/frontend/Dockerfile
+++ b/stacks/fastapi-next/frontend/Dockerfile
@@ -1,12 +1,18 @@
+# syntax=docker/dockerfile:1
 # {{ project_name }} frontend — Next.js. Image bakes source + deps so it serves
 # the app (default command) and the `node` profile (tsc/eslint/next build,
 # command overridden at call time).
-FROM node:20-slim
+FROM node:22-alpine
 
 WORKDIR /app
 
+# Deps first for layer caching. The BuildKit cache mount persists npm's download
+# cache across builds (outside the image), so a package.json change reinstalls
+# without re-fetching every unchanged package. No lockfile is committed yet, so
+# this uses `npm install`; commit package-lock.json and switch to `npm ci` for
+# reproducible installs.
 COPY package.json ./
-RUN npm install
+RUN --mount=type=cache,target=/root/.npm npm install
 
 COPY . .
 


### PR DESCRIPTION
## What

Optimize the `fastapi-next` stack's Docker builds. Since `bin/generate.py` stamps every project from `stacks/`, this propagates the improvements to every future project.

- Add BuildKit `# syntax=docker/dockerfile:1` + pip/npm **cache mounts** so a deps-manifest change re-resolves without re-downloading unchanged packages; drop the now-redundant `--no-cache-dir` (the cache mount keeps pip's cache out of the image).
- Add `backend/.dockerignore` + `frontend/.dockerignore` so `COPY . .` stops pulling `node_modules`/`.git`/`.venv`/`__pycache__` into the build context and image.
- Bump frontend base `node:20-slim` → `node:22-alpine` (matches the deployed project-healer frontend).

## Behavior preserved

Single-shot editable install still runs before `COPY . .`, per the `[tool.pytest.ini_options]` note in `pyproject.toml`. `.dockerignore` files carry no template tokens, so `generate.py` copies them verbatim into stamped projects.

## Verified

Built on a stamped descendant (project-scribe):
- frontend **787 MB → 493 MB (−37%)**
- backend **362 MB → 331 MB**
- `import app.main` resolves (editable install maps `app/`); `next dev` boots in ~1s on musl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
