### PR TITLE
docs: remote-access recipe (Tailscale desktop-app + userspace + quick-tunnel fallback)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Follow [docs/LIFT-LOG.md](docs/LIFT-LOG.md): generalize with tokens, place it in
 `template/` (universal) or `stacks/<stack>/` (stack-specific), document gotchas
 as inline comments, add a row to `docs/ANATOMY.md` and the lift log.
 Adding a whole new stack: [docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md).
+Exposing a local/dev service remotely (phone, anywhere, private): [docs/REMOTE-ACCESS.md](docs/REMOTE-ACCESS.md) — default to Tailscale `serve` over public tunnels.
 
 ## Hard rules (do not violate)
 
@@ -70,10 +71,20 @@ Adding a whole new stack: [docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md).
    the acceptance path, a meaningful failure/retry/rollback/cleanup path, exact
    automated and live checks, and inspectable evidence. Visible UI work also
    needs real rebuilt-app storyboard frames and a compact state/flow map. For a
-   material multi-step UI flow, add a short captioned release cut only when the
-   repository already provides a reproducible Dockerized harness and named Make
-   target; otherwise mark video N/A and give a still-frame walkthrough. Natural
-   voice narration is optional, never a universal completion gate.
+   material multi-step UI flow, run the repository's full end-user E2E/release
+   rehearsal when it has one and use those captures as the video source. Add a
+   **20–40 second narrated and captioned release cut** when the repository
+   provides a reproducible Dockerized harness and named Make target. The cut
+   needs a natural conversational voice, selectable or burned-in subtitles, and
+   restrained focus/transition effects that direct attention to the control or
+   state being discussed. Commit a compact polished master and optional GIF
+   preview under `docs/media/` when each is under 10 MB; use a release attachment
+   or Git LFS above that threshold, and keep raw E2E recordings as artifacts.
+   Keep E2E assertions at normal speed: capture asserted story beats and focus
+   targets without `slowMo` or fixed presentation waits, then add voice, captions,
+   pacing, and effects in a separate post-process after the tests pass.
+   Otherwise mark video N/A and give a still-frame walkthrough; never improvise
+   an untracked host media toolchain.
    Non-visual work substitutes request/response, log, migration, build/output,
    or state-transition evidence. Handoff artifacts use synthetic/test data and
    never contain credentials, secrets, private records, or production data.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ process ([LIFT-LOG](docs/LIFT-LOG.md)) for folding new lessons back in.
 | ✅ **Green-before-push** | One `make precommit` mirrors every CI gate locally, in Docker. Stop pushing to "see if CI passes." |
 | 📐 **Conventions enforced, not hoped-for** | Conventional Commits + forward-only migrations enforced by git hooks *and* CI. |
 | 🔭 **It documents itself** | A storyboard harness renders a live *planned-vs-implemented* map with screenshots straight from the running app. |
-| 🎬 **Evidence-backed handoffs** | Every feature reaches review with exact acceptance, failure/rollback, and verification evidence. Visible work adds real storyboard frames and a state map; a short captioned release cut is used when a reproducible harness exists. |
+| 🎬 **Evidence-backed handoffs** | Every feature reaches review with exact acceptance, failure/rollback, and verification evidence. Visible work adds real storyboard frames and a state map; supported flows capture asserted E2E story beats at normal speed, then post-produce narration, captions, focus effects, and a 20–40s release cut. |
 | 🚀 **Share in one button** | Server-backed stacks use `make deploy` for a public Cloudflare URL with no cloud bill; client-only stacks keep distribution owner-gated. |
 | 🧩 **Three real stacks + opt-in add-ons** | FastAPI+Next.js, Supabase+Flutter, or a Manifest V3 Chrome extension, with the painful gotchas baked into comments. k8s is one flag away for the server-backed stacks. |
 | 🤝 **AI-agent ready** | A root `AGENTS.md` (the cross-tool standard) lets Claude Code, Codex, Cursor, or Aider drive the repo on sight. |
@@ -97,4 +97,5 @@ whitelist-only, so GitHub Actions `${{ … }}` is never clobbered.
 - 🗺️ [docs/ANATOMY.md](docs/ANATOMY.md) — file-by-file map: what each piece is, why it exists, and which sibling it came from
 - ➕ [docs/ADDING-A-STACK.md](docs/ADDING-A-STACK.md) — author a new stack profile
 - ♻️ [docs/LIFT-LOG.md](docs/LIFT-LOG.md) — how learnings get harvested back into the template
