### PR TITLE
feat(template): add sortable queue race board

### DIFF
--- a/prototypes/operations-dashboard-web/dashboard.js
+++ b/prototypes/operations-dashboard-web/dashboard.js
@@ -7,7 +7,14 @@ const FORBIDDEN_FIELD_FRAGMENTS = ["endpoint", "url", "host", "ip", "path", "cre
 const RECORD_SPECS = {
   queue: {
     required: ["id", "title", "detail", "state", "exposure", "verification"],
-    optional: [],
+    optional: [
+      "completedSteps",
+      "totalSteps",
+      "currentStep",
+      "lastActiveSeconds",
+      "memoryMB",
+      "cpuPercent",
+    ],
     stateKey: "state",
     states: new Set(["running", "queued", "waiting", "ready"]),
   },
@@ -122,6 +129,57 @@ function assertRecord(section, record, index) {
       )
     ) {
       fail(`${path} has an invalid numeric resource value.`);
+    }
+  }
+  if (section === "queue") {
+    const hasCompleted = "completedSteps" in record;
+    const hasTotal = "totalSteps" in record;
+    if (
+      hasCompleted !== hasTotal
+      || (
+        hasCompleted
+        && (
+          !Number.isInteger(record.completedSteps)
+          || !Number.isInteger(record.totalSteps)
+          || record.completedSteps < 0
+          || record.totalSteps <= 0
+          || record.completedSteps > record.totalSteps
+          || record.totalSteps > 100000
+        )
+      )
+    ) {
+      fail(`${path} has invalid step progress.`);
+    }
+    if ("currentStep" in record) assertText(record.currentStep, 120, `${path}.currentStep`);
+    if (
+      "lastActiveSeconds" in record
+      && (
+        !Number.isInteger(record.lastActiveSeconds)
+        || record.lastActiveSeconds < 0
+        || record.lastActiveSeconds > 315360000
+      )
+    ) {
+      fail(`${path}.lastActiveSeconds is outside the supported range.`);
+    }
+    if (
+      "memoryMB" in record
+      && (
+        !Number.isFinite(record.memoryMB)
+        || record.memoryMB < 0
+        || record.memoryMB > 16777216
+      )
+    ) {
+      fail(`${path}.memoryMB is outside the supported range.`);
+    }
+    if (
+      "cpuPercent" in record
+      && (
+        !Number.isFinite(record.cpuPercent)
+        || record.cpuPercent < 0
+        || record.cpuPercent > 100
+      )
+    ) {
+      fail(`${path}.cpuPercent is outside the supported range.`);
     }
   }
   assertPrivacyNeutralValues(record, path);

--- a/prototypes/operations-dashboard/bin/publish-sanitized.mjs
+++ b/prototypes/operations-dashboard/bin/publish-sanitized.mjs
@@ -74,7 +74,7 @@ function releasePath(outputRoot, releaseId) {
 }
 
 function queueRecord(record) {
-  return {
+  const sanitized = {
     id: record.id,
     title: record.title,
     detail: record.detail,
@@ -82,6 +82,17 @@ function queueRecord(record) {
     exposure: record.exposure,
     verification: record.verification,
   };
+  for (const key of [
+    "completedSteps",
+    "totalSteps",
+    "currentStep",
+    "lastActiveSeconds",
+    "memoryMB",
+    "cpuPercent",
+  ]) {
+    if (record[key] !== undefined) sanitized[key] = record[key];
+  }
+  return sanitized;
 }
 
 function testRecord(record) {

--- a/prototypes/operations-dashboard/contract/README.md
+++ b/prototypes/operations-dashboard/contract/README.md
@@ -31,6 +31,15 @@ operating-system measurements. Numeric `value` and `capacity` fields are
 optional. The committed shared fixture omits them rather than claiming live
 capacity or telemetry.
 
+Queue records may add the optional, privacy-neutral evidence fields
+`completedSteps`, `totalSteps`, `currentStep`, `lastActiveSeconds`, `memoryMB`,
+and `cpuPercent`. The two step counts must appear together and completed work
+cannot exceed the current total. Increasing the total may therefore lower the
+derived completion percentage without erasing completed work. Consumers must
+treat missing evidence as unavailable rather than estimating it. These
+additive fields preserve compatibility with version `1.0` records that omit
+them.
+
 ## Canonical shape
 
 The root keys are exactly `schemaVersion`, `mode`, `queue`, `tests`,

--- a/prototypes/operations-dashboard/contract/dashboard-state.sample.json
+++ b/prototypes/operations-dashboard/contract/dashboard-state.sample.json
@@ -8,7 +8,13 @@
       "detail": "Replace with approved local or sanitized state.",
       "state": "running",
       "exposure": "sanitized",
-      "verification": "estimated"
+      "verification": "estimated",
+      "completedSteps": 5,
+      "totalSteps": 8,
+      "currentStep": "Verifying the bounded build",
+      "lastActiveSeconds": 18,
+      "memoryMB": 2450,
+      "cpuPercent": 36.5
     },
     {
       "id": "EX-Q2",
@@ -16,7 +22,41 @@
       "detail": "Awaiting a generic follow-up.",
       "state": "queued",
       "exposure": "sanitized",
-      "verification": "estimated"
+      "verification": "estimated",
+      "completedSteps": 1,
+      "totalSteps": 6,
+      "currentStep": "Waiting for a worker slot",
+      "lastActiveSeconds": 240,
+      "memoryMB": 180,
+      "cpuPercent": 0.4
+    },
+    {
+      "id": "EX-Q3",
+      "title": "Example dependency review",
+      "detail": "A synthetic dependency added two more steps.",
+      "state": "waiting",
+      "exposure": "sanitized",
+      "verification": "estimated",
+      "completedSteps": 3,
+      "totalSteps": 9,
+      "currentStep": "Resolve the added dependency",
+      "lastActiveSeconds": 900,
+      "memoryMB": 620,
+      "cpuPercent": 1.2
+    },
+    {
+      "id": "EX-Q4",
+      "title": "Example ready item",
+      "detail": "Synthetic work completed every declared step.",
+      "state": "ready",
+      "exposure": "sanitized",
+      "verification": "estimated",
+      "completedSteps": 8,
+      "totalSteps": 8,
+      "currentStep": "Ready for owner review",
+      "lastActiveSeconds": 45,
+      "memoryMB": 96,
+      "cpuPercent": 0
     }
   ],
   "tests": [

--- a/prototypes/operations-dashboard/contract/dashboard-state.schema.json
+++ b/prototypes/operations-dashboard/contract/dashboard-state.schema.json
@@ -118,6 +118,36 @@
         },
         "verification": {
           "$ref": "#/$defs/verification"
+        },
+        "completedSteps": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "totalSteps": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100000
+        },
+        "currentStep": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "lastActiveSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 315360000
+        },
+        "memoryMB": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 16777216
+        },
+        "cpuPercent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
         }
       }
     },

