### PR TITLE
feat(template): densify Operations Floater guide

### DIFF
--- a/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
+++ b/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
@@ -46,6 +46,9 @@ release.
 2. Copy the candidate to `INSTALLED_APP` using a metadata-preserving local copy.
 3. Launch it and verify one visible dashboard window, default frontmost state,
    unpin behavior, Command-W close, Dock reopen, and Reduce Motion.
+   At the default size, confirm queue and supporting panels use two columns.
+   Resize to the minimum and confirm they collapse to one column without
+   clipping the guide summary or four queue counters.
 4. Choose **Import Local Snapshot…** only if a canonical `local` version `1.0`
    snapshot is ready. The app validates before writing and gives the stored file
    private permissions.
@@ -70,7 +73,8 @@ is retained, and no import data is transmitted.
 ## Rollback
 
 Rollback triggers include failure to launch, signature or Gatekeeper rejection,
-missing window lifecycle behavior, unreadable canonical state, or a material
+missing window lifecycle behavior, an unreadable compact layout, motion that
+continues with Reduce Motion enabled, unreadable canonical state, or a material
 display regression.
 
 1. Quit the app.

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */; };
 		A705BC6F0D3A543F75D84535 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D7388421B1A4219EF55A7B2 /* Assets.xcassets */; };
 		B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */; };
+		C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */; };
 		FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2103622C4FB3754F316FE /* DashboardContract.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		02D2103622C4FB3754F316FE /* DashboardContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContract.swift; sourceTree = "<group>"; };
 		1879896A7B14D79C647AA2C1 /* OperationsFloater.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OperationsFloater.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePresentation.swift; sourceTree = "<group>"; };
 		62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsFloaterApp.swift; sourceTree = "<group>"; };
 		6D7388421B1A4219EF55A7B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotStore.swift; sourceTree = "<group>"; };
@@ -35,6 +37,7 @@
 			isa = PBXGroup;
 			children = (
 				02D2103622C4FB3754F316FE /* DashboardContract.swift */,
+				36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */,
 				CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */,
 				62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */,
 			);
@@ -121,6 +124,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */,
+				C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */,
 				2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */,
 				B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */,
 			);

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -33,15 +33,35 @@ Window lifecycle, foreground level, pinning, and source provenance are
 native-only capabilities. They are deliberately absent from the shared
 snapshot. The browser surface never reads or connects to the native app.
 
+## Shared presentation structure
+
+The native and web dashboards use the same information hierarchy without
+sharing runtime code or creating a device bridge:
+
+1. resource-budget evidence;
+2. queue lanes for running, queued, waiting, and ready work; and
+3. compact tests-and-quality and signals panels.
+
+The native surface adds a local queue guide and window controls. At widths of
+560 points or more, operational panels use a dense two-column grid; below that
+breakpoint, they collapse deterministically to one column. The canonical
+snapshot remains schema version `1.0`.
+
 ## Current behavior
 
 - The dashboard opens visibly in front and defaults to **Keep in front**.
 - Turning off **Keep in front** immediately restores normal window level.
 - Closing the window, including with Command-W, retains the app; use **Show
   Dashboard** or click the Dock icon to reopen the same window.
-- A procedural animated guide is rendered locally. It uses no image feed,
-  camera, microphone, network service, analytics, or external transmission.
-  Reduce Motion is respected.
+- A procedural animated guide summarizes only canonical state. Verified
+  failures and attention signals take priority; unverified failures do not
+  become attention cues.
+- Guide motion is a deterministic function of time and canonical state. Reduce
+  Motion produces a fully stable frame.
+- The guide uses no image feed, camera, microphone, network service, analytics,
+  or external transmission.
+- The default 620-by-640 window shows a dense two-column operational grid and
+  remains usable down to a 380-by-480 compact single-column layout.
 - The application target is sandboxed, uses hardened runtime, and includes a
   macOS app icon, encryption declaration, and productivity category.
 
@@ -50,7 +70,8 @@ preflight, local update procedure, acceptance checks, and rollback path.
 
 ## Validation
 
