### PR TITLE
docs(template): standardize shared local TLS authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ Adding a whole new stack: [docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md).
    running app. A project documenting itself is one of firestarter's merits; don't
    drop it, hide it behind a flag, or let a stack regress it. New stacks
    ([docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md)) must wire their own.
+7. **One workstation CA for local HTTPS.** Keep the cross-agent policy in
+   `template/docs/LOCAL_TLS.md`: generated projects reuse the owner-manifested
+   canonical proxy/CA, never create per-project roots, never expose CA keys, and
+   never persist certificate-verification bypasses.
 
 ## Verify before you commit
 
@@ -116,4 +120,5 @@ any generated stack *require* a paid feature to function.
 - [docs/ANATOMY.md](docs/ANATOMY.md) — file-by-file map, token reference, gotchas
 - [docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md) — new stack profiles
 - [docs/LIFT-LOG.md](docs/LIFT-LOG.md) — harvesting learnings back
+- [template/docs/LOCAL_TLS.md](template/docs/LOCAL_TLS.md) — shared local-CA policy
 - [firestarter.config.json](firestarter.config.json) — the variable manifest

--- a/docs/ANATOMY.md
+++ b/docs/ANATOMY.md
@@ -49,6 +49,7 @@ docs/                     this map, plus how-to guides
 | `.gitleaks.toml` | gitleaks config: extends default rules + allowlists build-artifact dirs (so local `make secret-scan` on a dirty tree is clean). Add narrow allowlists for known public/test fixtures | best-practice |
 | `docs/ci-secrets.md` | How to set `ANTHROPIC_API_KEY` without leaking it | sibling |
 | `docs/HOST_REQUIREMENTS.md` | Onboarding: the few tools that live on the host (Docker/git/make/gh) + a "do NOT install on host" table + opt-in native-mobile sections | sibling |
+| `docs/LOCAL_TLS.md` | Shared local-CA policy and macOS/Caddy runbook: fingerprint-checked trust, one canonical issuer, no agent-held CA keys, verified rollout/rollback | local-ai certificate incident |
 | `docs/OPEN_QUESTIONS.md` | Template for the deferred-decisions log (incl. a backup-strategy stub) | both |
 | `docs/GO_LIVE.md` | Clean-slate run/verify/go-live checklist tying together secrets, release, deploy, backups | sibling |
 | `docs/DEPLOY_POLICY.md` | The *decision frame* `GO_LIVE`/`DEPLOY` don't cover: when a deploy is **self-authorized** (3 conditions — ample testing, snapshot verification, post-deploy check) vs. what stays owner-only (credentials, prod-DB migrations, billing) | sibling |

--- a/docs/LIFT-LOG.md
+++ b/docs/LIFT-LOG.md
@@ -39,6 +39,7 @@ Every so often (e.g. when starting a new project), skim the siblings'
 
 | Date | Lifted | From | Into |
 |------|--------|------|------|
+| 2026-07-14 | **One workstation local CA**: generated projects now require agents to reuse a host-manifested canonical Caddy CA, compare exact root fingerprints, keep CA keys service-owned, reject per-project self-signed roots/TLS bypasses, and verify durable proxy config plus rollback. Includes the macOS Login-Keychain trust runbook and `.test` naming guidance. | local-ai duplicate-Caddy-CA incident | `template/AGENTS.md` + `template/CLAUDE.md` + `template/SECURITY.md` + `template/docs/` |
 | 2026-06-29 | Initial distillation: meta-layer + two stack profiles | siblings | template/ + stacks/ |
 | 2026-06-29 | Self-CI: firestarter runs its own ci/review/auto-merge + lenient branch protection | (best-practice) | .github/workflows/ |
 | 2026-06-29 | Sibling glean: dependabot, PR + issue templates, local ai-review.sh, postmortem template, .editorconfig, SECURITY.md, one-button Cloudflare deploy | sibling | template/ + stacks/ |

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -56,6 +56,16 @@ Run these every time you open a new session, in order. Do not skip.
    `backend/migrations/`.
 5. List Docker state: `docker compose ps` so you know whether the stack is up.
 