--- a/prototypes/operations-dashboard/contract/validate-dashboard.mjs
+++ b/prototypes/operations-dashboard/contract/validate-dashboard.mjs
@@ -1,5 +1,14 @@
 const rootKeys = ["schemaVersion", "mode", "queue", "tests", "resourceBudget", "signals"];
-const queueKeys = ["id", "title", "detail", "state", "exposure", "verification"];
+const queueRequiredKeys = ["id", "title", "detail", "state", "exposure", "verification"];
+const queueOptionalKeys = [
+  "completedSteps",
+  "totalSteps",
+  "currentStep",
+  "lastActiveSeconds",
+  "memoryMB",
+  "cpuPercent",
+];
+const queueKeys = [...queueRequiredKeys, ...queueOptionalKeys];
 const testKeys = ["id", "title", "detail", "result", "exposure", "verification"];
 const budgetRequiredKeys = [
   "id",
@@ -97,6 +106,14 @@ function assertNumber(value, path, { positive = false } = {}) {
   if (positive && value === 0) fail(path, "expected a number greater than zero");
 }
 
+function assertInteger(value, path, { positive = false, maximum } = {}) {
+  assertNumber(value, path, { positive });
+  if (!Number.isInteger(value)) fail(path, "expected an integer");
+  if (maximum !== undefined && value > maximum) {
+    fail(path, `must be no greater than ${maximum}`);
+  }
+}
+
 function assertRecordBase(record, path) {
   assertIdentifier(record.id, `${path}.id`);
   assertString(record.title, `${path}.title`, 120);
@@ -109,9 +126,38 @@ function assertRecordBase(record, path) {
 }
 
 function assertQueueRecord(record, path) {
-  assertKeys(record, queueKeys, queueKeys, path);
+  assertKeys(record, queueKeys, queueRequiredKeys, path);
   assertRecordBase(record, path);
   assertEnum(record.state, queueStates, `${path}.state`);
+  const hasCompleted = "completedSteps" in record;
+  const hasTotal = "totalSteps" in record;
+  if (hasCompleted !== hasTotal) {
+    fail(path, "completedSteps and totalSteps must be supplied together");
+  }
+  if (hasCompleted) {
+    assertInteger(record.completedSteps, `${path}.completedSteps`, { maximum: 100000 });
+    assertInteger(record.totalSteps, `${path}.totalSteps`, {
+      positive: true,
+      maximum: 100000,
+    });
+    if (record.completedSteps > record.totalSteps) {
+      fail(path, "completedSteps cannot exceed totalSteps");
+    }
+  }
+  if ("currentStep" in record) assertString(record.currentStep, `${path}.currentStep`, 120);
+  if ("lastActiveSeconds" in record) {
+    assertInteger(record.lastActiveSeconds, `${path}.lastActiveSeconds`, {
+      maximum: 315360000,
+    });
+  }
+  if ("memoryMB" in record) {
+    assertNumber(record.memoryMB, `${path}.memoryMB`);
+    if (record.memoryMB > 16777216) fail(`${path}.memoryMB`, "is outside the supported range");
+  }
+  if ("cpuPercent" in record) {
+    assertNumber(record.cpuPercent, `${path}.cpuPercent`);
+    if (record.cpuPercent > 100) fail(`${path}.cpuPercent`, "must be no greater than 100");
+  }
 }
 
 function assertTestRecord(record, path) {

--- a/prototypes/operations-dashboard/tests/contract.test.mjs
+++ b/prototypes/operations-dashboard/tests/contract.test.mjs
@@ -51,11 +51,56 @@ test("the schema exposes the canonical consumer sections and no transport fields
     assert.ok(definition.required.includes("verification"));
   }
 
+  assert.deepEqual(
+    Object.keys(schema.$defs.queueRecord.properties).sort(),
+    [
+      "completedSteps",
+      "cpuPercent",
+      "currentStep",
+      "detail",
+      "exposure",
+      "id",
+      "lastActiveSeconds",
+      "memoryMB",
+      "state",
+      "title",
+      "totalSteps",
+      "verification",
+    ],
+  );
+
   const serialized = JSON.stringify(schema);
   assert.doesNotMatch(
     serialized,
     /endpoint|hostname|localUrl|tailnetUrl|ipAddress|filePath|snapshotKind|qualityChecks/i,
   );
+});
+
+test("queue progress and resource evidence is optional, bounded, and internally consistent", async () => {
+  const fixture = await readJSON(fixtureURL);
+  const legacyCompatible = structuredClone(fixture);
+  for (const record of legacyCompatible.queue) {
+    delete record.completedSteps;
+    delete record.totalSteps;
+    delete record.currentStep;
+    delete record.lastActiveSeconds;
+    delete record.memoryMB;
+    delete record.cpuPercent;
+  }
+  assert.doesNotThrow(() => assertDashboardSnapshot(legacyCompatible));
+
+  const unpaired = structuredClone(fixture);
+  delete unpaired.queue[0].totalSteps;
+  assert.throws(() => assertDashboardSnapshot(unpaired), /supplied together/);
+
+  const regressed = structuredClone(fixture);
+  regressed.queue[0].completedSteps = 6;
+  regressed.queue[0].totalSteps = 5;
+  assert.throws(() => assertDashboardSnapshot(regressed), /cannot exceed/);
+
+  const excessiveCPU = structuredClone(fixture);
+  excessiveCPU.queue[0].cpuPercent = 100.1;
+  assert.throws(() => assertDashboardSnapshot(excessiveCPU), /no greater than 100/);
 });
 
 test("web snapshots require sanitized-remote mode and sanitized records", async () => {

--- a/prototypes/operations-dashboard/tests/publication.test.mjs
+++ b/prototypes/operations-dashboard/tests/publication.test.mjs
@@ -25,6 +25,12 @@ function localSnapshot(label = "First") {
         title: `${label} sanitized queue record`,
         detail: "Approved for the remote snapshot.",
         state: "running",
+        completedSteps: 3,
+        totalSteps: 5,
+        currentStep: "Synthetic validation",
+        lastActiveSeconds: 15,
+        memoryMB: 512,
+        cpuPercent: 12.5,
         ...recordMetadata(),
       },
       {
@@ -103,6 +109,24 @@ test("sanitization keeps allowlisted records and drops every local-only record",
     "signals",
     "tests",
   ]);
+  assert.deepEqual(
+    {
+      completedSteps: sanitized.queue[0].completedSteps,
+      totalSteps: sanitized.queue[0].totalSteps,
+      currentStep: sanitized.queue[0].currentStep,
+      lastActiveSeconds: sanitized.queue[0].lastActiveSeconds,
+      memoryMB: sanitized.queue[0].memoryMB,
+      cpuPercent: sanitized.queue[0].cpuPercent,
+    },
+    {
+      completedSteps: 3,
+      totalSteps: 5,
+      currentStep: "Synthetic validation",
+      lastActiveSeconds: 15,
+      memoryMB: 512,
+      cpuPercent: 12.5,
+    },
+  );
 });
 
 test("an unverified local-only record fails before it can be filtered", () => {

--- a/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
+++ b/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
@@ -49,10 +49,14 @@ release.
    At the default size, confirm queue and supporting panels use two columns.
    Resize to the minimum and confirm they collapse to one column without
    clipping the guide summary or four queue counters.
-4. Choose **Import Local Snapshot…** only if a canonical `local` version `1.0`
+4. Confirm each queue race shows a bounded progress chip, hover detail, and
+   click-to-expand detail. Exercise last-active, completion, memory, CPU, and
+   needs-attention sorting. Confirm an increased total-step count can move a
+   chip backward and Reduce Motion replaces animation with a stable frame.
+5. Choose **Import Local Snapshot…** only if a canonical `local` version `1.0`
    snapshot is ready. The app validates before writing and gives the stored file
    private permissions.
-5. Confirm the header reports a locally verified snapshot rather than the
+6. Confirm the header reports a locally verified snapshot rather than the
    generic sample.
 
 ## Update

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A705BC6F0D3A543F75D84535 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D7388421B1A4219EF55A7B2 /* Assets.xcassets */; };
 		B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */; };
 		C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */; };