+- 🔐 [docs/REMOTE-ACCESS.md](docs/REMOTE-ACCESS.md) — reach a stamped project's local/dev service from your phone anywhere, privately, via Tailscale (no domain, no registrar, no spend)
 - 🤖 [AGENTS.md](AGENTS.md) — operating brief for any AI session

--- a/docs/REMOTE-ACCESS.md
+++ b/docs/REMOTE-ACCESS.md
@@ -2,32 +2,47 @@
 
 A recipe for reaching a stamped project's local dev server or a self-hosted service
 **from anywhere** (your phone on cellular, another network) **privately** — without a
-public tunnel, a custom domain, a registrar/DNS change, root on the box, or any paid plan.
+public tunnel, a custom domain, a registrar/DNS change, or any paid plan.
 
 Lifted from `local-ai`, where it replaced a rotating Cloudflare quick-tunnel for a
 voice-auth phone app. See that repo's `docs/REMOTE_ACCESS.md` for the live example.
 
 ## When to reach for this
 
-You want a **stable** remote URL and the usual paths are blocked or heavy:
-no passwordless `sudo`, registrar/DNS changes gated or unavailable, you don't want to pay,
-and you don't want to expose the service on the public internet. Tailscale builds a private
-WireGuard mesh between *your own* devices and hands each a stable `*.ts.net` MagicDNS name.
-Nothing is publicly reachable, so it's strictly more private than a `trycloudflare`/ngrok
-public tunnel.
+You want a **stable** remote URL and the usual paths are blocked or heavy: registrar/DNS
+changes gated, no budget, and you don't want to expose the service on the public internet.
+Tailscale builds a private WireGuard mesh between *your own* devices and hands each a stable
+`*.ts.net` MagicDNS name. Nothing is publicly reachable, so it's strictly more private than a
+`trycloudflare`/ngrok public tunnel.
 
 Decision order for exposing a service:
-1. **Same LAN only** → local Caddy `tls internal` at `<host>.local` (see the generated
-   project's TLS docs).
-2. **Your devices, anywhere, private** → **Tailscale `serve`** (this doc). Default for
-   anything sensitive.
-3. **Public internet (non-your devices)** → Cloudflare Tunnel / Tailscale `funnel`. Only when
-   strangers must reach it; never for private data.
+1. **Same LAN only** → local Caddy `tls internal` at `<host>.local`.
+2. **Your devices, anywhere, private** → **Tailscale `serve`** (this doc). Default for sensitive.
+3. **Public internet (strangers)** → Cloudflare Tunnel / Tailscale `funnel`. Never for private data.
 
-## Rootless setup (no sudo)
+## Two ways to run the node — pick by device
 
-`tailscaled` wants root for a TUN device. With no passwordless sudo, run **userspace
-networking** — fully rootless; `serve`/`funnel` still work (they proxy at the app layer):
+### A. Desktop (macOS/Windows/Linux GUI) → the official Tailscale **app**  ← default
+
+On a real desktop, install the official app and sign in. It runs a system extension that wires
+**MagicDNS into the OS resolver** (the machine resolves `*.ts.net` natively), is **boot-persistent**,
+and gives a tray/menu-bar UI. On macOS the app's CLI is at
+`/Applications/Tailscale.app/Contents/MacOS/Tailscale` — use it for `serve`/`status`.
+
+> **macOS caveat that bites:** the Homebrew `tailscaled` **system daemon does NOT configure
+> macOS DNS** (no `100.100.100.100` scoped resolver in `scutil --dns`, even with
+> `--accept-dns=true`), so the Mac can't resolve its own `*.ts.net` name. Use the **.app** on a
+> Mac desktop, not the brew daemon.
+
+```bash
+APP=/Applications/Tailscale.app/Contents/MacOS/Tailscale
+"$APP" serve --bg --https=443 http://127.0.0.1:<port>   # -> https://<node>.<tailnet>.ts.net/
+```
+
+### B. Headless / no-sudo / server / container → rootless **userspace** daemon
+
+For a box with no GUI, no root, or no passwordless sudo (CI runner, VPS, container), run
+userspace networking — fully rootless; `serve`/`funnel` still work (they proxy at the app layer):
 
 ```bash
 mkdir -p ~/.tailscale-userspace
@@ -35,34 +50,25 @@ tailscaled --tun=userspace-networking \
   --socket=$HOME/.tailscale-userspace/sock \
   --statedir=$HOME/.tailscale-userspace/state &
 S=$HOME/.tailscale-userspace/sock
-tailscale --socket=$S up --hostname=<project>   # prints a login URL — the owner taps it
-```
-
-Every later `tailscale` call needs `--socket=$S`. **Caveat:** this instance does not survive
-reboot. For boot-persistence use `sudo tailscaled install-system-daemon` or the Tailscale
-desktop app — both need the owner at the machine with sudo.
-
-## Expose the service
-
-```bash
-# HTTP is fine for apps that don't need a browser "secure context":
-tailscale --socket=$S serve --bg --http=80   http://127.0.0.1:<port>
-# HTTPS (valid cert, no warning) for apps that do:
+tailscale --socket=$S up --hostname=<project>          # login URL — the owner taps it
 tailscale --socket=$S serve --bg --https=443 http://127.0.0.1:<port>
-#   -> https://<project>.<tailnet>.ts.net/
 ```
 
-Use `serve` (tailnet-only), not `funnel` (public), for private services.
+Every later `tailscale` call needs `--socket=$S`. **Caveats:** does not survive reboot; on a
+desktop OS it won't provide system DNS (peers still resolve it fine). A stopgap / headless tool,
+not the desktop answer.
 
-### Two gotchas that will bite you
+## Gotchas (both paths)
 
-- **HTTPS certs must be enabled on the tailnet** or `serve --https` fails with
-  `500 ... account does not support getting TLS certs`. Enable once at the Tailscale admin
-  DNS page → **HTTPS Certificates → Enable** (owner action).
-- **Secure-context APIs need HTTPS.** Anything using `getUserMedia`, `SpeechRecognition`,
-  service workers, clipboard, etc. is blocked by the browser over plain HTTP. Those services
-  **must** use `serve --https` (⇒ enable HTTPS certs first). Plain-HTTP `serve` is only for
-  apps that don't touch a secure-context API.
+- **HTTPS certs must be enabled on the tailnet** or `serve --https` fails
+  `500 ... account does not support getting TLS certs`. Enable once at the Tailscale admin DNS
+  page → **HTTPS Certificates → Enable** (owner action).
+- **Secure-context APIs need HTTPS.** `getUserMedia`, `SpeechRecognition`, service workers,
+  clipboard, etc. are blocked by the browser over plain HTTP → those services **must** use
+  `serve --https`. Plain-HTTP `serve` is only for apps that don't touch a secure-context API.
+- **Stale-node / `-1` name.** Switching daemons or re-registering leaves the old node reserving
+  the hostname → the new one becomes `<name>-1`. Delete the stale node in the admin console to
+  reclaim the clean name, then `serve reset` + re-apply so the TLS cert matches the current name.
 
-The owner's phone joins the tailnet via the Tailscale app (same account); the `*.ts.net`
-URL then works from any network.
+Use `serve` (tailnet-only), not `funnel` (public), for private services. The owner's phone joins
+the tailnet via the Tailscale app (same account); the `*.ts.net` URL then works from any network.

--- a/docs/REMOTE-ACCESS.md
+++ b/docs/REMOTE-ACCESS.md
@@ -1,0 +1,68 @@
+# Remote access to a local/dev service (Tailscale)
+
+A recipe for reaching a stamped project's local dev server or a self-hosted service
+**from anywhere** (your phone on cellular, another network) **privately** — without a
+public tunnel, a custom domain, a registrar/DNS change, root on the box, or any paid plan.
+
+Lifted from `local-ai`, where it replaced a rotating Cloudflare quick-tunnel for a
+voice-auth phone app. See that repo's `docs/REMOTE_ACCESS.md` for the live example.
+
+## When to reach for this
+
+You want a **stable** remote URL and the usual paths are blocked or heavy:
+no passwordless `sudo`, registrar/DNS changes gated or unavailable, you don't want to pay,
+and you don't want to expose the service on the public internet. Tailscale builds a private
+WireGuard mesh between *your own* devices and hands each a stable `*.ts.net` MagicDNS name.
+Nothing is publicly reachable, so it's strictly more private than a `trycloudflare`/ngrok
+public tunnel.
+
+Decision order for exposing a service:
+1. **Same LAN only** → local Caddy `tls internal` at `<host>.local` (see the generated
+   project's TLS docs).
+2. **Your devices, anywhere, private** → **Tailscale `serve`** (this doc). Default for
+   anything sensitive.
+3. **Public internet (non-your devices)** → Cloudflare Tunnel / Tailscale `funnel`. Only when
+   strangers must reach it; never for private data.
+
+## Rootless setup (no sudo)
+
+`tailscaled` wants root for a TUN device. With no passwordless sudo, run **userspace
+networking** — fully rootless; `serve`/`funnel` still work (they proxy at the app layer):
+
+```bash
+mkdir -p ~/.tailscale-userspace
+tailscaled --tun=userspace-networking \
+  --socket=$HOME/.tailscale-userspace/sock \
+  --statedir=$HOME/.tailscale-userspace/state &
+S=$HOME/.tailscale-userspace/sock
+tailscale --socket=$S up --hostname=<project>   # prints a login URL — the owner taps it
+```
+
+Every later `tailscale` call needs `--socket=$S`. **Caveat:** this instance does not survive
+reboot. For boot-persistence use `sudo tailscaled install-system-daemon` or the Tailscale
+desktop app — both need the owner at the machine with sudo.
+
+## Expose the service
+
+```bash
+# HTTP is fine for apps that don't need a browser "secure context":
+tailscale --socket=$S serve --bg --http=80   http://127.0.0.1:<port>
+# HTTPS (valid cert, no warning) for apps that do:
+tailscale --socket=$S serve --bg --https=443 http://127.0.0.1:<port>
+#   -> https://<project>.<tailnet>.ts.net/
+```
+
+Use `serve` (tailnet-only), not `funnel` (public), for private services.
+
+### Two gotchas that will bite you
+
+- **HTTPS certs must be enabled on the tailnet** or `serve --https` fails with
+  `500 ... account does not support getting TLS certs`. Enable once at the Tailscale admin
+  DNS page → **HTTPS Certificates → Enable** (owner action).
+- **Secure-context APIs need HTTPS.** Anything using `getUserMedia`, `SpeechRecognition`,
+  service workers, clipboard, etc. is blocked by the browser over plain HTTP. Those services
+  **must** use `serve --https` (⇒ enable HTTPS certs first). Plain-HTTP `serve` is only for
+  apps that don't touch a secure-context API.
+
+The owner's phone joins the tailnet via the Tailscale app (same account); the `*.ts.net`
+URL then works from any network.

--- a/docs/REMOTE-ACCESS.md
+++ b/docs/REMOTE-ACCESS.md
@@ -72,3 +72,15 @@ not the desktop answer.
 
 Use `serve` (tailnet-only), not `funnel` (public), for private services. The owner's phone joins
 the tailnet via the Tailscale app (same account); the `*.ts.net` URL then works from any network.
+
+## Fallback: Cloudflare quick-tunnel (PUBLIC, no client install)
+
+When a viewer **can't be on your tailnet** (lending access to someone who won't install Tailscale,
+or a throwaway demo link), `cloudflared tunnel --url http://localhost:<port>` needs no account and
+prints a random `https://<words>.trycloudflare.com` URL with real TLS. It's **public**, so only for
+non-sensitive / short-lived access. Weaknesses: the URL **rotates on every restart** and the tunnel
+**silently deregisters** on network change/idle (process stays up but the host stops resolving —
+detect with `dig @1.1.1.1 <host>`, not a local lookup). Make it usable with a **keep-alive watcher**
+(a launchd/systemd loop that restarts `cloudflared` when the host stops resolving and re-publishes
+the new URL, e.g. via a push notification). For a *durable* public URL, prefer a **named** Cloudflare
+tunnel (stable hostname + auto-reconnect), which needs a zone on Cloudflare.


### PR DESCRIPTION
Reach a stamped project's local/dev service from anywhere, privately: Tailscale .app on desktop (native MagicDNS, boot-persistent), rootless userspace daemon for headless/no-sudo, and the public Cloudflare quick-tunnel fallback. README + AGENTS pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)