+## Local TLS and certificate authority
+
+Read [docs/LOCAL_TLS.md](docs/LOCAL_TLS.md) before changing local HTTPS. Reuse
+the owner's canonical workstation CA and reverse proxy recorded in
+`~/.config/pet-projects/local-tls.json`; never create a per-project root or
+unrelated self-signed certificate. Agents configure routes, while the shared CA
+service signs certificates and retains all private keys. Trust-store changes,
+CA rotation, and live proxy reloads are owner-approved host operations. Verify
+HTTPS without `-k`, `--insecure`, or disabled certificate checks.
+
 ## Commit, branch, and merge workflow
 
 ### Branching

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -44,6 +44,10 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full layer rules.
   `feat fix refactor chore docs test ci build`. Subject ≤ 100 chars.
 - **Forward-only migrations.** Never edit an applied migration except for
   provably idempotent `IF NOT EXISTS` hardening. New behaviour = new numbered file.
+- **One local CA, no agent-held signing keys.** Before changing local HTTPS, read
+  `docs/LOCAL_TLS.md` and the host's `~/.config/pet-projects/local-tls.json`.
+  Reuse the canonical proxy/CA; never create a project root or persist a TLS
+  verification bypass.
 - **Stage explicit paths, never `git add -A`.** This checkout may be shared by
   concurrent sessions; blanket staging sweeps another session's work into your
   commit. `.claude/settings.json` denies the blanket forms — see *Branching* in

--- a/template/SECURITY.md
+++ b/template/SECURITY.md
@@ -24,6 +24,12 @@ You'll get an acknowledgement and a coordinated disclosure timeline.
   Cloudflare quick-tunnel is anonymous) — keep it that way.
 - The anonymous-identity and data-exposure invariants in `ARCHITECTURE.md` are
   part of the security surface — a violation is a vulnerability, not a bug.
+- **Local CA keys are workstation credentials.** Never read, copy, export,
+  transmit, or commit a root/intermediate private key. Local projects reuse the
+  owner-approved CA described in [docs/LOCAL_TLS.md](docs/LOCAL_TLS.md); agents
+  configure routes and let the CA service issue short-lived certificates.
+  Never persist a TLS verification bypass. Trust-store changes and CA rotation
+  require explicit owner approval and exact-fingerprint verification.
 
 ## Scope
 

--- a/template/docs/HOST_REQUIREMENTS.md
+++ b/template/docs/HOST_REQUIREMENTS.md
@@ -33,6 +33,15 @@ Verify: `gh --version`
 
 That's it. Everything below is optional.
 