+		C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9DF97AD77E17679BD52803 /* QueueRace.swift */; };
 		FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2103622C4FB3754F316FE /* DashboardContract.swift */; };
 /* End PBXBuildFile section */
 
@@ -18,6 +19,7 @@
 		02D2103622C4FB3754F316FE /* DashboardContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContract.swift; sourceTree = "<group>"; };
 		1879896A7B14D79C647AA2C1 /* OperationsFloater.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OperationsFloater.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePresentation.swift; sourceTree = "<group>"; };
+		4A9DF97AD77E17679BD52803 /* QueueRace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueRace.swift; sourceTree = "<group>"; };
 		62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsFloaterApp.swift; sourceTree = "<group>"; };
 		6D7388421B1A4219EF55A7B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotStore.swift; sourceTree = "<group>"; };
@@ -40,6 +42,7 @@
 				36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */,
 				CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */,
 				62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */,
+				4A9DF97AD77E17679BD52803 /* QueueRace.swift */,
 			);
 			name = OperationsFloater;
 			path = Sources/OperationsFloater;
@@ -127,6 +130,7 @@
 				C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */,
 				2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */,
 				B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */,
+				C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -39,7 +39,7 @@ The native and web dashboards use the same information hierarchy without
 sharing runtime code or creating a device bridge:
 
 1. resource-budget evidence;
-2. queue lanes for running, queued, waiting, and ready work; and
+2. sortable queue race lanes for running, queued, waiting, and ready work; and
 3. compact tests-and-quality and signals panels.
 
 The native surface adds a local queue guide and window controls. At widths of
@@ -60,6 +60,13 @@ snapshot remains schema version `1.0`.
   Motion produces a fully stable frame.
 - The guide uses no image feed, camera, microphone, network service, analytics,
   or external transmission.
+- Queue work appears on a 0-to-100 percent rail. Its rectangular chip animates
+  as verified step evidence changes; adding steps can move the chip backward
+  without erasing completed work. Hovering shows the full summary and clicking
+  the chip or **Details** expands the lane.
+- Queue races can retain source order or sort by last activity, completion,
+  memory, CPU, or a deterministic needs-attention score. Missing evidence sorts
+  last and is labeled unavailable rather than estimated.
 - The default 620-by-640 window shows a dense two-column operational grid and
   remains usable down to a 380-by-480 compact single-column layout.
 - The application target is sandboxed, uses hardened runtime, and includes a