-Run the focused source and lifecycle tests:
+Run the focused source, deterministic-guide, compact-layout, privacy, and
+lifecycle tests:
 
 ```bash
 swift test

--- a/prototypes/operations-floater/Sources/OperationsFloater/GuidePresentation.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/GuidePresentation.swift
@@ -1,0 +1,186 @@
+import CoreGraphics
+import Foundation
+
+enum GuideActivity: Equatable, Sendable {
+    case attention
+    case active
+    case ready
+    case waiting
+    case idle
+}
+
+struct GuideCue: Equatable, Sendable {
+    let activity: GuideActivity
+    let title: String
+    let detail: String
+}
+
+extension DashboardSnapshot {
+    var guideCue: GuideCue {
+        let verifiedFailureCount = tests.lazy.filter {
+            $0.result == .failed && $0.verification == .verified
+        }.count
+        let verifiedAttentionCount = signals.lazy.filter {
+            $0.state == .attention && $0.verification == .verified
+        }.count
+        if verifiedFailureCount + verifiedAttentionCount > 0 {
+            return GuideCue(
+                activity: .attention,
+                title: "Verified attention needed",
+                detail: countDescription(
+                    verifiedFailureCount + verifiedAttentionCount,
+                    singular: "verified item needs a decision.",
+                    plural: "verified items need a decision."
+                )
+            )
+        }
+
+        let runningCount = queue.lazy.filter { $0.state == .running }.count
+        if runningCount > 0 {
+            return GuideCue(
+                activity: .active,
+                title: "Active lane moving",
+                detail: countDescription(
+                    runningCount,
+                    singular: "item is currently in the running lane.",
+                    plural: "items are currently in the running lane."
+                )
+            )
+        }
+
+        let readyCount = queue.lazy.filter {
+            $0.state == .ready || $0.state == .queued
+        }.count
+        if readyCount > 0 {
+            return GuideCue(
+                activity: .ready,
+                title: "Next work is staged",
+                detail: countDescription(
+                    readyCount,
+                    singular: "item can keep the queue moving.",
+                    plural: "items can keep the queue moving."
+                )
+            )
+        }
+
+        let waitingCount = queue.lazy.filter { $0.state == .waiting }.count
+        if waitingCount > 0 {
+            return GuideCue(
+                activity: .waiting,
+                title: "Queue is waiting",
+                detail: countDescription(
+                    waitingCount,
+                    singular: "item is waiting for a dependency.",
+                    plural: "items are waiting for dependencies."
+                )
+            )
+        }
+
+        return GuideCue(
+            activity: .idle,
+            title: "Queue is clear",
+            detail: "No operational work is currently supplied."
+        )
+    }
+
+    private func countDescription(
+        _ count: Int,
+        singular: String,
+        plural: String
+    ) -> String {
+        "\(count) \(count == 1 ? singular : plural)"
+    }
+}
+
+struct GuideMotionFrame: Equatable, Sendable {
+    let bob: Double
+    let eyeScale: Double
+    let wave: Double
+    let pulse: Double
+
+    static let still = GuideMotionFrame(
+        bob: 0,
+        eyeScale: 1,
+        wave: 0,
+        pulse: 1
+    )
+}
+
+enum GuideMotionSampler {
+    static func frame(
+        at time: TimeInterval,
+        activity: GuideActivity,
+        reduceMotion: Bool
+    ) -> GuideMotionFrame {
+        guard !reduceMotion else { return .still }
+
+        let nonnegativeTime = max(0, time)
+        let parameters = parameters(for: activity)
+        let blinkPhase = nonnegativeTime.truncatingRemainder(dividingBy: 4)
+        return GuideMotionFrame(
+            bob: sin(nonnegativeTime * parameters.speed) * parameters.amplitude,
+            eyeScale: (3.82...3.96).contains(blinkPhase) ? 0.14 : 1,
+            wave: sin(nonnegativeTime * parameters.speed * 1.08) * parameters.wave,
+            pulse: 1 + sin(nonnegativeTime * parameters.speed * 0.72) * parameters.pulse
+        )
+    }
+
+    private static func parameters(
+        for activity: GuideActivity
+    ) -> (speed: Double, amplitude: Double, wave: Double, pulse: Double) {
+        switch activity {
+        case .attention:
+            (3.0, 3.8, 14, 0.05)
+        case .active:
+            (2.3, 3.1, 11, 0.04)
+        case .ready:
+            (1.9, 2.5, 8, 0.035)
+        case .waiting:
+            (1.5, 1.9, 5, 0.025)
+        case .idle:
+            (1.2, 1.4, 3, 0.018)
+        }
+    }
+}
+
+enum DashboardLayoutDensity: Equatable, Sendable {
+    case compact
+    case dense
+}
+
+struct DashboardLayoutMetrics: Equatable, Sendable {
+    static let defaultWindowSize = CGSize(width: 620, height: 640)
+    static let minimumWindowSize = CGSize(width: 380, height: 480)
+    static let denseBreakpoint: CGFloat = 560
+
+    let density: DashboardLayoutDensity
+    let columnCount: Int
+    let contentPadding: CGFloat
+    let sectionSpacing: CGFloat
+    let recordPadding: CGFloat
+    let guideSize: CGFloat
+
+    init(width: CGFloat) {
+        if width >= Self.denseBreakpoint {
+            density = .dense
+            columnCount = 2
+            contentPadding = 12
+            sectionSpacing = 10
+            recordPadding = 9
+            guideSize = 74
+        } else {
+            density = .compact
+            columnCount = 1
+            contentPadding = 14
+            sectionSpacing = 12
+            recordPadding = 10
+            guideSize = 68
+        }
+    }
+
+    func estimatedCardWidth(containerWidth: CGFloat) -> CGFloat {
+        let available = max(0, containerWidth - contentPadding * 2)
+        let totalSpacing = sectionSpacing * CGFloat(max(0, columnCount - 1))
+        return max(0, (available - totalSpacing) / CGFloat(columnCount))
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -155,6 +155,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 @MainActor
 final class DashboardWindowController {
+    static let frameAutosaveName = "OperationsDashboardWindowDenseV1"
+
     private(set) var panel: NSWindow?
     private let state: DashboardState
     private let activatesApplication: Bool
@@ -182,7 +184,10 @@ final class DashboardWindowController {
 
     private func makeDashboardWindow() -> NSWindow {
         let panel = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 680),
+            contentRect: NSRect(
+                origin: .zero,
+                size: DashboardLayoutMetrics.defaultWindowSize
+            ),
             styleMask: [.titled, .closable, .resizable, .utilityWindow, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -194,9 +199,9 @@ final class DashboardWindowController {
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.tabbingMode = .disallowed
-        panel.setFrameAutosaveName("OperationsDashboardWindow")
+        panel.setFrameAutosaveName(Self.frameAutosaveName)
         panel.level = state.pinned ? .floating : .normal
-        panel.minSize = NSSize(width: 340, height: 440)
+        panel.minSize = DashboardLayoutMetrics.minimumWindowSize
         panel.center()
         panel.contentView = NSHostingView(rootView: DashboardView(state: state))
         state.onPinnedChange = { [weak panel] isPinned in
@@ -266,6 +271,13 @@ final class DashboardState: ObservableObject {
     }
 }
 
+private struct QueueLaneDefinition: Identifiable {
+    let state: QueueRecord.State
+    let title: String
+
+    var id: QueueRecord.State { state }
+}
+
 private struct DashboardView: View {
     @StateObject private var state: DashboardState
 
@@ -274,25 +286,26 @@ private struct DashboardView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    avatar
-                    queueSummary
-                    queueLane(title: "Running", queueState: .running)
-                    queueLane(title: "Queued", queueState: .queued)
-                    queueLane(title: "Waiting", queueState: .waiting)
-                    queueLane(title: "Ready", queueState: .ready)
-                    testSection
-                    resourceSection
-                    signalSection
+        GeometryReader { geometry in
+            let metrics = DashboardLayoutMetrics(width: geometry.size.width)
+            VStack(spacing: 0) {
+                header
+                Divider()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: metrics.sectionSpacing) {
+                        guideStrip(metrics: metrics)
+                        resourceBudgetPanel(metrics: metrics)
+                        queueGrid(metrics: metrics)
+                        supportingGrid(metrics: metrics)
+                    }
+                    .padding(metrics.contentPadding)
                 }
-                .padding(18)
             }
         }
-        .frame(minWidth: 340, minHeight: 440)
+        .frame(
+            minWidth: DashboardLayoutMetrics.minimumWindowSize.width,
+            minHeight: DashboardLayoutMetrics.minimumWindowSize.height
+        )
         .background(.regularMaterial)
         .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
             state.reload()
@@ -313,120 +326,273 @@ private struct DashboardView: View {
                 .controlSize(.small)
                 .accessibilityLabel("Keep dashboard in front")
         }
-        .padding(16)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
     }
 
-    private var avatar: some View {
-        HStack(spacing: 14) {
-            AnimatedGuideAvatar()
-                .frame(width: 92, height: 92)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Queue guide").font(.headline)
-                Text(
-                    state.snapshot.queue.contains(where: { $0.state == .running })
-                    ? "Tracking the active lane."
-                    : "The active lane is clear."
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+    private func guideStrip(metrics: DashboardLayoutMetrics) -> some View {
+        let cue = state.snapshot.guideCue
+        return VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 12) {
+                AnimatedGuideAvatar(cue: cue)
+                    .frame(width: metrics.guideSize, height: metrics.guideSize)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(cue.title)
+                        .font(.headline)
+                    Text(cue.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Local procedural guide")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(guideAccent(for: cue.activity))
+                }
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
+
+            LazyVGrid(
+                columns: Array(
+                    repeating: GridItem(.flexible(minimum: 52), spacing: 7),
+                    count: 4
+                ),
+                spacing: 7
+            ) {
+                compactMetric(state.itemCount(for: .running), "running", .blue)
+                compactMetric(state.itemCount(for: .queued), "queued", .orange)
+                compactMetric(state.itemCount(for: .waiting), "waiting", .purple)
+                compactMetric(state.itemCount(for: .ready), "ready", .green)
+            }
         }
-        .padding(14)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .padding(11)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(guideAccent(for: cue.activity).opacity(0.22), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Queue guide: \(cue.title). \(cue.detail)")
     }
 
-    private var queueSummary: some View {
-        HStack(spacing: 10) {
-            metric(count(for: .running), "running", .blue)
-            metric(count(for: .queued), "queued", .orange)
-            metric(count(for: .waiting), "waiting", .purple)
-        }
-    }
-
-    private func count(for stateToCount: QueueRecord.State) -> String {
-        String(state.itemCount(for: stateToCount))
-    }
-
-    private func metric(_ number: String, _ label: String, _ color: Color) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(number).font(.title2.bold()).foregroundStyle(color)
-            Text(label).font(.caption).foregroundStyle(.secondary)
+    private func compactMetric(_ count: Int, _ label: String, _ color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(String(count))
+                .font(.headline.monospacedDigit())
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(color.opacity(0.11), in: RoundedRectangle(cornerRadius: 8))
     }
 
-    @ViewBuilder
-    private func queueLane(title: String, queueState: QueueRecord.State) -> some View {
-        let selected = state.snapshot.queue.filter { $0.state == queueState }
-        if !selected.isEmpty {
-            recordSection(title: title, records: selected) { record in
-                recordCard(
-                    title: record.title,
-                    detail: record.detail,
-                    badge: record.verification.rawValue
-                )
+    private func resourceBudgetPanel(metrics: DashboardLayoutMetrics) -> some View {
+        dashboardPanel(
+            title: "Resource budget",
+            subtitle: "Scheduling evidence",
+            metrics: metrics
+        ) {
+            LazyVGrid(
+                columns: gridColumns(metrics: metrics),
+                alignment: .leading,
+                spacing: 0
+            ) {
+                ForEach(state.snapshot.resourceBudget) { record in
+                    recordRow(
+                        title: record.title,
+                        detail: record.detail,
+                        status: record.displayValue,
+                        verification: record.verification.rawValue,
+                        metrics: metrics
+                    )
+                }
             }
         }
     }
 
-    private var testSection: some View {
-        recordSection(title: "Tests", records: state.snapshot.tests) { record in
-            recordCard(title: record.title, detail: record.detail, badge: record.result.rawValue)
+    private func queueGrid(metrics: DashboardLayoutMetrics) -> some View {
+        let definitions = [
+            QueueLaneDefinition(state: .running, title: "Running"),
+            QueueLaneDefinition(state: .queued, title: "Queued"),
+            QueueLaneDefinition(state: .waiting, title: "Waiting"),
+            QueueLaneDefinition(state: .ready, title: "Ready")
+        ].filter { definition in
+            state.snapshot.queue.contains { $0.state == definition.state }
+        }
+
+        return LazyVGrid(
+            columns: gridColumns(metrics: metrics),
+            alignment: .leading,
+            spacing: metrics.sectionSpacing
+        ) {
+            ForEach(definitions) { definition in
+                let records = state.snapshot.queue.filter { $0.state == definition.state }
+                dashboardPanel(
+                    title: definition.title,
+                    subtitle: "\(records.count) records",
+                    metrics: metrics
+                ) {
+                    VStack(spacing: 0) {
+                        ForEach(records) { record in
+                            recordRow(
+                                title: record.title,
+                                detail: record.detail,
+                                status: nil,
+                                verification: record.verification.rawValue,
+                                metrics: metrics
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 
-    private var resourceSection: some View {
-        recordSection(title: "Resource budget", records: state.snapshot.resourceBudget) { record in
-            recordCard(title: record.title, detail: record.detail, badge: record.displayValue)
+    private func supportingGrid(metrics: DashboardLayoutMetrics) -> some View {
+        LazyVGrid(
+            columns: gridColumns(metrics: metrics),
+            alignment: .leading,
+            spacing: metrics.sectionSpacing
+        ) {
+            dashboardPanel(
+                title: "Tests and quality",
+                subtitle: "\(state.snapshot.tests.count) records",
+                metrics: metrics
+            ) {
+                VStack(spacing: 0) {
+                    ForEach(state.snapshot.tests) { record in
+                        recordRow(
+                            title: record.title,
+                            detail: record.detail,
+                            status: record.result.rawValue,
+                            verification: record.verification.rawValue,
+                            metrics: metrics
+                        )
+                    }
+                }
+            }
+
+            dashboardPanel(
+                title: "Signals",
+                subtitle: "\(state.snapshot.signals.count) records",
+                metrics: metrics
+            ) {
+                VStack(spacing: 0) {
+                    ForEach(state.snapshot.signals) { record in
+                        recordRow(
+                            title: record.title,
+                            detail: record.detail,
+                            status: record.state.rawValue,
+                            verification: record.verification.rawValue,
+                            metrics: metrics
+                        )
+                    }
+                }
+            }
         }
     }
 
-    private var signalSection: some View {
-        recordSection(title: "Signals", records: state.snapshot.signals) { record in
-            recordCard(title: record.title, detail: record.detail, badge: record.state.rawValue)
-        }
+    private func gridColumns(metrics: DashboardLayoutMetrics) -> [GridItem] {
+        Array(
+            repeating: GridItem(
+                .flexible(minimum: 170),
+                spacing: metrics.sectionSpacing,
+                alignment: .top
+            ),
+            count: metrics.columnCount
+        )
     }
 
-    private func recordSection<Record: Identifiable, Content: View>(
+    private func dashboardPanel<Content: View>(
         title: String,
-        records: [Record],
-        @ViewBuilder content: @escaping (Record) -> Content
+        subtitle: String,
+        metrics: DashboardLayoutMetrics,
+        @ViewBuilder content: () -> Content
     ) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title.uppercased())
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            ForEach(records) { record in
-                content(record)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title.uppercased())
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
+            .padding(.horizontal, metrics.recordPadding)
+            .padding(.vertical, 7)
+            Divider()
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 11))
+        .clipShape(RoundedRectangle(cornerRadius: 11))
+    }
+
+    private func recordRow(
+        title: String,
+        detail: String,
+        status: String?,
+        verification: String,
+        metrics: DashboardLayoutMetrics
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(2)
+                Spacer(minLength: 4)
+                if let status {
+                    compactBadge(status)
+                }
+            }
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(metrics.density == .dense ? 2 : 3)
+            compactBadge(verification)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(metrics.recordPadding)
+        .overlay(alignment: .bottom) {
+            Divider()
         }
     }
 
-    private func recordCard(title: String, detail: String, badge: String) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(title).font(.body.weight(.medium))
-                Spacer()
-                Text(badge.replacingOccurrences(of: "-", with: " "))
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.secondary)
-            }
-            Text(detail).font(.caption).foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+    private func compactBadge(_ value: String) -> some View {
+        Text(value.replacingOccurrences(of: "-", with: " "))
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.quinary, in: Capsule())
     }
+
+    private func guideAccent(for activity: GuideActivity) -> Color {
+        switch activity {
+        case .attention:
+            .orange
+        case .active:
+            .cyan
+        case .ready:
+            .green
+        case .waiting:
+            .purple
+        case .idle:
+            .secondary
+        }
+    }
+
 }
 
 /// A procedural, non-personal avatar. No image asset, camera, microphone, or
 /// network service is used; the motion is generated locally by TimelineView.
 private struct AnimatedGuideAvatar: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let cue: GuideCue
 
     var body: some View {
         TimelineView(
@@ -436,55 +602,71 @@ private struct AnimatedGuideAvatar: View {
             )
         ) { timeline in
             let time = timeline.date.timeIntervalSinceReferenceDate
-            let bob = reduceMotion ? 0 : sin(time * 2.0) * 3.0
-            let blink = reduceMotion ? 1.0 : (abs(sin(time * 0.72)) > 0.985 ? 0.12 : 1.0)
-            let wave = reduceMotion ? 0 : sin(time * 2.0) * 12.0
-            let pulse = reduceMotion ? 1.0 : 1.0 + sin(time * 1.6) * 0.035
+            let frame = GuideMotionSampler.frame(
+                at: time,
+                activity: cue.activity,
+                reduceMotion: reduceMotion
+            )
 
             ZStack {
                 Circle()
                     .fill(
                         AngularGradient(
-                            colors: [.indigo, .cyan, .mint, .indigo],
+                            colors: [.indigo, accent, .mint, .indigo],
                             center: .center
                         )
                     )
                     .opacity(0.23)
-                    .scaleEffect(pulse)
+                    .scaleEffect(frame.pulse)
                 Circle()
                     .fill(.ultraThinMaterial)
                     .overlay(Circle().stroke(.white.opacity(0.38), lineWidth: 1))
                     .padding(7)
 
                 Circle()
-                    .fill(Color.indigo.opacity(0.95))
+                    .fill(accent.gradient)
                     .frame(width: 54, height: 54)
-                    .offset(y: bob)
+                    .offset(y: frame.bob)
                 Circle()
-                    .fill(Color.indigo.opacity(0.85))
+                    .fill(accent.opacity(0.85))
                     .frame(width: 17, height: 17)
-                    .offset(x: -27, y: bob + 4)
+                    .offset(x: -27, y: frame.bob + 4)
                 Circle()
-                    .fill(Color.indigo.opacity(0.85))
+                    .fill(accent.opacity(0.85))
                     .frame(width: 17, height: 17)
-                    .offset(x: 27, y: bob + 4)
+                    .offset(x: 27, y: frame.bob + 4)
 
                 HStack(spacing: 13) {
-                    Capsule().fill(.white).frame(width: 7, height: 10 * blink)
-                    Capsule().fill(.white).frame(width: 7, height: 10 * blink)
+                    Capsule().fill(.white).frame(width: 7, height: 10 * frame.eyeScale)
+                    Capsule().fill(.white).frame(width: 7, height: 10 * frame.eyeScale)
                 }
-                .offset(y: bob - 5)
+                .offset(y: frame.bob - 5)
                 Capsule()
                     .fill(.white.opacity(0.9))
                     .frame(width: 18, height: 4)
-                    .offset(y: bob + 13)
+                    .offset(y: frame.bob + 13)
                 Capsule()
-                    .fill(Color.cyan.opacity(0.9))
+                    .fill(accent.opacity(0.9))
                     .frame(width: 10, height: 29)
-                    .rotationEffect(.degrees(-35 + wave))
-                    .offset(x: 31, y: bob + 29)
+                    .rotationEffect(.degrees(-35 + frame.wave))
+                    .offset(x: 31, y: frame.bob + 29)
             }
             .drawingGroup()
+        }
+    }
+
+    private var accent: Color {
+        switch cue.activity {
+        case .attention:
+            .orange
+        case .active:
+            .cyan
+        case .ready:
+            .green
+        case .waiting:
+            .purple
+        case .idle:
+            .indigo
         }
     }
 }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -15,6 +15,7 @@ struct DashboardStateTests {
         #expect(state.itemCount(for: .running) == 1)
         #expect(state.itemCount(for: .queued) == 1)
         #expect(state.itemCount(for: .waiting) == 0)
+        #expect(state.itemCount(for: .ready) == 0)
         #expect(state.snapshot.resourceBudget.first?.verification == .unavailable)
     }
 
@@ -197,6 +198,11 @@ struct DashboardStateTests {
         let firstWindow = controller.show()
         #expect(firstWindow.isVisible)
         #expect(firstWindow.level == .floating)
+        #expect(firstWindow.minSize == DashboardLayoutMetrics.minimumWindowSize)
+        #expect(
+            firstWindow.frameAutosaveName
+                == NSWindow.FrameAutosaveName(DashboardWindowController.frameAutosaveName)
+        )
 
         state.pinned = false
         #expect(firstWindow.level == .normal)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -1,0 +1,217 @@
+import AppKit
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Guide presentation")
+struct GuidePresentationTests {
+    @Test("Motion frames are deterministic for the same inputs")
+    func motionIsDeterministic() {
+        let first = GuideMotionSampler.frame(
+            at: 12.375,
+            activity: .active,
+            reduceMotion: false
+        )
+        let second = GuideMotionSampler.frame(
+            at: 12.375,
+            activity: .active,
+            reduceMotion: false
+        )
+
+        #expect(first == second)
+        #expect(first != .still)
+    }
+
+    @Test("Reduce Motion produces a stable frame for every guide state")
+    func reduceMotionIsStable() {
+        let activities: [GuideActivity] = [.attention, .active, .ready, .waiting, .idle]
+
+        for activity in activities {
+            #expect(
+                GuideMotionSampler.frame(
+                    at: 8_942.5,
+                    activity: activity,
+                    reduceMotion: true
+                ) == .still
+            )
+        }
+    }
+
+    @Test("Blink timing is deterministic and bounded")
+    func deterministicBlink() {
+        let open = GuideMotionSampler.frame(
+            at: 3.5,
+            activity: .active,
+            reduceMotion: false
+        )
+        let closed = GuideMotionSampler.frame(
+            at: 3.9,
+            activity: .active,
+            reduceMotion: false
+        )
+
+        #expect(open.eyeScale == 1)
+        #expect(closed.eyeScale == 0.14)
+        #expect(abs(closed.bob) <= 3.1)
+        #expect(abs(closed.wave) <= 11)
+        #expect((0.96...1.04).contains(closed.pulse))
+    }
+
+    @Test("Guide state gives verified attention priority over active work")
+    func verifiedAttentionHasPriority() {
+        let snapshot = makeSnapshot(
+            queue: [
+                QueueRecord(
+                    id: "Q1",
+                    title: "Active example",
+                    detail: "Generic record.",
+                    state: .running,
+                    exposure: .sanitized,
+                    verification: .estimated
+                )
+            ],
+            tests: [
+                TestRecord(
+                    id: "T1",
+                    title: "Verified failure",
+                    detail: "Generic record.",
+                    result: .failed,
+                    exposure: .sanitized,
+                    verification: .verified
+                )
+            ]
+        )
+
+        #expect(snapshot.guideCue.activity == .attention)
+        #expect(snapshot.guideCue.title == "Verified attention needed")
+        #expect(snapshot.guideCue.detail == "1 verified item needs a decision.")
+    }
+
+    @Test("Unverified failure does not become an attention cue")
+    func unverifiedFailureDoesNotEscalate() {
+        let snapshot = makeSnapshot(
+            queue: [
+                QueueRecord(
+                    id: "Q1",
+                    title: "Queued example",
+                    detail: "Generic record.",
+                    state: .queued,
+                    exposure: .sanitized,
+                    verification: .estimated
+                )
+            ],
+            tests: [
+                TestRecord(
+                    id: "T1",
+                    title: "Estimated failure",
+                    detail: "Generic record.",
+                    result: .failed,
+                    exposure: .sanitized,
+                    verification: .estimated
+                )
+            ]
+        )
+
+        #expect(snapshot.guideCue.activity == .ready)
+        #expect(snapshot.guideCue.title == "Next work is staged")
+    }
+
+    @Test("Guide cue deterministically covers waiting and empty queues")
+    func waitingAndIdleCues() {
+        let waiting = makeSnapshot(
+            queue: [
+                QueueRecord(
+                    id: "Q1",
+                    title: "Waiting example",
+                    detail: "Generic record.",
+                    state: .waiting,
+                    exposure: .sanitized,
+                    verification: .estimated
+                )
+            ]
+        )
+        let idle = makeSnapshot()
+
+        #expect(waiting.guideCue.activity == .waiting)
+        #expect(waiting.guideCue.detail == "1 item is waiting for a dependency.")
+        #expect(idle.guideCue.activity == .idle)
+        #expect(idle.guideCue.detail == "No operational work is currently supplied.")
+    }
+
+    @Test("Compact and dense layouts switch at one deterministic breakpoint")
+    func layoutBreakpoint() {
+        let compact = DashboardLayoutMetrics(
+            width: DashboardLayoutMetrics.denseBreakpoint - 1
+        )
+        let dense = DashboardLayoutMetrics(
+            width: DashboardLayoutMetrics.denseBreakpoint
+        )
+
+        #expect(compact.density == .compact)
+        #expect(compact.columnCount == 1)
+        #expect(dense.density == .dense)
+        #expect(dense.columnCount == 2)
+        #expect(compact.estimatedCardWidth(containerWidth: 559) == 531)
+        #expect(dense.estimatedCardWidth(containerWidth: 560) == 263)
+    }
+
+    @Test("Default and minimum windows preserve useful card widths")
+    func layoutWindowBounds() {
+        let defaultMetrics = DashboardLayoutMetrics(
+            width: DashboardLayoutMetrics.defaultWindowSize.width
+        )
+        let minimumMetrics = DashboardLayoutMetrics(
+            width: DashboardLayoutMetrics.minimumWindowSize.width
+        )
+
+        #expect(DashboardLayoutMetrics.defaultWindowSize == CGSize(width: 620, height: 640))
+        #expect(DashboardLayoutMetrics.minimumWindowSize == CGSize(width: 380, height: 480))
+        #expect(defaultMetrics.estimatedCardWidth(containerWidth: 620) == 293)
+        #expect(minimumMetrics.estimatedCardWidth(containerWidth: 380) == 352)
+    }
+
+    @Test("Application entitlements contain no network, microphone, or camera capability")
+    func entitlementsRemainLocalOnly() throws {
+        let data = try Data(
+            contentsOf: packageRoot().appendingPathComponent("OperationsFloater.entitlements")
+        )
+        let value = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        )
+        let entitlements = try #require(value as? [String: Any])
+
+        #expect(entitlements.count == 2)
+        #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
+        #expect(
+            entitlements["com.apple.security.files.user-selected.read-only"] as? Bool == true
+        )
+        #expect(entitlements["com.apple.security.network.client"] == nil)
+        #expect(entitlements["com.apple.security.device.audio-input"] == nil)
+        #expect(entitlements["com.apple.security.device.camera"] == nil)
+    }
+
+    private func makeSnapshot(
+        queue: [QueueRecord] = [],
+        tests: [TestRecord] = [],
+        resourceBudget: [ResourceBudgetRecord] = [],
+        signals: [SignalRecord] = []
+    ) -> DashboardSnapshot {
+        DashboardSnapshot(
+            schemaVersion: "1.0",
+            mode: .sample,
+            queue: queue,
+            tests: tests,
+            resourceBudget: resourceBudget,
+            signals: signals
+        )
+    }
+
+    private func packageRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}


### PR DESCRIPTION
## Summary

- make the native Operations Floater a denser single-window dashboard that mirrors the web information hierarchy without changing shared runtime boundaries
- add a deterministic, privacy-neutral local queue guide with verified-attention priority and Reduce Motion support
- add explicit compact/dense layout metrics, a versioned window-frame migration, and focused presentation/privacy tests

## Contract and privacy

- canonical dashboard schema remains version `1.0`
- no changes under `prototypes/operations-dashboard/**` or `prototypes/operations-dashboard-web/**`
- no camera, microphone, network, analytics, credentials, telemetry, or external transmission
- signing, bundle identity, and App Store settings are unchanged

## Local validation

- `swift test`: 21/21 passed
- deterministic motion/state, Reduce Motion, compact breakpoint/card widths, entitlements, adapter, update/rollback, and window lifecycle covered
- `git diff --check`: passed
- source plist and entitlements lint: passed
- unsigned macOS Release build: succeeded
- built `Info.plist` lint: passed; productivity category present
- bounded Release smoke: dense 620-point two-column layout and compact 380-point one-column layout rendered readably

## Rollback

Revert this commit to restore the prior layout and frame-autosave key. The dashboard snapshot install/restore mechanism is unchanged.