+### Local HTTPS (optional)
+
+When this project needs a trusted local HTTPS URL, reuse the workstation's
+canonical reverse proxy and local CA rather than installing a project-specific
+certificate tool. Read [LOCAL_TLS.md](LOCAL_TLS.md) and, when present,
+`~/.config/pet-projects/local-tls.json`. Caddy/OpenSSL are host infrastructure in
+that workflow, not project language SDKs. Importing a trust root or reloading the
+live proxy remains an owner-approved operation.
+
 ## 2. What you do NOT install on the host
 
 These are managed inside Docker (behind Compose profiles, invoked by the

--- a/template/docs/LOCAL_TLS.md
+++ b/template/docs/LOCAL_TLS.md
@@ -1,0 +1,182 @@
+# Local HTTPS and the shared development CA
+
+Local HTTPS uses one workstation-owned certificate authority (CA), not a new
+self-signed certificate for every project. This keeps browser trust durable and
+prevents each tool or AI agent from silently creating a different trust root.
+
+## Non-negotiable model
+
+```text
+one owner-trusted local root
+  -> one service-managed intermediate
+    -> short-lived project certificates
+```
+
+- The reverse-proxy/CA service signs certificates. Agents configure routes;
+  they do **not** handle signing keys or sign certificates themselves.
+- Never create or trust a per-project root CA when the host already has a
+  canonical local CA.
+- Never read, copy, display, transmit, or commit `root.key`, `intermediate.key`,
+  or any exported private key.
+- Never make `-k`, `--insecure`, disabled verification, or an "accept any
+  certificate" callback part of committed code or permanent configuration.
+- Importing/removing a trust root, rotating the CA, or reloading the live proxy
+  is an owner-approved host operation. Normal branch, review, test, rollout,
+  and rollback rules still apply.
+
+## Agent startup procedure
+
+When a task involves local HTTPS:
+
+1. Read `~/.config/pet-projects/local-tls.json` if it exists. It is the
+   workstation's non-secret source of truth for the proxy service, persistent
+   data directory, public root-certificate path, expected SHA-256 fingerprint,
+   canonical config, and naming policy.
+2. Inspect the process that actually serves the port. Do not assume an
+   interactive shell and a background service use the same data directory.
+3. Match the public root certificate's SHA-256 fingerprint to the manifest
+   before changing trust. A common name is not sufficient: two roots can have
+   the same name but different keys.
+4. Add the project route to the canonical reverse proxy and use its internal
+   issuer. Do not launch a second proxy instance with a different data
+   directory.
+5. Parse candidate and rollback Caddyfiles without provisioning by running
+   `caddy adapt --config <file> --adapter caddyfile >/dev/null`. Review the diff,
+   reload only with authorization, and verify the live URL without a TLS bypass.
+
+If the manifest is absent, stop before creating or trusting a CA. Ask the owner
+whether to adopt the existing proxy CA or establish a new workstation CA, then
+record the approved public metadata in that manifest. Private keys never belong
+in the manifest.
+
+## Caddy pattern
+
+For a Mac using one Homebrew Caddy service, the canonical service owns the root,
+intermediate, and leaf lifecycle:
+
+```caddyfile
+{
+	skip_install_trust
+}
+
+https://{{ project_slug }}.dev.test:8443 {
+	reverse_proxy 127.0.0.1:{{ port_web }}
+	tls internal
+}
+```
+
+This stamped example is only for a server-based project whose web service is
+actually listening on loopback port `{{ port_web }}`. Confirm the process and
+health path before deployment. A browser extension or another project with no
+local server needs no proxy route and no child certificate; apply this workflow
+only if that project later adds a loopback service.
+
+`skip_install_trust` is intentional after the owner performs the one-time,
+fingerprint-checked trust operation. It prevents background reloads from trying
+to make trust-store changes. Caddy's persistent data directory must be preserved;
+starting another Caddy under a different `HOME`/`XDG_DATA_HOME` creates a second,
+untrusted CA even when both roots have the same display name.
+
+Version a project-specific Caddy snippet when useful, but deploy it into the
+canonical config named by the host manifest. Preflight candidate and rollback
+syntax without provisioning:
+
+```bash
+caddy adapt --config /path/to/Caddyfile --adapter caddyfile >/dev/null
+```
+
+Do **not** use `caddy validate` or `caddy adapt --validate` from an ordinary
+interactive shell for a `tls internal` config. Validation provisions PKI and can
+create a second root/intermediate under the shell's `HOME`/`XDG_DATA_HOME`. Let
+the already-running canonical service provision during the authorized reload.
+A service restart must read the same persistent config that was live-tested; an
+admin-API-only reload from another file is not durable.
+
+## One-time macOS trust procedure
+
+The owner performs this once. Replace the examples with the exact values from
+the host manifest:
+
+```bash
+ROOT_CERT=/path/from/local-tls.json
+EXPECTED_SHA256=FINGERPRINT_FROM_LOCAL_TLS_JSON
+normalize_sha256() {
+  printf '%s' "$1" | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]'
+}
+EXPECTED_SHA256="$(normalize_sha256 "$EXPECTED_SHA256")"
+ACTUAL_SHA256="$(normalize_sha256 "$(
+  openssl x509 -in "$ROOT_CERT" -noout -fingerprint -sha256 | sed 's/.*=//'
+)")"
+if [ "$ACTUAL_SHA256" = "$EXPECTED_SHA256" ]; then
+  security add-trusted-cert \
+    -r trustRoot \
+    -p ssl \
+    -k "$HOME/Library/Keychains/login.keychain-db" \
+    "$ROOT_CERT"
+else
+  printf 'Refusing trust import: root fingerprint mismatch\n' >&2
+fi
+```
+
+This trusts only the public root for SSL in the current user's Login Keychain.
+System-wide trust is a separate administrator-approved action. Never import a
+private key. Browsers already running may need a full restart before they notice
+the updated Keychain.
+
+To inspect installed roots, compare exact fingerprints rather than names:
+
+```bash
+security find-certificate -a -Z -c 'Caddy Local Authority' \
+  "$HOME/Library/Keychains/login.keychain-db"
+```
+
+## Naming
+
+- Keep an existing `macbook-pro.local`-style name only when Bonjour/mDNS is the
+  intended resolver. `.local` has special mDNS meaning.
+- Prefer `<project>.dev.test` for new pet projects. `.test` is reserved for
+  testing and cannot collide with a public DNS suffix.
+- Add explicit local name resolution (for example, owner-managed `/etc/hosts`
+  entries or a local DNS resolver). A certificate does not create DNS.
+- The port is not part of a certificate name. The same trusted certificate name
+  works on `443`, `8443`, or another HTTPS port when the URL includes that port.
+
+## Verification
+
+Success requires all of the following:
+
+```bash
+PROJECT_HOST={{ project_slug }}.dev.test
+PROJECT_PORT=8443
+
+# No -k / --insecure. Append the project's documented health path when it has one.
+curl --fail --show-error --silent "https://${PROJECT_HOST}:${PROJECT_PORT}/"
+
+# Confirm the served identity, issuer, validity, and SANs.
+openssl s_client -connect "${PROJECT_HOST}:${PROJECT_PORT}" \
+  -servername "$PROJECT_HOST" </dev/null 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates -ext subjectAltName
+```
+
+For a project with no local server, skip certificate issuance and this live URL
+check. Otherwise, also open the URL in the owner's normal browser and confirm
+there is no warning.
+Some Python, Node, Java, and container runtimes do not use the macOS Keychain.
+Give those clients the **public root certificate** through their supported CA
+bundle setting (for example `SSL_CERT_FILE`) rather than disabling verification.
+
+## Rollback and CA compromise
+
+Before removing trust, identify the exact installed SHA-256 fingerprint from the
+host manifest. Then remove only that certificate and its user trust settings:
+
+```bash
+security delete-certificate -t -Z SHA256_WITHOUT_COLONS \
+  "$HOME/Library/Keychains/login.keychain-db"
+```
+
+Removing trust does not delete Caddy's CA files; it only restores browser
+warnings. If a CA private key may have been exposed, stop using the CA, remove
+its trust anchor, rotate to a new root, reissue all project certificates, update
+the host manifest, and document the incident. Do not quietly re-trust a copied
+or unexplained root.


### PR DESCRIPTION
## Summary

- Add a universal local-TLS runbook for generated projects.
- Tell every agent to reuse a host-manifested canonical CA and never create per-project roots or handle CA keys.
- Use project tokens for server-based Caddy examples and explicitly skip no-server stacks.
- Document fingerprint-normalized, fail-closed macOS trust; non-provisioning Caddy preflight; verified rollout; rollback; and CA-compromise handling.
- Record the reusable learning in Anatomy and the Lift Log.

## Security and compatibility

- No private key, secret, or host-specific certificate is committed.
- Trust import is conditional on an exact SHA-256 match.
- `caddy validate` and `caddy adapt --validate` are explicitly rejected for interactive preflight because they provision PKI.
- The policy stamps into all stacks; no-server projects are told not to issue a certificate.

## Verification

- Docker-stamped `fastapi-next`, `supabase-flutter`, and `chrome-extension`.
- Confirmed `docs/LOCAL_TLS.md`, AGENTS, and SECURITY references in every output.
- Confirmed all template tokens resolve and GitHub expressions survive.
- Ran generated script-smoke checks for all three stacks.
- Compiled the generator inside Docker and syntax-checked the entrypoint.
- Confirmed plain `caddy adapt` creates no PKI files in a fresh data directory.
- gitleaks v8.30.1: no leaks.
- `git diff --check`.
- Independent security/template review: LGTM after every blocking and non-blocking finding was fixed.

## Rollout and rollback

This is a documentation/template-only change. New stamps inherit the policy; existing projects can lift it deliberately. Roll back by reverting the squash commit through a PR.