--- a/prototypes/operations-floater/Sources/OperationsFloater/DashboardContract.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/DashboardContract.swift
@@ -26,6 +26,45 @@ struct QueueRecord: Identifiable, Decodable, Hashable {
     let state: State
     let exposure: DashboardExposure
     let verification: DashboardVerification
+    let completedSteps: Int?
+    let totalSteps: Int?
+    let currentStep: String?
+    let lastActiveSeconds: Int?
+    let memoryMB: Double?
+    let cpuPercent: Double?
+
+    init(
+        id: String,
+        title: String,
+        detail: String,
+        state: State,
+        exposure: DashboardExposure,
+        verification: DashboardVerification,
+        completedSteps: Int? = nil,
+        totalSteps: Int? = nil,
+        currentStep: String? = nil,
+        lastActiveSeconds: Int? = nil,
+        memoryMB: Double? = nil,
+        cpuPercent: Double? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.state = state
+        self.exposure = exposure
+        self.verification = verification
+        self.completedSteps = completedSteps
+        self.totalSteps = totalSteps
+        self.currentStep = currentStep
+        self.lastActiveSeconds = lastActiveSeconds
+        self.memoryMB = memoryMB
+        self.cpuPercent = cpuPercent
+    }
+
+    var progressFraction: Double? {
+        guard let completedSteps, let totalSteps, totalSteps > 0 else { return nil }
+        return min(1, max(0, Double(completedSteps) / Double(totalSteps)))
+    }
 }
 
 struct TestRecord: Identifiable, Decodable, Hashable {
@@ -128,7 +167,15 @@ struct DashboardSnapshot: Decodable, Hashable {
         )
         try requireRecordKeys(
             root["queue"],
-            required: ["id", "title", "detail", "state", "exposure", "verification"]
+            required: ["id", "title", "detail", "state", "exposure", "verification"],
+            optional: [
+                "completedSteps",
+                "totalSteps",
+                "currentStep",
+                "lastActiveSeconds",
+                "memoryMB",
+                "cpuPercent",
+            ]
         )
         try requireRecordKeys(
             root["tests"],
@@ -181,6 +228,27 @@ struct DashboardSnapshot: Decodable, Hashable {
         }) else {
             throw ValidationError.invalidResourceBudget
         }
+        guard queue.allSatisfy({ record in
+            let stepsArePaired = (record.completedSteps == nil) == (record.totalSteps == nil)
+            let stepsAreValid =
+                record.completedSteps.map { $0 >= 0 && $0 <= 100_000 } ?? true
+            let totalIsValid = record.totalSteps.map { $0 > 0 && $0 <= 100_000 } ?? true
+            let completedFitsTotal =
+                if let completed = record.completedSteps, let total = record.totalSteps {
+                    completed <= total
+                } else {
+                    true
+                }
+            return stepsArePaired
+                && stepsAreValid
+                && totalIsValid
+                && completedFitsTotal
+                && (record.lastActiveSeconds.map { $0 >= 0 && $0 <= 315_360_000 } ?? true)
+                && (record.memoryMB.map { $0 >= 0 && $0 <= 16_777_216 } ?? true)
+                && (record.cpuPercent.map { $0 >= 0 && $0 <= 100 } ?? true)
+        }) else {
+            throw ValidationError.invalidRecordContent
+        }
 
         let commonFields =
             queue.map { ($0.id, $0.title, $0.detail) }
@@ -194,6 +262,9 @@ struct DashboardSnapshot: Decodable, Hashable {
         }),
         resourceBudget.allSatisfy({
             Self.isValidString($0.displayValue, maximum: 80)
+        }),
+        queue.allSatisfy({
+            $0.currentStep.map { Self.isValidString($0, maximum: 120) } ?? true
         }) else {
             throw ValidationError.invalidRecordContent
         }
@@ -211,7 +282,13 @@ struct DashboardSnapshot: Decodable, Hashable {
                 detail: "Replace with approved local or sanitized state.",
                 state: .running,
                 exposure: .sanitized,
-                verification: .estimated
+                verification: .estimated,
+                completedSteps: 5,
+                totalSteps: 8,
+                currentStep: "Verifying the bounded build",
+                lastActiveSeconds: 18,
+                memoryMB: 2_450,
+                cpuPercent: 36.5
             ),
             QueueRecord(
                 id: "EX-Q2",
@@ -219,7 +296,41 @@ struct DashboardSnapshot: Decodable, Hashable {
                 detail: "Awaiting a generic follow-up.",
                 state: .queued,
                 exposure: .sanitized,
-                verification: .estimated
+                verification: .estimated,
+                completedSteps: 1,
+                totalSteps: 6,
+                currentStep: "Waiting for a worker slot",
+                lastActiveSeconds: 240,
+                memoryMB: 180,
+                cpuPercent: 0.4
+            ),
+            QueueRecord(
+                id: "EX-Q3",
+                title: "Example dependency review",
+                detail: "A synthetic dependency added two more steps.",
+                state: .waiting,
+                exposure: .sanitized,
+                verification: .estimated,
+                completedSteps: 3,
+                totalSteps: 9,
+                currentStep: "Resolve the added dependency",
+                lastActiveSeconds: 900,
+                memoryMB: 620,
+                cpuPercent: 1.2
+            ),
+            QueueRecord(
+                id: "EX-Q4",
+                title: "Example ready item",
+                detail: "Synthetic work completed every declared step.",
+                state: .ready,
+                exposure: .sanitized,
+                verification: .estimated,
+                completedSteps: 8,
+                totalSteps: 8,
+                currentStep: "Ready for owner review",
+                lastActiveSeconds: 45,
+                memoryMB: 96,
+                cpuPercent: 0
             )
         ],
         tests: [

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -271,13 +271,6 @@ final class DashboardState: ObservableObject {
     }
 }
 
-private struct QueueLaneDefinition: Identifiable {
-    let state: QueueRecord.State
-    let title: String
-
-    var id: QueueRecord.State { state }
-}
-
 private struct DashboardView: View {
     @StateObject private var state: DashboardState
 
@@ -295,7 +288,7 @@ private struct DashboardView: View {
                     VStack(alignment: .leading, spacing: metrics.sectionSpacing) {
                         guideStrip(metrics: metrics)
                         resourceBudgetPanel(metrics: metrics)
-                        queueGrid(metrics: metrics)
+                        QueueRaceBoard(records: state.snapshot.queue, metrics: metrics)
                         supportingGrid(metrics: metrics)
                     }
                     .padding(metrics.contentPadding)
@@ -408,44 +401,6 @@ private struct DashboardView: View {
                         verification: record.verification.rawValue,
                         metrics: metrics
                     )
-                }
-            }
-        }
-    }
-
-    private func queueGrid(metrics: DashboardLayoutMetrics) -> some View {
-        let definitions = [
-            QueueLaneDefinition(state: .running, title: "Running"),
-            QueueLaneDefinition(state: .queued, title: "Queued"),
-            QueueLaneDefinition(state: .waiting, title: "Waiting"),
-            QueueLaneDefinition(state: .ready, title: "Ready")
-        ].filter { definition in
-            state.snapshot.queue.contains { $0.state == definition.state }
-        }
-
-        return LazyVGrid(
-            columns: gridColumns(metrics: metrics),
-            alignment: .leading,
-            spacing: metrics.sectionSpacing
-        ) {
-            ForEach(definitions) { definition in
-                let records = state.snapshot.queue.filter { $0.state == definition.state }
-                dashboardPanel(
-                    title: definition.title,
-                    subtitle: "\(records.count) records",
-                    metrics: metrics
-                ) {
-                    VStack(spacing: 0) {
-                        ForEach(records) { record in
-                            recordRow(
-                                title: record.title,
-                                detail: record.detail,
-                                status: nil,
-                                verification: record.verification.rawValue,
-                                metrics: metrics
-                            )
-                        }
-                    }
                 }
             }
         }

--- a/prototypes/operations-floater/Sources/OperationsFloater/QueueRace.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/QueueRace.swift
@@ -1,0 +1,500 @@
+import Foundation
+import SwiftUI
+
+enum QueueRaceSort: String, CaseIterable, Identifiable, Sendable {
+    case sourceOrder
+    case recentlyActive
+    case finishFirst
+    case memory
+    case cpu
+    case needsAttention
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .sourceOrder:
+            "Queue order"
+        case .recentlyActive:
+            "Last active"
+        case .finishFirst:
+            "Closest to finish"
+        case .memory:
+            "Most memory"
+        case .cpu:
+            "Most CPU"
+        case .needsAttention:
+            "Needs attention"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .sourceOrder:
+            "list.number"
+        case .recentlyActive:
+            "clock.arrow.circlepath"
+        case .finishFirst:
+            "flag.checkered"
+        case .memory:
+            "memorychip"
+        case .cpu:
+            "cpu"
+        case .needsAttention:
+            "exclamationmark.triangle"
+        }
+    }
+}
+
+enum QueueRaceSorter {
+    static func sorted(
+        _ records: [QueueRecord],
+        by sort: QueueRaceSort
+    ) -> [QueueRecord] {
+        guard sort != .sourceOrder else { return records }
+        let indexed = Array(records.enumerated())
+        return indexed.sorted { left, right in
+            let comparison: ComparisonResult
+            switch sort {
+            case .sourceOrder:
+                comparison = .orderedSame
+            case .recentlyActive:
+                comparison = compareAscending(
+                    left.element.lastActiveSeconds,
+                    right.element.lastActiveSeconds
+                )
+            case .finishFirst:
+                comparison = compareDescending(
+                    left.element.progressFraction,
+                    right.element.progressFraction
+                )
+            case .memory:
+                comparison = compareDescending(left.element.memoryMB, right.element.memoryMB)
+            case .cpu:
+                comparison = compareDescending(left.element.cpuPercent, right.element.cpuPercent)
+            case .needsAttention:
+                comparison = compareDescending(
+                    attentionScore(left.element),
+                    attentionScore(right.element)
+                )
+            }
+            return comparison == .orderedSame
+                ? left.offset < right.offset
+                : comparison == .orderedAscending
+        }.map(\.element)
+    }
+
+    private static func compareAscending<T: Comparable>(
+        _ left: T?,
+        _ right: T?
+    ) -> ComparisonResult {
+        switch (left, right) {
+        case let (.some(left), .some(right)):
+            if left < right { return .orderedAscending }
+            if left > right { return .orderedDescending }
+            return .orderedSame
+        case (.some, .none):
+            return .orderedAscending
+        case (.none, .some):
+            return .orderedDescending
+        case (.none, .none):
+            return .orderedSame
+        }
+    }
+
+    private static func compareDescending<T: Comparable>(
+        _ left: T?,
+        _ right: T?
+    ) -> ComparisonResult {
+        switch (left, right) {
+        case let (.some(left), .some(right)):
+            if left > right { return .orderedAscending }
+            if left < right { return .orderedDescending }
+            return .orderedSame
+        case (.some, .none):
+            return .orderedAscending
+        case (.none, .some):
+            return .orderedDescending
+        case (.none, .none):
+            return .orderedSame
+        }
+    }
+
+    private static func attentionScore(_ record: QueueRecord) -> Int {
+        let stateScore =
+            switch record.state {
+            case .waiting: 50
+            case .running: 30
+            case .queued: 20
+            case .ready: 0
+            }
+        let verificationScore =
+            switch record.verification {
+            case .unavailable, .notImplemented: 30
+            case .estimated: 10
+            case .verified: 0
+            }
+        let staleScore =
+            switch record.lastActiveSeconds {
+            case .some(let seconds) where seconds >= 86_400: 20
+            case .some(let seconds) where seconds >= 3_600: 10
+            default: 0
+            }
+        return stateScore + verificationScore + staleScore
+    }
+}
+
+struct QueueRaceBoard: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let records: [QueueRecord]
+    let metrics: DashboardLayoutMetrics
+
+    @State private var sort: QueueRaceSort = .recentlyActive
+    @State private var expandedRecordID: String?
+    @State private var hoveredRecordID: String?
+
+    private var sortedRecords: [QueueRecord] {
+        QueueRaceSorter.sorted(records, by: sort)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .center, spacing: 8) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("WORK RACES")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.secondary)
+                    Text("\(records.count) lanes · sorted by \(sort.label.lowercased())")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer(minLength: 8)
+                Picker("Sort work races", selection: $sort) {
+                    ForEach(QueueRaceSort.allCases) { option in
+                        Label(option.label, systemImage: option.systemImage)
+                            .tag(option)
+                    }
+                }
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .labelsHidden()
+                .accessibilityLabel("Sort work races")
+            }
+            .padding(.horizontal, metrics.recordPadding)
+            .padding(.vertical, 7)
+
+            Divider()
+
+            HStack {
+                Text("0% · START")
+                Spacer()
+                Text("Steps added can move a task backward")
+                Spacer()
+                Text("FINISH · 100%")
+            }
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .padding(.horizontal, metrics.recordPadding)
+            .padding(.vertical, 6)
+
+            VStack(spacing: 0) {
+                ForEach(Array(sortedRecords.enumerated()), id: \.element.id) { rank, record in
+                    QueueRaceLane(
+                        record: record,
+                        rank: rank + 1,
+                        metrics: metrics,
+                        isExpanded: expandedRecordID == record.id,
+                        isHovered: hoveredRecordID == record.id,
+                        onToggleExpanded: {
+                            withAnimation(reduceMotion ? nil : .snappy(duration: 0.24)) {
+                                expandedRecordID =
+                                    expandedRecordID == record.id ? nil : record.id
+                            }
+                        },
+                        onHover: { hovering in
+                            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) {
+                                hoveredRecordID = hovering ? record.id : nil
+                            }
+                        }
+                    )
+                }
+            }
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.86),
+                value: sortedRecords.map(\.id)
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 11))
+        .clipShape(RoundedRectangle(cornerRadius: 11))
+    }
+}
+
+private struct QueueRaceLane: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let record: QueueRecord
+    let rank: Int
+    let metrics: DashboardLayoutMetrics
+    let isExpanded: Bool
+    let isHovered: Bool
+    let onToggleExpanded: () -> Void
+    let onHover: (Bool) -> Void
+
+    private var progress: Double {
+        record.progressFraction ?? 0
+    }
+
+    private var accent: Color {
+        switch record.state {
+        case .running:
+            .cyan
+        case .queued:
+            .orange
+        case .waiting:
+            .purple
+        case .ready:
+            .green
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                Text(String(format: "%02d", rank))
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 19, alignment: .leading)
+                Text(record.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                stateBadge
+                Spacer(minLength: 4)
+                Text(progressLabel)
+                    .font(.caption2.monospacedDigit().weight(.bold))
+                    .foregroundStyle(accent)
+            }
+
+            raceRail
+
+            HStack(spacing: 8) {
+                Label(activityLabel, systemImage: "clock")
+                Label(memoryLabel, systemImage: "memorychip")
+                Label(cpuLabel, systemImage: "cpu")
+                Spacer(minLength: 0)
+                Button(isExpanded ? "Less" : "Details") {
+                    onToggleExpanded()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 9, weight: .semibold))
+            }
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+
+            if isHovered || isExpanded {
+                detailPanel
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(metrics.recordPadding)
+        .contentShape(Rectangle())
+        .onHover(perform: onHover)
+        .help(hoverSummary)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .zIndex(isHovered || isExpanded ? 1 : 0)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(
+            "\(record.title), \(record.state.rawValue), \(progressLabel), "
+                + "\(activityLabel), \(memoryLabel), \(cpuLabel)"
+        )
+    }
+
+    private var raceRail: some View {
+        GeometryReader { geometry in
+            let chipWidth = min(126, max(76, geometry.size.width * 0.22))
+            let travel = max(0, geometry.size.width - chipWidth)
+            let chipOffset = travel * progress
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.secondary.opacity(0.14))
+                    .frame(height: 8)
+                    .overlay(alignment: .leading) {
+                        Capsule()
+                            .fill(accent.opacity(0.4))
+                            .frame(width: chipOffset + chipWidth / 2, height: 8)
+                    }
+                    .overlay {
+                        HStack {
+                            ForEach(0..<5, id: \.self) { index in
+                                Rectangle()
+                                    .fill(Color.primary.opacity(index == 0 || index == 4 ? 0.28 : 0.16))
+                                    .frame(width: 1, height: index == 0 || index == 4 ? 12 : 8)
+                                if index < 4 { Spacer() }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 11)
+
+                Button {
+                    onToggleExpanded()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: stateIcon)
+                        Text(chipLabel)
+                            .lineLimit(1)
+                    }
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: chipWidth, height: 26)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(accent.gradient)
+                            .shadow(color: accent.opacity(0.32), radius: 4, y: 2)
+                    )
+                }
+                .buttonStyle(.plain)
+                .offset(x: chipOffset)
+                .accessibilityLabel("Open \(record.title) details")
+            }
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.62, dampingFraction: 0.78),
+                value: progress
+            )
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: 0.25),
+                value: record.state
+            )
+        }
+        .frame(height: 30)
+    }
+
+    private var detailPanel: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(record.detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if let currentStep = record.currentStep {
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Text("NOW")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(accent)
+                    Text(currentStep)
+                        .font(.caption2.weight(.medium))
+                }
+            }
+            LazyVGrid(
+                columns: Array(
+                    repeating: GridItem(.flexible(minimum: 76), alignment: .leading),
+                    count: metrics.density == .dense ? 3 : 2
+                ),
+                alignment: .leading,
+                spacing: 5
+            ) {
+                detailMetric("Steps", stepsLabel)
+                detailMetric("Progress", progressLabel)
+                detailMetric("Last active", activityLabel)
+                detailMetric("Memory", memoryLabel)
+                detailMetric("CPU", cpuLabel)
+                detailMetric("Evidence", record.verification.rawValue)
+            }
+        }
+        .padding(8)
+        .background(accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func detailMetric(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label.uppercased())
+                .font(.system(size: 7, weight: .bold))
+                .foregroundStyle(.tertiary)
+            Text(value.replacingOccurrences(of: "-", with: " "))
+                .font(.system(size: 9, weight: .medium))
+                .lineLimit(1)
+        }
+    }
+
+    private var stateBadge: some View {
+        Text(record.state.rawValue.uppercased())
+            .font(.system(size: 8, weight: .bold))
+            .foregroundStyle(accent)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(accent.opacity(0.12), in: Capsule())
+    }
+
+    private var stateIcon: String {
+        switch record.state {
+        case .running:
+            "play.fill"
+        case .queued:
+            "hourglass"
+        case .waiting:
+            "pause.fill"
+        case .ready:
+            "flag.checkered"
+        }
+    }
+
+    private var chipLabel: String {
+        guard record.progressFraction != nil else { return "NO PROGRESS" }
+        return "\(Int((progress * 100).rounded()))%"
+    }
+
+    private var progressLabel: String {
+        guard record.progressFraction != nil else { return "Progress unavailable" }
+        return "\(Int((progress * 100).rounded()))%"
+    }
+
+    private var stepsLabel: String {
+        guard let completed = record.completedSteps, let total = record.totalSteps else {
+            return "Not supplied"
+        }
+        return "\(completed) of \(total)"
+    }
+
+    private var activityLabel: String {
+        guard let seconds = record.lastActiveSeconds else { return "Activity unavailable" }
+        switch seconds {
+        case 0..<60:
+            return "\(seconds)s ago"
+        case 60..<3_600:
+            return "\(seconds / 60)m ago"
+        case 3_600..<86_400:
+            return "\(seconds / 3_600)h ago"
+        default:
+            return "\(seconds / 86_400)d ago"
+        }
+    }
+
+    private var memoryLabel: String {
+        guard let memory = record.memoryMB else { return "Memory unavailable" }
+        if memory >= 1_024 {
+            return String(format: "%.1f GB", memory / 1_024)
+        }
+        return "\(Int(memory.rounded())) MB"
+    }
+
+    private var cpuLabel: String {
+        guard let cpu = record.cpuPercent else { return "CPU unavailable" }
+        return String(format: "%.1f%% CPU", cpu)
+    }
+
+    private var hoverSummary: String {
+        [
+            record.title,
+            record.detail,
+            record.currentStep.map { "Current: \($0)" },
+            "State: \(record.state.rawValue)",
+            "Steps: \(stepsLabel)",
+            "Progress: \(progressLabel)",
+            "Last active: \(activityLabel)",
+            "Memory: \(memoryLabel)",
+            "CPU: \(cpuLabel)",
+            "Evidence: \(record.verification.rawValue)",
+        ]
+        .compactMap { $0 }
+        .joined(separator: "\n")
+    }
+}

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -14,8 +14,9 @@ struct DashboardStateTests {
         #expect(state.sourceDescription == "Generic sample — local only")
         #expect(state.itemCount(for: .running) == 1)
         #expect(state.itemCount(for: .queued) == 1)
-        #expect(state.itemCount(for: .waiting) == 0)
-        #expect(state.itemCount(for: .ready) == 0)
+        #expect(state.itemCount(for: .waiting) == 1)
+        #expect(state.itemCount(for: .ready) == 1)
+        #expect(state.snapshot.queue.first?.progressFraction == 0.625)
         #expect(state.snapshot.resourceBudget.first?.verification == .unavailable)
     }
 
@@ -44,6 +45,9 @@ struct DashboardStateTests {
         #expect(state.snapshot.tests.first?.result == .queued)
         #expect(state.snapshot.resourceBudget.first?.displayValue == "Busy")
         #expect(state.snapshot.signals.first?.verification == .verified)
+        #expect(state.snapshot.queue.first?.completedSteps == 3)
+        #expect(state.snapshot.queue.first?.totalSteps == 5)
+        #expect(state.snapshot.queue.first?.cpuPercent == 42.5)
     }
 
     @Test("Draft contract aliases fail closed to the generic sample")
@@ -189,6 +193,18 @@ struct DashboardStateTests {
         #expect(state.snapshot == .sample)
     }
 
+    @Test("Invalid or unpaired progress evidence fails closed")
+    func invalidProgressFailsClosed() throws {
+        let invalid = localFixture(verification: "verified")
+            .replacingOccurrences(of: #""totalSteps": 5"#, with: #""totalSteps": 2"#)
+        let fixtureURL = try makeFixture(contents: invalid)
+        defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
+
+        let state = DashboardState(snapshotURL: fixtureURL)
+
+        #expect(state.snapshot == .sample)
+    }
+
     @Test("Window opens frontmost, unpins, closes, and reopens as the same retained window")
     func windowLifecycleAndPinning() {
         _ = NSApplication.shared
@@ -259,7 +275,13 @@ struct DashboardStateTests {
               "detail": "Local record",
               "state": "running",
               "exposure": "local-only",
-              "verification": "\(verification)"
+              "verification": "\(verification)",
+              "completedSteps": 3,
+              "totalSteps": 5,
+              "currentStep": "Synthetic verification",
+              "lastActiveSeconds": 12,
+              "memoryMB": 768,
+              "cpuPercent": 42.5
             },
             {
               "id": "Q2",

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/QueueRaceTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/QueueRaceTests.swift
@@ -1,0 +1,159 @@
+import Testing
+@testable import OperationsFloater
+
+@Suite("Queue race board")
+struct QueueRaceTests {
+    @Test("Adding steps moves progress backward without losing completed work")
+    func addedStepsRegressTheSlider() throws {
+        let before = record(
+            id: "before",
+            completed: 3,
+            total: 4,
+            active: 10,
+            memory: 100,
+            cpu: 10
+        )
+        let after = record(
+            id: "after",
+            completed: 3,
+            total: 6,
+            active: 10,
+            memory: 100,
+            cpu: 10
+        )
+
+        let beforeProgress = try #require(before.progressFraction)
+        let afterProgress = try #require(after.progressFraction)
+        #expect(beforeProgress == 0.75)
+        #expect(afterProgress == 0.5)
+        #expect(afterProgress < beforeProgress)
+    }
+
+    @Test("Every numeric sort is deterministic and leaves missing evidence last")
+    func numericSortModes() {
+        let records = [
+            record(
+                id: "middle",
+                completed: 2,
+                total: 4,
+                active: 40,
+                memory: 400,
+                cpu: 20
+            ),
+            record(
+                id: "high",
+                completed: 4,
+                total: 5,
+                active: 10,
+                memory: 800,
+                cpu: 70
+            ),
+            QueueRecord(
+                id: "missing",
+                title: "Missing metrics",
+                detail: "No runtime evidence.",
+                state: .queued,
+                exposure: .sanitized,
+                verification: .unavailable
+            ),
+        ]
+
+        #expect(
+            QueueRaceSorter.sorted(records, by: .recentlyActive).map(\.id)
+                == ["high", "middle", "missing"]
+        )
+        #expect(
+            QueueRaceSorter.sorted(records, by: .finishFirst).map(\.id)
+                == ["high", "middle", "missing"]
+        )
+        #expect(
+            QueueRaceSorter.sorted(records, by: .memory).map(\.id)
+                == ["high", "middle", "missing"]
+        )
+        #expect(
+            QueueRaceSorter.sorted(records, by: .cpu).map(\.id)
+                == ["high", "middle", "missing"]
+        )
+    }
+
+    @Test("Needs-attention sorting raises waiting and unverifiable work")
+    func attentionSort() {
+        let ready = record(
+            id: "ready",
+            state: .ready,
+            verification: .verified,
+            completed: 5,
+            total: 5,
+            active: 5,
+            memory: 50,
+            cpu: 0
+        )
+        let running = record(
+            id: "running",
+            state: .running,
+            verification: .verified,
+            completed: 3,
+            total: 5,
+            active: 5,
+            memory: 200,
+            cpu: 20
+        )
+        let waiting = record(
+            id: "waiting",
+            state: .waiting,
+            verification: .unavailable,
+            completed: 1,
+            total: 5,
+            active: 7_200,
+            memory: 10,
+            cpu: 0
+        )
+
+        #expect(
+            QueueRaceSorter.sorted(
+                [ready, running, waiting],
+                by: .needsAttention
+            ).map(\.id) == ["waiting", "running", "ready"]
+        )
+    }
+
+    @Test("Source order is preserved exactly")
+    func sourceOrder() {
+        let records = [
+            record(id: "c", completed: 1, total: 4, active: 1, memory: 1, cpu: 1),
+            record(id: "a", completed: 4, total: 4, active: 2, memory: 2, cpu: 2),
+            record(id: "b", completed: 2, total: 4, active: 3, memory: 3, cpu: 3),
+        ]
+
+        #expect(
+            QueueRaceSorter.sorted(records, by: .sourceOrder).map(\.id)
+                == ["c", "a", "b"]
+        )
+    }
+
+    private func record(
+        id: String,
+        state: QueueRecord.State = .running,
+        verification: DashboardVerification = .verified,
+        completed: Int,
+        total: Int,
+        active: Int,
+        memory: Double,
+        cpu: Double
+    ) -> QueueRecord {
+        QueueRecord(
+            id: id,
+            title: "Synthetic \(id)",
+            detail: "Synthetic queue race record.",
+            state: state,
+            exposure: .sanitized,
+            verification: verification,
+            completedSteps: completed,
+            totalSteps: total,
+            currentStep: "Synthetic step",
+            lastActiveSeconds: active,
+            memoryMB: memory,
+            cpuPercent: cpu
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- extend schema 1.0 queue records with optional, bounded progress, current-step,
  activity-age, memory, and normalized CPU evidence
- preserve legacy queue records and carry explicitly sanitized optional evidence
  through publication
- replace grouped queue cards in the native macOS floater with animated 0-100%
  race lanes
- add hover summaries, click-to-expand details, and deterministic sorting by
  source order, activity, completion, memory, CPU, or attention
- keep missing evidence visibly unavailable and sorted last instead of
  inventing estimates

## Why

The previous queue grouped work only by state, so it could not show how far a
task had progressed, move backward when new steps were added, expose resource
evidence, or reorder lanes by operational priority.

## Privacy and compatibility

- schema version remains `1.0`; all six new fields are optional and legacy
  records remain valid
- strict native, shared, and web validators reject malformed bounds and unknown
  fields
- no endpoint, host, path, credential, private snapshot, or
  workstation-specific value is added
- the native target retains its original no-network entitlements in this PR

## Validation

Exact commit `d64334f2c822ab3d9e24fdf4be64d49cf7853eb3` was validated from a clean
detached worktree:

- `swift test`: 26 tests passed
- shared dashboard Node suite: 15 tests passed
- static web privacy suite: 6 tests passed
- unsigned Release `xcodebuild` with `CODE_SIGNING_ALLOWED=NO`: succeeded
- bounded native UI check: four rails rendered; full help was exposed; click
  drill-down rendered; sort menu exposed all six modes; memory sort reordered
  lanes correctly
- all three Firestarter example stacks stamped cleanly in Docker; no token
  leaks; generated shell parsed; generator compiled
- `git diff --check`: clean
