### PR TITLE
feat(operations-floater): host bounded recorder conversations

### DIFF
--- a/docs/OPERATIONS-DASHBOARD.md
+++ b/docs/OPERATIONS-DASHBOARD.md
@@ -83,6 +83,25 @@ The selected source path is not retained, invalid input cannot replace the
 current snapshot, and missing or invalid runtime state falls back to the
 committed generic sample. The app has no network updater.
 
+The native assistant can also host one statically allowlisted conversation
+module at a time. The dashboard retains the UI, explicit microphone permission,
+on-device transcription, optional local speech output, and ephemeral chat
+memory. Modules use only the fixed `127.0.0.1` contract, have no UI/mic/TTS,
+persistence, capture, injection, replay, or arbitrary network capability, and
+lose the floor on any contract or provenance failure. See the
+[conversation module 1.0 contract](../prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md).
+
+For low-disruption local UI checks, create and retain a spare macOS Desktop,
+assign Operations Floater to that Desktop in the Dock when launches should
+route there automatically, and launch with
+`open -g ... --args --background-ui-test`. That mode is unpinned,
+single-Space, nonactivating, and does not force-order its window above unrelated
+work. The assignment is keyed to the candidate's bundle identifier, so a
+differently identified build needs its own one-time assignment. Desktop
+creation and Dock assignment remain explicit user actions because macOS exposes
+no supported silent Desktop-management API. See
+[`prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md`](../prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md).
+
 See
 [`prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md`](../prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md)
 for signed-install preflight, update acceptance, and application rollback.

--- a/prototypes/operations-floater/Info.plist
+++ b/prototypes/operations-floater/Info.plist
@@ -27,5 +27,9 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Start Voice Conversation uses the microphone only while you explicitly listen.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Voice Conversation requires on-device speech recognition and keeps transcripts ephemeral.</string>
 </dict>
 </plist>

--- a/prototypes/operations-floater/OperationsFloater.entitlements
+++ b/prototypes/operations-floater/OperationsFloater.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -13,7 +13,9 @@
 		C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */; };
 		C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9DF97AD77E17679BD52803 /* QueueRace.swift */; };
 		C8B57BCE1270FE6351B6218A /* RouterChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF18361984088F8616CB04 /* RouterChat.swift */; };
+		F333740CE69F4C5EBA9536A2 /* ConversationModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675EB43F01F9FDA3CC6763B1 /* ConversationModule.swift */; };
 		FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2103622C4FB3754F316FE /* DashboardContract.swift */; };
+		FE30922D27D73D155CBD75EC /* ConversationVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37B6D58036BC8B9F8A47688 /* ConversationVoice.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,7 +25,9 @@
 		42AF18361984088F8616CB04 /* RouterChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterChat.swift; sourceTree = "<group>"; };
 		4A9DF97AD77E17679BD52803 /* QueueRace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueRace.swift; sourceTree = "<group>"; };
 		62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsFloaterApp.swift; sourceTree = "<group>"; };
+		675EB43F01F9FDA3CC6763B1 /* ConversationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationModule.swift; sourceTree = "<group>"; };
 		6D7388421B1A4219EF55A7B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A37B6D58036BC8B9F8A47688 /* ConversationVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationVoice.swift; sourceTree = "<group>"; };
 		CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -40,6 +44,8 @@
 		B80BC94537001B87D87E8E07 /* OperationsFloater */ = {
 			isa = PBXGroup;
 			children = (
+				675EB43F01F9FDA3CC6763B1 /* ConversationModule.swift */,
+				A37B6D58036BC8B9F8A47688 /* ConversationVoice.swift */,
 				02D2103622C4FB3754F316FE /* DashboardContract.swift */,
 				36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */,
 				CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */,
@@ -129,6 +135,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F333740CE69F4C5EBA9536A2 /* ConversationModule.swift in Sources */,
+				FE30922D27D73D155CBD75EC /* ConversationVoice.swift in Sources */,
 				FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */,
 				C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */,
 				2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */,

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -49,7 +49,12 @@ snapshot remains schema version `1.0`.
 
 ## Current behavior
 
-- The dashboard opens visibly in front and defaults to **Keep in front**.
+- An explicit user launch opens visibly in front but defaults **Keep in front**
+  to off. Pinning is always a deliberate user choice.
+- A deliberate `--background-ui-test` launch mode leaves **Keep in front** off,
+  stays on one macOS Desktop, and neither activates the app nor force-orders its
+  window above unrelated work. Normal user launches retain the foreground
+  behavior above.
 - Turning off **Keep in front** immediately restores normal window level.
 - Closing the window, including with Command-W, retains the app; use **Show
   Dashboard** or click the Dock icon to reopen the same window.
@@ -58,8 +63,8 @@ snapshot remains schema version `1.0`.
   become attention cues.
 - Guide motion is a deterministic function of time and canonical state. Reduce
   Motion produces a fully stable frame.
-- The guide uses no image feed, camera, microphone, network service, analytics,
-  or external transmission.
+- The guide itself uses no image feed, camera, microphone, network service,
+  analytics, or external transmission.
 - Queue work appears on a 0-to-100 percent rail. Its rectangular chip animates
   as verified step evidence changes; adding steps can move the chip backward
   without erasing completed work. Hovering shows the full summary and clicking
@@ -72,11 +77,12 @@ snapshot remains schema version `1.0`.
   `http://127.0.0.1:11500/v1/chat/completions` with model `auto`. The app sends
   no provider key, Relay token, dashboard snapshot, or stored file. The Router
   owns model choice and any separately configured, policy-guarded escalation.
-- Every assistant bubble keeps its own bounded responder provenance. Explicit
-  Router metadata is labeled **Claude**, **Codex**, or **Local LLM**, with a
-  reported model when available. Other reported providers retain their bounded
-  name. A legacy response containing only `model: "auto"` is labeled **Router ·
-  provider not reported**; the app never guesses an identity from `auto`.
+- Every assistant bubble keeps its own bounded responder provenance. The label
+  comes only from Router-reported `responder.kind` or `responder.provider`
+  fields and is closed to **Claude**, **Codex**, or **local-LLM**, with the
+  reported model when available. Model text alone is never used to infer
+  identity. Missing, malformed, or other provider metadata fails closed without
+  adding an assistant bubble.
 - Reply monitoring is independently default-off. When enabled, or when
   **Review** is clicked, a second Router-selected request checks whether the
   reply answered the request, stayed evidence-aware, and gave a useful next
@@ -88,6 +94,23 @@ snapshot remains schema version `1.0`.
 - The chat composer is a multiline text area: **Return** sends a non-empty
   draft, while **Shift-Return** inserts a newline without contacting the
   Router. The same behavior is exposed as an accessibility hint.
+- A compiled static module allowlist can give exactly one bounded conversation
+  module the floor. Modules provide no UI, mic, TTS, persistence, capture,
+  input injection, executable replay, arbitrary network, or dynamic code.
+  Escape or **Return to dashboard** revokes the floor. The built-in synthetic
+  checkpoint module provides deterministic contract testing; the geometry
+  recorder adapter uses only fixed loopback IPC and neutral synthetic fixture
+  events.
+- Voice conversation is separately explicit and default-off. Production speech
+  recognition requires an on-device provider and fails closed when permission,
+  provider metadata, or on-device support is unavailable. Start, pause, resume,
+  stop, listening, thinking, and responding states remain visible. Optional
+  local spoken replies are default-off and interruptible. Finalized speech is
+  staged immediately as a pending **You** bubble, then follows the same host
+  send path after exactly 2.000 seconds of continuous pause. Resumed speech
+  cancels and restarts that timer. Pause, stop, floor revoke, module switch,
+  clear, and window teardown cancel the pending turn; transcript/session memory
+  is ephemeral.
 - The UI warns that private or patient data must not be entered because an
   already-configured Router escalation may leave the device. Router policy
   remains the authoritative egress guard.
@@ -98,6 +121,12 @@ snapshot remains schema version `1.0`.
 
 See [INSTALL_UPDATE_ROLLBACK.md](INSTALL_UPDATE_ROLLBACK.md) for the release
 preflight, local update procedure, acceptance checks, and rollback path.
+See [docs/BACKGROUND_UI_TESTING.md](docs/BACKGROUND_UI_TESTING.md) for the
+low-disruption spare-Desktop test workflow and its measured limitations.
+See
+[docs/CONVERSATION_MODULE_CONTRACT.md](docs/CONVERSATION_MODULE_CONTRACT.md)
+for the versioned module manifest, exact IPC envelope and bounds, floor
+lifecycle, privacy posture, and failure behavior.
 
 ## Validation
 

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationModule.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationModule.swift
@@ -1,0 +1,1184 @@
+import Combine
+import Foundation
+
+enum ConversationModuleContract {
+    static let version = "1.0"
+    static let clientIdentifier = "operations-floater"
+    static let loopbackBaseURL = URL(
+        string: "http://127.0.0.1:11510/v1/conversation-modules"
+    )!
+
+    static let maximumNarrationCharacters = 2_000
+    static let maximumContextTurns = 6
+    static let maximumContextCharacters = 6_000
+    static let maximumEvents = 32
+    static let maximumReplyCharacters = 4_000
+    static let maximumQuestionCharacters = 600
+    static let maximumStatuses = 4
+    static let maximumCheckpoints = 8
+    static let maximumProposedActions = 4
+    static let maximumResponseBytes = 65_536
+    static let maximumHealthBytes = 16_384
+}
+
+enum ConversationModuleCapability: String, Codable, CaseIterable, Sendable {
+    case narration
+    case normalizedPointerEvents = "normalized-pointer-events"
+    case navigationKeys = "navigation-keys"
+    case placeholderEvents = "placeholder-events"
+    case neutralWindowContext = "neutral-window-context"
+    case checkpoints
+    case proposedActions = "proposed-actions"
+}
+
+struct ConversationModulePrivacy: Codable, Equatable, Sendable {
+    let ephemeralOnly: Bool
+    let moduleOwnsMicrophone: Bool
+    let moduleOwnsUI: Bool
+    let moduleOwnsTTS: Bool
+    let arbitraryNetwork: Bool
+    let persistence: Bool
+    let screenCapture: Bool
+    let inputInjection: Bool
+    let executableReplay: Bool
+
+    static let hostControlled = ConversationModulePrivacy(
+        ephemeralOnly: true,
+        moduleOwnsMicrophone: false,
+        moduleOwnsUI: false,
+        moduleOwnsTTS: false,
+        arbitraryNetwork: false,
+        persistence: false,
+        screenCapture: false,
+        inputInjection: false,
+        executableReplay: false
+    )
+
+    func validate() throws {
+        guard self == .hostControlled else {
+            throw ConversationModuleError.privacyContractRejected
+        }
+    }
+}
+
+struct ConversationModuleManifest: Codable, Equatable, Identifiable, Sendable {
+    let contractVersion: String
+    let moduleID: String
+    let displayName: String
+    let capabilities: [ConversationModuleCapability]
+    let privacy: ConversationModulePrivacy
+    let provenanceSourceID: String
+    let allowedTranscriptProviders: [ConversationTranscriptProvider]
+    let allowedWindowBindingIDs: [String]
+
+    var id: String { moduleID }
+
+    func validate() throws {
+        guard contractVersion == ConversationModuleContract.version else {
+            throw ConversationModuleError.unsupportedContract
+        }
+        guard Self.validIdentifier(moduleID, maximum: 120),
+              Self.validIdentifier(provenanceSourceID, maximum: 120),
+              !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              displayName.count <= 80,
+              Set(capabilities).count == capabilities.count,
+              !capabilities.isEmpty,
+              !allowedTranscriptProviders.isEmpty,
+              Set(allowedTranscriptProviders).count == allowedTranscriptProviders.count,
+              Set(allowedWindowBindingIDs).count == allowedWindowBindingIDs.count,
+              allowedWindowBindingIDs.count <= 8,
+              allowedWindowBindingIDs.allSatisfy({
+                  Self.validIdentifier($0, maximum: 120)
+              }),
+              capabilities.contains(.neutralWindowContext)
+                == !allowedWindowBindingIDs.isEmpty else {
+            throw ConversationModuleError.invalidManifest
+        }
+        try privacy.validate()
+    }
+
+    static func validIdentifier(_ value: String, maximum: Int) -> Bool {
+        guard value.count <= maximum else { return false }
+        return value.range(
+            of: #"^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+}
+
+struct ConversationModuleProvenance: Codable, Equatable, Sendable {
+    let sourceID: String
+    let buildDigest: String
+
+    func validate(expectedSourceID: String) throws {
+        guard sourceID == expectedSourceID,
+              buildDigest.range(
+                  of: #"^[a-f0-9]{64}$"#,
+                  options: .regularExpression
+              ) != nil else {
+            throw ConversationModuleError.provenanceMismatch
+        }
+    }
+}
+
+enum ConversationModuleHealthState: String, Codable, Sendable {
+    case ready
+    case degraded
+    case unavailable
+}
+
+struct ConversationModuleHealth: Codable, Equatable, Sendable {
+    let contractVersion: String
+    let moduleID: String
+    let state: ConversationModuleHealthState
+    let privacy: ConversationModulePrivacy
+    let provenance: ConversationModuleProvenance
+
+    func validate(for manifest: ConversationModuleManifest) throws {
+        try manifest.validate()
+        guard contractVersion == manifest.contractVersion,
+              moduleID == manifest.moduleID,
+              privacy == manifest.privacy else {
+            throw ConversationModuleError.healthMismatch
+        }
+        try privacy.validate()
+        try provenance.validate(expectedSourceID: manifest.provenanceSourceID)
+    }
+}
+
+enum ConversationFloorState: String, Codable, Sendable {
+    case granted
+    case revoked
+}
+
+struct ConversationFloorGrant: Codable, Equatable, Sendable {
+    let state: ConversationFloorState
+    let moduleID: String
+    let token: String
+
+    func validate(expectedModuleID: String, expectedState: ConversationFloorState) throws {
+        guard state == expectedState,
+              moduleID == expectedModuleID,
+              token.range(
+                  of: #"^floor_[a-f0-9-]{36}$"#,
+                  options: .regularExpression
+              ) != nil else {
+            throw ConversationModuleError.floorMismatch
+        }
+    }
+}
+
+enum ConversationTranscriptProvider: String, Codable, Hashable, Sendable {
+    case typedKeyboard = "typed-keyboard"
+    case onDevice
+    case syntheticFixture
+}
+
+enum ConversationModuleRequestKind: String, Codable, Sendable {
+    case turn
+    case revoke
+    case end
+}
+
+enum ConversationModuleContextRole: String, Codable, Sendable {
+    case user
+    case module
+}
+
+struct ConversationModuleContextTurn: Codable, Equatable, Sendable {
+    let role: ConversationModuleContextRole
+    let text: String
+
+    func validate() throws {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= 1_000 else {
+            throw ConversationModuleError.contextTooLarge
+        }
+    }
+}
+
+struct ConversationModuleContext: Codable, Equatable, Sendable {
+    let turns: [ConversationModuleContextTurn]
+
+    static let empty = ConversationModuleContext(turns: [])
+
+    func validate() throws {
+        guard turns.count <= ConversationModuleContract.maximumContextTurns,
+              turns.reduce(0, { $0 + $1.text.count })
+                <= ConversationModuleContract.maximumContextCharacters else {
+            throw ConversationModuleError.contextTooLarge
+        }
+        try turns.forEach { try $0.validate() }
+    }
+}
+
+enum ConversationPointerPhase: String, Codable, Sendable {
+    case move
+    case down
+    case up
+    case drag
+}
+
+enum ConversationNavigationKey: String, Codable, Sendable {
+    case tab
+    case returnKey = "return"
+    case space
+    case arrowLeft = "arrow-left"
+    case arrowRight = "arrow-right"
+    case arrowUp = "arrow-up"
+    case arrowDown = "arrow-down"
+    case delete
+}
+
+enum ConversationPlaceholderKind: String, Codable, Sendable {
+    case primaryAction = "primary-action"
+    case secondaryAction = "secondary-action"
+    case textField = "text-field"
+    case canvasRegion = "canvas-region"
+}
+
+enum ConversationModuleEventKind: String, Codable, Sendable {
+    case normalizedPointer = "normalized-pointer"
+    case navigationKey = "navigation-key"
+    case placeholder
+}
+
+struct ConversationModuleEvent: Codable, Equatable, Sendable {
+    let eventID: String
+    let sequence: Int
+    let kind: ConversationModuleEventKind
+    let pointerPhase: ConversationPointerPhase?
+    let normalizedX: Double?
+    let normalizedY: Double?
+    let navigationKey: ConversationNavigationKey?
+    let placeholder: ConversationPlaceholderKind?
+
+    func validate() throws {
+        guard eventID.range(
+            of: #"^event_[a-z0-9-]{1,64}$"#,
+            options: .regularExpression
+        ) != nil,
+              sequence >= 1 else {
+            throw ConversationModuleError.invalidEvent
+        }
+        switch kind {
+        case .normalizedPointer:
+            guard pointerPhase != nil,
+                  let normalizedX,
+                  let normalizedY,
+                  (0...1).contains(normalizedX),
+                  (0...1).contains(normalizedY),
+                  navigationKey == nil,
+                  placeholder == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        case .navigationKey:
+            guard navigationKey != nil,
+                  pointerPhase == nil,
+                  normalizedX == nil,
+                  normalizedY == nil,
+                  placeholder == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        case .placeholder:
+            guard placeholder != nil,
+                  pointerPhase == nil,
+                  normalizedX == nil,
+                  normalizedY == nil,
+                  navigationKey == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        }
+    }
+}
+
+struct ConversationModuleWindowContext: Codable, Equatable, Sendable {
+    let bindingID: String
+    let width: Int
+    let height: Int
+
+    func validate(allowedBindingIDs: [String]) throws {
+        guard allowedBindingIDs.contains(bindingID),
+              (100...8_192).contains(width),
+              (100...8_192).contains(height) else {
+            throw ConversationModuleError.windowBindingRejected
+        }
+    }
+}
+
+struct ConversationModuleRequest: Codable, Equatable, Sendable {
+    let contractVersion: String
+    let kind: ConversationModuleRequestKind
+    let moduleID: String
+    let requestID: String
+    let turnID: String
+    let sequence: Int
+    let floor: ConversationFloorGrant
+    let transcriptProvider: ConversationTranscriptProvider
+    let narration: String
+    let context: ConversationModuleContext
+    let events: [ConversationModuleEvent]
+    let window: ConversationModuleWindowContext?
+    let provenance: ConversationModuleProvenance
+
+    func validate(for manifest: ConversationModuleManifest) throws {
+        try manifest.validate()
+        guard contractVersion == manifest.contractVersion,
+              moduleID == manifest.moduleID,
+              requestID.range(
+                  of: #"^request_[a-f0-9-]{36}$"#,
+                  options: .regularExpression
+              ) != nil,
+              turnID.range(
+                  of: #"^turn_[a-f0-9-]{36}$"#,
+                  options: .regularExpression
+              ) != nil,
+              sequence >= 1,
+              events.count <= ConversationModuleContract.maximumEvents else {
+            throw ConversationModuleError.invalidRequest
+        }
+
+        let expectedFloorState: ConversationFloorState =
+            kind == .turn ? .granted : .revoked
+        try floor.validate(
+            expectedModuleID: moduleID,
+            expectedState: expectedFloorState
+        )
+        try provenance.validate(expectedSourceID: manifest.provenanceSourceID)
+        try context.validate()
+
+        switch kind {
+        case .turn:
+            let trimmed = narration.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  trimmed.count <= ConversationModuleContract.maximumNarrationCharacters,
+                  manifest.allowedTranscriptProviders.contains(transcriptProvider),
+                  manifest.capabilities.contains(.narration) else {
+                if !manifest.allowedTranscriptProviders.contains(transcriptProvider) {
+                    throw ConversationModuleError.transcriptProviderRejected
+                }
+                throw ConversationModuleError.narrationRejected
+            }
+        case .revoke, .end:
+            guard narration.isEmpty, context.turns.isEmpty, events.isEmpty, window == nil else {
+                throw ConversationModuleError.invalidRequest
+            }
+        }
+
+        for (index, event) in events.enumerated() {
+            try event.validate()
+            guard event.sequence == index + 1 else {
+                throw ConversationModuleError.sequenceMismatch
+            }
+            switch event.kind {
+            case .normalizedPointer:
+                guard manifest.capabilities.contains(.normalizedPointerEvents) else {
+                    throw ConversationModuleError.capabilityRejected
+                }
+            case .navigationKey:
+                guard manifest.capabilities.contains(.navigationKeys) else {
+                    throw ConversationModuleError.capabilityRejected
+                }
+            case .placeholder:
+                guard manifest.capabilities.contains(.placeholderEvents) else {
+                    throw ConversationModuleError.capabilityRejected
+                }
+            }
+        }
+
+        if let window {
+            guard manifest.capabilities.contains(.neutralWindowContext) else {
+                throw ConversationModuleError.capabilityRejected
+            }
+            try window.validate(allowedBindingIDs: manifest.allowedWindowBindingIDs)
+        }
+    }
+}
+
+enum ConversationModuleState: String, Codable, Sendable {
+    case idle
+    case observing
+    case checkpointReady = "checkpoint-ready"
+    case awaitingAnswer = "awaiting-answer"
+    case completed
+    case refused
+}
+
+enum ConversationModuleStatusKind: String, Codable, Sendable {
+    case info
+    case attention
+    case error
+}
+
+struct ConversationModuleStatus: Codable, Equatable, Sendable {
+    let code: String
+    let kind: ConversationModuleStatusKind
+    let summary: String
+
+    func validate() throws {
+        guard ConversationModuleManifest.validIdentifier(code, maximum: 64),
+              !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              summary.count <= 240 else {
+            throw ConversationModuleError.invalidResponse
+        }
+    }
+}
+
+struct ConversationModuleCheckpoint: Codable, Equatable, Sendable {
+    let checkpointID: String
+    let summary: String
+    let confidence: Double
+
+    func validate() throws {
+        guard checkpointID.range(
+            of: #"^checkpoint_[a-z0-9-]{1,64}$"#,
+            options: .regularExpression
+        ) != nil,
+              !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              summary.count <= 400,
+              (0...1).contains(confidence) else {
+            throw ConversationModuleError.invalidResponse
+        }
+    }
+}
+
+enum ConversationModuleActionKind: String, Codable, Sendable {
+    case acknowledgeCheckpoint = "acknowledge-checkpoint"
+    case discardCheckpoint = "discard-checkpoint"
+    case reviewReplayProposal = "review-replay-proposal"
+    case endModule = "end-module"
+}
+
+struct ConversationModuleProposedAction: Codable, Equatable, Sendable {
+    let actionID: String
+    let kind: ConversationModuleActionKind
+    let title: String
+    let humanApprovalRequired: Bool
+
+    func validate() throws {
+        guard actionID.range(
+            of: #"^action_[a-z0-9-]{1,64}$"#,
+            options: .regularExpression
+        ) != nil,
+              !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              title.count <= 120,
+              humanApprovalRequired else {
+            throw ConversationModuleError.invalidResponse
+        }
+    }
+}
+
+struct ConversationModuleResponse: Codable, Equatable, Sendable {
+    let contractVersion: String
+    let moduleID: String
+    let requestID: String
+    let turnID: String
+    let sequence: Int
+    let floor: ConversationFloorGrant
+    let state: ConversationModuleState
+    let reply: String?
+    let statuses: [ConversationModuleStatus]
+    let checkpoints: [ConversationModuleCheckpoint]
+    let question: String?
+    let proposedActions: [ConversationModuleProposedAction]
+    let provenance: ConversationModuleProvenance
+
+    func validate(
+        for request: ConversationModuleRequest,
+        manifest: ConversationModuleManifest,
+        pinnedProvenance: ConversationModuleProvenance
+    ) throws {
+        guard contractVersion == request.contractVersion,
+              moduleID == request.moduleID,
+              requestID == request.requestID,
+              turnID == request.turnID,
+              sequence == request.sequence,
+              floor == request.floor,
+              provenance == pinnedProvenance,
+              statuses.count <= ConversationModuleContract.maximumStatuses,
+              checkpoints.count <= ConversationModuleContract.maximumCheckpoints,
+              proposedActions.count
+                <= ConversationModuleContract.maximumProposedActions else {
+            throw ConversationModuleError.invalidResponse
+        }
+        try provenance.validate(expectedSourceID: manifest.provenanceSourceID)
+        if let reply {
+            guard !reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  reply.count <= ConversationModuleContract.maximumReplyCharacters else {
+                throw ConversationModuleError.invalidResponse
+            }
+        }
+        if let question {
+            guard !question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  question.count
+                    <= ConversationModuleContract.maximumQuestionCharacters else {
+                throw ConversationModuleError.invalidResponse
+            }
+        }
+        try statuses.forEach { try $0.validate() }
+        try checkpoints.forEach { try $0.validate() }
+        try proposedActions.forEach { try $0.validate() }
+
+        guard checkpoints.isEmpty || manifest.capabilities.contains(.checkpoints),
+              proposedActions.isEmpty
+                || manifest.capabilities.contains(.proposedActions) else {
+            throw ConversationModuleError.capabilityRejected
+        }
+    }
+}
+
+enum ConversationModuleError: LocalizedError, Equatable {
+    case unsupportedContract
+    case invalidManifest
+    case privacyContractRejected
+    case provenanceMismatch
+    case healthMismatch
+    case moduleUnavailable
+    case floorAlreadyGranted
+    case floorMissing
+    case floorMismatch
+    case invalidRequest
+    case narrationRejected
+    case transcriptProviderRejected
+    case contextTooLarge
+    case invalidEvent
+    case sequenceMismatch
+    case capabilityRejected
+    case windowBindingRejected
+    case invalidResponse
+    case moduleRefused
+    case responseTooLarge
+    case rejected(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedContract:
+            "The conversation module uses an unsupported contract version."
+        case .invalidManifest:
+            "The conversation module manifest is invalid."
+        case .privacyContractRejected:
+            "The conversation module requested a forbidden capability."
+        case .provenanceMismatch:
+            "The conversation module provenance changed or was not reported."
+        case .healthMismatch:
+            "The conversation module health response did not match its allowlist entry."
+        case .moduleUnavailable:
+            "The selected conversation module is unavailable."
+        case .floorAlreadyGranted:
+            "Return to the dashboard before giving another module the floor."
+        case .floorMissing:
+            "No conversation module currently has the floor."
+        case .floorMismatch:
+            "The conversation module floor token did not match."
+        case .invalidRequest:
+            "The conversation module request was invalid."
+        case .narrationRejected:
+            "The narration was empty, oversized, or unsupported."
+        case .transcriptProviderRejected:
+            "The transcription provider was missing or not allowlisted for this module."
+        case .contextTooLarge:
+            "The bounded conversation context was invalid."
+        case .invalidEvent:
+            "A normalized module event was invalid."
+        case .sequenceMismatch:
+            "The conversation module sequence was missing, replayed, or out of order."
+        case .capabilityRejected:
+            "The conversation module used a capability outside its allowlist."
+        case .windowBindingRejected:
+            "The neutral window binding was not allowlisted."
+        case .invalidResponse:
+            "The conversation module returned an invalid response."
+        case .moduleRefused:
+            "The conversation module refused the turn and returned control to the dashboard."
+        case .responseTooLarge:
+            "The conversation module response exceeded its safety limit."
+        case let .rejected(status):
+            "The conversation module declined the request (HTTP \(status))."
+        }
+    }
+}
+
+enum ConversationModuleCodec {
+    static func encodeRequest(_ request: ConversationModuleRequest) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(request)
+    }
+
+    static func decodeHealth(_ data: Data) throws -> ConversationModuleHealth {
+        guard data.count <= ConversationModuleContract.maximumHealthBytes else {
+            throw ConversationModuleError.responseTooLarge
+        }
+        let value = try JSONSerialization.jsonObject(with: data)
+        let object = try strictObject(
+            value,
+            required: [
+                "contractVersion", "moduleID", "state", "privacy", "provenance",
+            ]
+        )
+        _ = try strictObject(
+            object["privacy"],
+            required: privacyKeys
+        )
+        _ = try strictObject(
+            object["provenance"],
+            required: ["sourceID", "buildDigest"]
+        )
+        return try JSONDecoder().decode(ConversationModuleHealth.self, from: data)
+    }
+
+    static func decodeResponse(_ data: Data) throws -> ConversationModuleResponse {
+        guard data.count <= ConversationModuleContract.maximumResponseBytes else {
+            throw ConversationModuleError.responseTooLarge
+        }
+        let value = try JSONSerialization.jsonObject(with: data)
+        let object = try strictObject(
+            value,
+            required: [
+                "contractVersion", "moduleID", "requestID", "turnID", "sequence",
+                "floor", "state", "statuses", "checkpoints", "proposedActions",
+                "provenance",
+            ],
+            optional: ["reply", "question"]
+        )
+        _ = try strictObject(
+            object["floor"],
+            required: ["state", "moduleID", "token"]
+        )
+        _ = try strictObject(
+            object["provenance"],
+            required: ["sourceID", "buildDigest"]
+        )
+        try strictArray(
+            object["statuses"],
+            required: ["code", "kind", "summary"]
+        )
+        try strictArray(
+            object["checkpoints"],
+            required: ["checkpointID", "summary", "confidence"]
+        )
+        try strictArray(
+            object["proposedActions"],
+            required: ["actionID", "kind", "title", "humanApprovalRequired"]
+        )
+        if let reply = object["reply"], !(reply is String) {
+            throw ConversationModuleError.invalidResponse
+        }
+        if let question = object["question"], !(question is String) {
+            throw ConversationModuleError.invalidResponse
+        }
+        return try JSONDecoder().decode(ConversationModuleResponse.self, from: data)
+    }
+
+    private static let privacyKeys: Set<String> = [
+        "ephemeralOnly", "moduleOwnsMicrophone", "moduleOwnsUI", "moduleOwnsTTS",
+        "arbitraryNetwork", "persistence", "screenCapture", "inputInjection",
+        "executableReplay",
+    ]
+
+    private static func strictObject(
+        _ value: Any?,
+        required: Set<String>,
+        optional: Set<String> = []
+    ) throws -> [String: Any] {
+        guard let object = value as? [String: Any],
+              Set(object.keys) == required.union(optional).intersection(Set(object.keys)),
+              required.isSubset(of: Set(object.keys)) else {
+            throw ConversationModuleError.invalidResponse
+        }
+        return object
+    }
+
+    private static func strictArray(
+        _ value: Any?,
+        required: Set<String>
+    ) throws {
+        guard let values = value as? [Any] else {
+            throw ConversationModuleError.invalidResponse
+        }
+        for value in values {
+            _ = try strictObject(value, required: required)
+        }
+    }
+}
+
+protocol ConversationModuleTransport: Sendable {
+    func health(for manifest: ConversationModuleManifest) async throws
+        -> ConversationModuleHealth
+    func perform(
+        _ request: ConversationModuleRequest,
+        manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleResponse
+}
+
+struct ConversationModuleRegistration: Sendable {
+    let manifest: ConversationModuleManifest
+    let transport: any ConversationModuleTransport
+}
+
+enum ConversationModuleAllowlist {
+    static let syntheticManifest = ConversationModuleManifest(
+        contractVersion: ConversationModuleContract.version,
+        moduleID: "firestarter.synthetic.checkpoint",
+        displayName: "Synthetic checkpoint reference",
+        capabilities: [.narration, .checkpoints, .proposedActions],
+        privacy: .hostControlled,
+        provenanceSourceID: "firestarter.operations-floater.synthetic",
+        allowedTranscriptProviders: [.typedKeyboard, .onDevice, .syntheticFixture],
+        allowedWindowBindingIDs: []
+    )
+
+    static let geometryRecorderManifest = ConversationModuleManifest(
+        contractVersion: ConversationModuleContract.version,
+        moduleID: "auggie.verbal-orders.synthetic-geometry-recorder",
+        displayName: "Synthetic geometry recorder",
+        capabilities: [
+            .narration,
+            .normalizedPointerEvents,
+            .navigationKeys,
+            .placeholderEvents,
+            .neutralWindowContext,
+            .checkpoints,
+            .proposedActions,
+        ],
+        privacy: .hostControlled,
+        provenanceSourceID: "auggie.project-verbal-orders.geometry-recorder",
+        allowedTranscriptProviders: [.onDevice, .syntheticFixture],
+        allowedWindowBindingIDs: [
+            "verbal-orders.synthetic.geometry-canvas",
+        ]
+    )
+
+    static func liveRegistrations() -> [ConversationModuleRegistration] {
+        [
+            ConversationModuleRegistration(
+                manifest: syntheticManifest,
+                transport: SyntheticConversationModule()
+            ),
+            ConversationModuleRegistration(
+                manifest: geometryRecorderManifest,
+                transport: LoopbackConversationModuleClient()
+            ),
+        ]
+    }
+}
+
+actor SyntheticConversationModule: ConversationModuleTransport {
+    private static let provenance = ConversationModuleProvenance(
+        sourceID: "firestarter.operations-floater.synthetic",
+        buildDigest: "7e3b6a1b0d4586f3d3b99a8e4b5114ca4f963f1b6ce974cf81682433c73547de"
+    )
+
+    private var activeToken: String?
+    private var nextSequence = 1
+    private var checkpointCount = 0
+
+    func health(for manifest: ConversationModuleManifest) async throws
+        -> ConversationModuleHealth {
+        let health = ConversationModuleHealth(
+            contractVersion: ConversationModuleContract.version,
+            moduleID: manifest.moduleID,
+            state: .ready,
+            privacy: .hostControlled,
+            provenance: Self.provenance
+        )
+        try health.validate(for: manifest)
+        return health
+    }
+
+    func perform(
+        _ request: ConversationModuleRequest,
+        manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleResponse {
+        let snapshot = (activeToken, nextSequence, checkpointCount)
+        do {
+            try request.validate(for: manifest)
+            guard request.provenance == Self.provenance else {
+                throw ConversationModuleError.provenanceMismatch
+            }
+            if let activeToken {
+                guard activeToken == request.floor.token else {
+                    throw ConversationModuleError.floorMismatch
+                }
+            } else {
+                activeToken = request.floor.token
+            }
+            guard request.sequence == nextSequence else {
+                throw ConversationModuleError.sequenceMismatch
+            }
+
+            let response: ConversationModuleResponse
+            switch request.kind {
+            case .turn:
+                checkpointCount += 1
+                response = ConversationModuleResponse(
+                    contractVersion: request.contractVersion,
+                    moduleID: request.moduleID,
+                    requestID: request.requestID,
+                    turnID: request.turnID,
+                    sequence: request.sequence,
+                    floor: request.floor,
+                    state: .checkpointReady,
+                    reply: "Synthetic checkpoint \(checkpointCount) is ready for review.",
+                    statuses: [
+                        ConversationModuleStatus(
+                            code: "checkpoint-ready",
+                            kind: .info,
+                            summary: "A bounded synthetic narration turn was accepted."
+                        ),
+                    ],
+                    checkpoints: [
+                        ConversationModuleCheckpoint(
+                            checkpointID: "checkpoint_\(checkpointCount)",
+                            summary: "Synthetic checkpoint with no captured content.",
+                            confidence: 1
+                        ),
+                    ],
+                    question: nil,
+                    proposedActions: [
+                        ConversationModuleProposedAction(
+                            actionID: "action_review-\(checkpointCount)",
+                            kind: .acknowledgeCheckpoint,
+                            title: "Review synthetic checkpoint",
+                            humanApprovalRequired: true
+                        ),
+                    ],
+                    provenance: Self.provenance
+                )
+            case .revoke, .end:
+                response = ConversationModuleResponse(
+                    contractVersion: request.contractVersion,
+                    moduleID: request.moduleID,
+                    requestID: request.requestID,
+                    turnID: request.turnID,
+                    sequence: request.sequence,
+                    floor: request.floor,
+                    state: .idle,
+                    reply: nil,
+                    statuses: [],
+                    checkpoints: [],
+                    question: nil,
+                    proposedActions: [],
+                    provenance: Self.provenance
+                )
+            }
+            try response.validate(
+                for: request,
+                manifest: manifest,
+                pinnedProvenance: Self.provenance
+            )
+            nextSequence += 1
+            if request.kind != .turn {
+                activeToken = nil
+                nextSequence = 1
+                checkpointCount = 0
+            }
+            return response
+        } catch {
+            activeToken = snapshot.0
+            nextSequence = snapshot.1
+            checkpointCount = snapshot.2
+            throw error
+        }
+    }
+}
+
+struct LoopbackConversationModuleClient: ConversationModuleTransport {
+    private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate,
+        @unchecked Sendable {
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void
+        ) {
+            completionHandler(nil)
+        }
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeSession()
+    }
+
+    func health(for manifest: ConversationModuleManifest) async throws
+        -> ConversationModuleHealth {
+        var request = URLRequest(url: endpoint(for: manifest, action: "health"))
+        request.httpMethod = "GET"
+        request.timeoutInterval = 2
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(
+            ConversationModuleContract.clientIdentifier,
+            forHTTPHeaderField: "X-Client-App"
+        )
+        let (data, response) = try await session.data(for: request)
+        try validateHTTP(response)
+        let health = try ConversationModuleCodec.decodeHealth(data)
+        try health.validate(for: manifest)
+        return health
+    }
+
+    func perform(
+        _ requestValue: ConversationModuleRequest,
+        manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleResponse {
+        try requestValue.validate(for: manifest)
+        var request = URLRequest(url: endpoint(for: manifest, action: "turn"))
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            ConversationModuleContract.clientIdentifier,
+            forHTTPHeaderField: "X-Client-App"
+        )
+        request.httpBody = try ConversationModuleCodec.encodeRequest(requestValue)
+        let (data, response) = try await session.data(for: request)
+        try validateHTTP(response)
+        return try ConversationModuleCodec.decodeResponse(data)
+    }
+
+    private func endpoint(
+        for manifest: ConversationModuleManifest,
+        action: String
+    ) -> URL {
+        ConversationModuleContract.loopbackBaseURL
+            .appendingPathComponent(manifest.moduleID, isDirectory: true)
+            .appendingPathComponent(action)
+    }
+
+    private func validateHTTP(_ response: URLResponse) throws {
+        guard let response = response as? HTTPURLResponse else {
+            throw ConversationModuleError.invalidResponse
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw ConversationModuleError.rejected(response.statusCode)
+        }
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.httpShouldSetCookies = false
+        return URLSession(
+            configuration: configuration,
+            delegate: NoRedirectDelegate(),
+            delegateQueue: nil
+        )
+    }
+}
+
+@MainActor
+final class ConversationModuleHostSession: ObservableObject {
+    @Published private(set) var manifests: [ConversationModuleManifest]
+    @Published var selectedModuleID: String?
+    @Published private(set) var healthByModuleID: [String: ConversationModuleHealth] = [:]
+    @Published private(set) var activeFloor: ConversationFloorGrant?
+    @Published private(set) var activeState: ConversationModuleState = .idle
+    @Published private(set) var lastResponse: ConversationModuleResponse?
+    @Published private(set) var lastError: String?
+    @Published private(set) var isWorking = false
+
+    private let registrations: [String: ConversationModuleRegistration]
+    private let tokenFactory: () -> String
+    private var pinnedProvenance: ConversationModuleProvenance?
+    private var nextSequence = 1
+
+    init(
+        registrations: [ConversationModuleRegistration] =
+            ConversationModuleAllowlist.liveRegistrations(),
+        tokenFactory: @escaping () -> String = {
+            "floor_\(UUID().uuidString.lowercased())"
+        }
+    ) {
+        let sortedManifests = registrations.map(\.manifest).sorted {
+            $0.displayName < $1.displayName
+        }
+        self.registrations = Dictionary(
+            uniqueKeysWithValues: registrations.map { ($0.manifest.moduleID, $0) }
+        )
+        self.tokenFactory = tokenFactory
+        manifests = sortedManifests
+        selectedModuleID = sortedManifests.first?.moduleID
+    }
+
+    var activeManifest: ConversationModuleManifest? {
+        guard let moduleID = activeFloor?.moduleID else { return nil }
+        return registrations[moduleID]?.manifest
+    }
+
+    func refreshHealth(moduleID: String) async {
+        guard let registration = registrations[moduleID] else { return }
+        do {
+            let health = try await registration.transport.health(
+                for: registration.manifest
+            )
+            try health.validate(for: registration.manifest)
+            healthByModuleID[moduleID] = health
+        } catch {
+            healthByModuleID[moduleID] = nil
+        }
+    }
+
+    func grantSelectedFloor() async {
+        do {
+            guard activeFloor == nil else {
+                throw ConversationModuleError.floorAlreadyGranted
+            }
+            guard let moduleID = selectedModuleID,
+                  let registration = registrations[moduleID] else {
+                throw ConversationModuleError.moduleUnavailable
+            }
+            isWorking = true
+            defer { isWorking = false }
+            let health = try await registration.transport.health(
+                for: registration.manifest
+            )
+            try health.validate(for: registration.manifest)
+            guard health.state == .ready else {
+                throw ConversationModuleError.moduleUnavailable
+            }
+            let floor = ConversationFloorGrant(
+                state: .granted,
+                moduleID: moduleID,
+                token: tokenFactory()
+            )
+            try floor.validate(expectedModuleID: moduleID, expectedState: .granted)
+            healthByModuleID[moduleID] = health
+            pinnedProvenance = health.provenance
+            activeFloor = floor
+            activeState = .idle
+            lastResponse = nil
+            lastError = nil
+            nextSequence = 1
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func submit(
+        narration: String,
+        transcriptProvider: ConversationTranscriptProvider,
+        context: ConversationModuleContext,
+        events: [ConversationModuleEvent] = [],
+        window: ConversationModuleWindowContext? = nil
+    ) async throws -> ConversationModuleResponse {
+        guard let floor = activeFloor,
+              let provenance = pinnedProvenance,
+              let registration = registrations[floor.moduleID] else {
+            throw ConversationModuleError.floorMissing
+        }
+        guard narration.count <= ConversationModuleContract.maximumNarrationCharacters else {
+            throw ConversationModuleError.narrationRejected
+        }
+        isWorking = true
+        defer { isWorking = false }
+        let request = ConversationModuleRequest(
+            contractVersion: ConversationModuleContract.version,
+            kind: .turn,
+            moduleID: floor.moduleID,
+            requestID: "request_\(UUID().uuidString.lowercased())",
+            turnID: "turn_\(UUID().uuidString.lowercased())",
+            sequence: nextSequence,
+            floor: floor,
+            transcriptProvider: transcriptProvider,
+            narration: narration,
+            context: context,
+            events: events,
+            window: window,
+            provenance: provenance
+        )
+        try request.validate(for: registration.manifest)
+        do {
+            let response = try await registration.transport.perform(
+                request,
+                manifest: registration.manifest
+            )
+            try response.validate(
+                for: request,
+                manifest: registration.manifest,
+                pinnedProvenance: provenance
+            )
+            guard response.state != .refused else {
+                throw ConversationModuleError.moduleRefused
+            }
+            lastResponse = response
+            activeState = response.state
+            lastError = nil
+            nextSequence += 1
+            return response
+        } catch {
+            let description = error.localizedDescription
+            await closeFloor(kind: .revoke)
+            lastError = description
+            throw error
+        }
+    }
+
+    func revokeFloor() async {
+        await closeFloor(kind: .revoke)
+    }
+
+    func endFloor() async {
+        await closeFloor(kind: .end)
+    }
+
+    private func closeFloor(kind: ConversationModuleRequestKind) async {
+        guard let grantedFloor = activeFloor,
+              let provenance = pinnedProvenance,
+              let registration = registrations[grantedFloor.moduleID] else {
+            clearFloor()
+            return
+        }
+        let revokedFloor = ConversationFloorGrant(
+            state: .revoked,
+            moduleID: grantedFloor.moduleID,
+            token: grantedFloor.token
+        )
+        let request = ConversationModuleRequest(
+            contractVersion: ConversationModuleContract.version,
+            kind: kind,
+            moduleID: grantedFloor.moduleID,
+            requestID: "request_\(UUID().uuidString.lowercased())",
+            turnID: "turn_\(UUID().uuidString.lowercased())",
+            sequence: nextSequence,
+            floor: revokedFloor,
+            transcriptProvider: .typedKeyboard,
+            narration: "",
+            context: .empty,
+            events: [],
+            window: nil,
+            provenance: provenance
+        )
+        do {
+            try request.validate(for: registration.manifest)
+            let response = try await registration.transport.perform(
+                request,
+                manifest: registration.manifest
+            )
+            try response.validate(
+                for: request,
+                manifest: registration.manifest,
+                pinnedProvenance: provenance
+            )
+        } catch {
+            // Revocation is fail-closed locally even when the module is gone.
+        }
+        clearFloor()
+    }
+
+    private func clearFloor() {
+        activeFloor = nil
+        activeState = .idle
+        pinnedProvenance = nil
+        nextSequence = 1
+        lastResponse = nil
+        lastError = nil
+        isWorking = false
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
@@ -1,0 +1,532 @@
+import AVFoundation
+import Combine
+import Foundation
+import Speech
+
+struct ConversationTranscriptResult: Equatable, Sendable {
+    let text: String
+    let isFinal: Bool
+}
+
+enum ConversationVoiceAuthorization: String, Equatable, Sendable {
+    case notDetermined
+    case denied
+    case restricted
+    case authorized
+}
+
+enum ConversationVoiceState: String, Equatable, Sendable {
+    case off
+    case requestingPermission = "requesting-permission"
+    case listening
+    case paused
+    case thinking
+    case responding
+    case unavailable
+
+    var displayName: String {
+        switch self {
+        case .off:
+            "Mic off"
+        case .requestingPermission:
+            "Requesting permission"
+        case .listening:
+            "Listening"
+        case .paused:
+            "Paused"
+        case .thinking:
+            "Thinking"
+        case .responding:
+            "Responding"
+        case .unavailable:
+            "Unavailable"
+        }
+    }
+}
+
+enum ConversationVoiceError: LocalizedError, Equatable {
+    case permissionDenied
+    case recognizerUnavailable
+    case providerMetadataUnavailable
+    case onDeviceRecognitionUnsupported
+    case audioUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .permissionDenied:
+            "Microphone and Speech Recognition permission are required."
+        case .recognizerUnavailable:
+            "On-device Speech Recognition is currently unavailable."
+        case .providerMetadataUnavailable:
+            "The transcription provider was not reported."
+        case .onDeviceRecognitionUnsupported:
+            "This Mac cannot provide on-device recognition for the selected language."
+        case .audioUnavailable:
+            "The microphone audio engine could not start."
+        }
+    }
+}
+
+protocol ConversationTranscriptionEngine: AnyObject, Sendable {
+    var provider: ConversationTranscriptProvider? { get }
+    var supportsOnDeviceRecognition: Bool { get }
+    var isRunning: Bool { get }
+    var resultHandler: (@Sendable (Result<ConversationTranscriptResult, ConversationVoiceError>)
+        -> Void)? { get set }
+
+    func currentAuthorization() -> ConversationVoiceAuthorization
+    func requestAuthorization() async -> ConversationVoiceAuthorization
+    func start() throws
+    func stop()
+}
+
+protocol ConversationSpeechOutput: AnyObject, Sendable {
+    var isSpeaking: Bool { get }
+    var completionHandler: (@Sendable () -> Void)? { get set }
+    func speak(_ text: String)
+    func stop()
+}
+
+final class OnDeviceConversationTranscriber: NSObject, ConversationTranscriptionEngine,
+    @unchecked Sendable {
+    let provider: ConversationTranscriptProvider? = .onDevice
+    var supportsOnDeviceRecognition: Bool {
+        recognizer?.supportsOnDeviceRecognition == true
+    }
+    private(set) var isRunning = false
+    var resultHandler: (@Sendable (Result<ConversationTranscriptResult, ConversationVoiceError>)
+        -> Void)?
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var recognitionGeneration = 0
+
+    init(locale: Locale = Locale(identifier: "en_US")) {
+        recognizer = SFSpeechRecognizer(locale: locale)
+        super.init()
+    }
+
+    func currentAuthorization() -> ConversationVoiceAuthorization {
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        let microphone = AVCaptureDevice.authorizationStatus(for: .audio)
+        if speech == .denied || microphone == .denied {
+            return .denied
+        }
+        if speech == .restricted || microphone == .restricted {
+            return .restricted
+        }
+        if speech == .authorized, microphone == .authorized {
+            return .authorized
+        }
+        return .notDetermined
+    }
+
+    func requestAuthorization() async -> ConversationVoiceAuthorization {
+        let microphoneGranted: Bool
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            microphoneGranted = true
+        case .notDetermined:
+            microphoneGranted = await AVCaptureDevice.requestAccess(for: .audio)
+        case .denied, .restricted:
+            microphoneGranted = false
+        @unknown default:
+            microphoneGranted = false
+        }
+
+        let speechStatus: SFSpeechRecognizerAuthorizationStatus
+        if SFSpeechRecognizer.authorizationStatus() == .notDetermined {
+            speechStatus = await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization {
+                    continuation.resume(returning: $0)
+                }
+            }
+        } else {
+            speechStatus = SFSpeechRecognizer.authorizationStatus()
+        }
+
+        guard microphoneGranted, speechStatus == .authorized else {
+            return speechStatus == .restricted ? .restricted : .denied
+        }
+        return .authorized
+    }
+
+    func start() throws {
+        guard !isRunning else { return }
+        guard currentAuthorization() == .authorized else {
+            throw ConversationVoiceError.permissionDenied
+        }
+        guard let recognizer, recognizer.isAvailable else {
+            throw ConversationVoiceError.recognizerUnavailable
+        }
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw ConversationVoiceError.onDeviceRecognitionUnsupported
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.taskHint = .dictation
+        request.requiresOnDeviceRecognition = true
+        self.request = request
+
+        let input = audioEngine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1_024, format: format) {
+            [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+        } catch {
+            input.removeTap(onBus: 0)
+            self.request = nil
+            throw ConversationVoiceError.audioUnavailable
+        }
+        isRunning = true
+
+        recognitionGeneration += 1
+        let generation = recognitionGeneration
+        recognitionTask = recognizer.recognitionTask(with: request) {
+            [weak self] result, error in
+            guard let self, generation == recognitionGeneration else { return }
+            if let result {
+                let value = ConversationTranscriptResult(
+                    text: result.bestTranscription.formattedString,
+                    isFinal: result.isFinal
+                )
+                resultHandler?(.success(value))
+                if result.isFinal {
+                    teardownAudio()
+                }
+            }
+            if error != nil {
+                teardownAudio()
+                resultHandler?(.failure(.recognizerUnavailable))
+            }
+        }
+    }
+
+    func stop() {
+        recognitionGeneration += 1
+        request?.endAudio()
+        recognitionTask?.cancel()
+        teardownAudio()
+    }
+
+    private func teardownAudio() {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request = nil
+        recognitionTask = nil
+        isRunning = false
+    }
+}
+
+final class LocalConversationSpeechOutput: NSObject, ConversationSpeechOutput,
+    AVSpeechSynthesizerDelegate, @unchecked Sendable {
+    var isSpeaking: Bool { synthesizer.isSpeaking }
+    var completionHandler: (@Sendable () -> Void)?
+
+    private let synthesizer = AVSpeechSynthesizer()
+
+    override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func speak(_ text: String) {
+        stop()
+        let utterance = AVSpeechUtterance(
+            string: String(
+                text.prefix(ConversationModuleContract.maximumReplyCharacters)
+            )
+        )
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        synthesizer.speak(utterance)
+    }
+
+    func stop() {
+        if synthesizer.isSpeaking || synthesizer.isPaused {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+    }
+
+    func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didFinish utterance: AVSpeechUtterance
+    ) {
+        completionHandler?()
+    }
+
+    func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didCancel utterance: AVSpeechUtterance
+    ) {
+        // Cancellation is driven by explicit Stop/Interrupt or reply replacement.
+        // The session owns the next state so a stale utterance cannot restart audio.
+    }
+}
+
+@MainActor
+final class VoiceConversationSession: ObservableObject {
+    static let submissionPause: Duration = .seconds(2)
+
+    @Published private(set) var state: ConversationVoiceState = .off
+    @Published private(set) var authorization: ConversationVoiceAuthorization
+    @Published private(set) var transcriptPreview = ""
+    @Published private(set) var hasPendingSubmission = false
+    @Published var spokenRepliesEnabled = false
+    @Published private(set) var lastError: String?
+
+    var onTranscriptStaged: ((String) -> Void)?
+    var onFinalTranscript: ((String, ConversationTranscriptProvider) -> Void)?
+    var onPendingTranscriptCancelled: (() -> Void)?
+
+    private let engine: any ConversationTranscriptionEngine
+    private let speechOutput: any ConversationSpeechOutput
+    private let debounceSleeper: @Sendable (Duration) async throws -> Void
+    private var conversationActive = false
+    private var startGeneration = 0
+    private var committedSegments: [String] = []
+    private var pendingSubmissionTask: Task<Void, Never>?
+
+    init(
+        engine: any ConversationTranscriptionEngine =
+            OnDeviceConversationTranscriber(),
+        speechOutput: any ConversationSpeechOutput =
+            LocalConversationSpeechOutput(),
+        debounceSleeper: @escaping @Sendable (Duration) async throws -> Void = {
+            try await Task.sleep(for: $0)
+        }
+    ) {
+        self.engine = engine
+        self.speechOutput = speechOutput
+        self.debounceSleeper = debounceSleeper
+        authorization = engine.currentAuthorization()
+        installCallbacks()
+    }
+
+    deinit {
+        pendingSubmissionTask?.cancel()
+        engine.stop()
+        speechOutput.stop()
+    }
+
+    func start() async {
+        startGeneration += 1
+        let generation = startGeneration
+        conversationActive = false
+        speechOutput.stop()
+        lastError = nil
+        state = .requestingPermission
+        let status = await engine.requestAuthorization()
+        guard generation == startGeneration,
+              state == .requestingPermission else {
+            return
+        }
+        authorization = status
+        guard status == .authorized else {
+            fail(.permissionDenied)
+            return
+        }
+        guard let provider = engine.provider else {
+            fail(.providerMetadataUnavailable)
+            return
+        }
+        guard provider == .onDevice || provider == .syntheticFixture else {
+            fail(.providerMetadataUnavailable)
+            return
+        }
+        guard engine.supportsOnDeviceRecognition else {
+            fail(.onDeviceRecognitionUnsupported)
+            return
+        }
+        conversationActive = true
+        startEngine()
+    }
+
+    func pause() {
+        guard conversationActive, state == .listening else { return }
+        cancelPendingSubmission()
+        engine.stop()
+        state = .paused
+    }
+
+    func resume() {
+        guard conversationActive, state == .paused else { return }
+        startEngine()
+    }
+
+    func stop() {
+        startGeneration += 1
+        conversationActive = false
+        cancelPendingSubmission()
+        engine.stop()
+        speechOutput.stop()
+        transcriptPreview = ""
+        lastError = nil
+        state = .off
+    }
+
+    func markThinking() {
+        guard conversationActive else { return }
+        pendingSubmissionTask?.cancel()
+        pendingSubmissionTask = nil
+        hasPendingSubmission = false
+        engine.stop()
+        state = .thinking
+    }
+
+    func cancelPendingSubmission() {
+        let hadPendingContent =
+            pendingSubmissionTask != nil
+            || hasPendingSubmission
+            || !committedSegments.isEmpty
+            || !transcriptPreview.isEmpty
+        pendingSubmissionTask?.cancel()
+        pendingSubmissionTask = nil
+        hasPendingSubmission = false
+        committedSegments = []
+        transcriptPreview = ""
+        if hadPendingContent {
+            onPendingTranscriptCancelled?()
+        }
+    }
+
+    func handleReply(_ text: String) {
+        guard conversationActive else { return }
+        if spokenRepliesEnabled {
+            state = .responding
+            speechOutput.speak(text)
+        } else {
+            transcriptPreview = ""
+            startEngine()
+        }
+    }
+
+    func handleReplyFailure() {
+        guard conversationActive else { return }
+        transcriptPreview = ""
+        startEngine()
+    }
+
+    func interruptSpokenReply() {
+        guard conversationActive, state == .responding else { return }
+        state = .thinking
+        speechOutput.stop()
+        transcriptPreview = ""
+        startEngine()
+    }
+
+    private func installCallbacks() {
+        engine.resultHandler = { [weak self] result in
+            Task { @MainActor [weak self] in
+                self?.apply(result)
+            }
+        }
+        speechOutput.completionHandler = { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.conversationActive,
+                      self.state == .responding else { return }
+                self.transcriptPreview = ""
+                self.startEngine()
+            }
+        }
+    }
+
+    private func startEngine() {
+        do {
+            try engine.start()
+            state = .listening
+            lastError = nil
+        } catch let error as ConversationVoiceError {
+            fail(error)
+        } catch {
+            fail(.audioUnavailable)
+        }
+    }
+
+    private func apply(
+        _ result: Result<ConversationTranscriptResult, ConversationVoiceError>
+    ) {
+        guard conversationActive else { return }
+        switch result {
+        case let .success(transcript):
+            let boundedSegment = String(
+                transcript.text.prefix(
+                    ConversationModuleContract.maximumNarrationCharacters
+                )
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !boundedSegment.isEmpty,
+                  let provider = engine.provider,
+                  provider == .onDevice || provider == .syntheticFixture else {
+                return
+            }
+            pendingSubmissionTask?.cancel()
+            pendingSubmissionTask = nil
+            hasPendingSubmission = false
+
+            if transcript.isFinal {
+                committedSegments.append(boundedSegment)
+            }
+            let stagedText = boundedTranscript(
+                partialSegment: transcript.isFinal ? nil : boundedSegment
+            )
+            transcriptPreview = stagedText
+            onTranscriptStaged?(stagedText)
+
+            guard transcript.isFinal else { return }
+            scheduleSubmission(text: stagedText, provider: provider)
+            startEngine()
+        case let .failure(error):
+            fail(error)
+        }
+    }
+
+    private func boundedTranscript(partialSegment: String?) -> String {
+        let components = committedSegments + [partialSegment].compactMap { $0 }
+        return String(
+            components
+                .joined(separator: " ")
+                .prefix(ConversationModuleContract.maximumNarrationCharacters)
+        )
+    }
+
+    private func scheduleSubmission(
+        text: String,
+        provider: ConversationTranscriptProvider
+    ) {
+        hasPendingSubmission = true
+        pendingSubmissionTask = Task { [weak self, debounceSleeper] in
+            do {
+                try await debounceSleeper(Self.submissionPause)
+                try Task.checkCancellation()
+                guard let self, self.conversationActive else { return }
+                self.pendingSubmissionTask = nil
+                self.hasPendingSubmission = false
+                self.committedSegments = []
+                self.markThinking()
+                self.onFinalTranscript?(text, provider)
+            } catch {
+                // Cancellation is expected whenever speech resumes or control changes.
+            }
+        }
+    }
+
+    private func fail(_ error: ConversationVoiceError) {
+        startGeneration += 1
+        cancelPendingSubmission()
+        engine.stop()
+        conversationActive = false
+        state = .unavailable
+        lastError = error.localizedDescription
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -4,12 +4,76 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct DashboardLaunchConfiguration: Equatable {
+    static let backgroundUITestArgument = "--background-ui-test"
+    static let syntheticConversationUITestArgument =
+        "--synthetic-conversation-ui-test"
+    static let geometryConversationUITestArgument =
+        "--geometry-conversation-ui-test"
+    static let compactUITestArgument = "--compact-ui-test"
+
+    let isBackgroundUITest: Bool
+    let usesSyntheticConversationFixture: Bool
+    let usesGeometryConversationFixture: Bool
+    let usesCompactTestFrame: Bool
+
+    init(arguments: [String] = ProcessInfo.processInfo.arguments) {
+        isBackgroundUITest = arguments.contains(Self.backgroundUITestArgument)
+        usesSyntheticConversationFixture =
+            isBackgroundUITest
+            && arguments.contains(Self.syntheticConversationUITestArgument)
+        usesGeometryConversationFixture =
+            isBackgroundUITest
+            && arguments.contains(Self.geometryConversationUITestArgument)
+        usesCompactTestFrame =
+            isBackgroundUITest
+            && arguments.contains(Self.compactUITestArgument)
+    }
+
+    var initialPinned: Bool { false }
+    var activatesApplication: Bool { !isBackgroundUITest }
+    var foregroundsWindow: Bool { !isBackgroundUITest }
+    var joinsAllSpaces: Bool { !isBackgroundUITest }
+    var usesSavedFrame: Bool { !isBackgroundUITest }
+    var initialWindowSize: CGSize {
+        usesCompactTestFrame
+            ? DashboardLayoutMetrics.minimumWindowSize
+            : DashboardLayoutMetrics.defaultWindowSize
+    }
+    var conversationFixtureModuleID: String? {
+        if usesGeometryConversationFixture {
+            return ConversationModuleAllowlist.geometryRecorderManifest.moduleID
+        }
+        if usesSyntheticConversationFixture {
+            return ConversationModuleAllowlist.syntheticManifest.moduleID
+        }
+        return nil
+    }
+}
+
 @main
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let shared = AppDelegate()
-    private let dashboardState = DashboardState()
-    private lazy var windowController = DashboardWindowController(state: dashboardState)
+    private let launchConfiguration: DashboardLaunchConfiguration
+    private let dashboardState: DashboardState
+    private lazy var windowController = DashboardWindowController(
+        state: dashboardState,
+        activatesApplication: launchConfiguration.activatesApplication,
+        foregroundsWindow: launchConfiguration.foregroundsWindow,
+        joinsAllSpaces: launchConfiguration.joinsAllSpaces,
+        usesSavedFrame: launchConfiguration.usesSavedFrame,
+        initialWindowSize: launchConfiguration.initialWindowSize,
+        conversationFixtureModuleID:
+            launchConfiguration.conversationFixtureModuleID
+    )
+
+    private override init() {
+        let launchConfiguration = DashboardLaunchConfiguration()
+        self.launchConfiguration = launchConfiguration
+        dashboardState = DashboardState(initialPinned: launchConfiguration.initialPinned)
+        super.init()
+    }
 
     static func main() {
         let application = NSApplication.shared
@@ -157,21 +221,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 final class DashboardWindowController {
     static let frameAutosaveName = "OperationsDashboardWindowDenseV1"
 
+    static func collectionBehavior(joinsAllSpaces: Bool) -> NSWindow.CollectionBehavior {
+        joinsAllSpaces
+            ? [.canJoinAllSpaces, .fullScreenAuxiliary]
+            : [.managed]
+    }
+
     private(set) var panel: NSWindow?
     private let state: DashboardState
     private let activatesApplication: Bool
+    private let foregroundsWindow: Bool
+    private let joinsAllSpaces: Bool
+    private let usesSavedFrame: Bool
+    private let initialWindowSize: CGSize
+    private let conversationFixtureModuleID: String?
 
-    init(state: DashboardState, activatesApplication: Bool = true) {
+    init(
+        state: DashboardState,
+        activatesApplication: Bool = true,
+        foregroundsWindow: Bool = true,
+        joinsAllSpaces: Bool = true,
+        usesSavedFrame: Bool = true,
+        initialWindowSize: CGSize = DashboardLayoutMetrics.defaultWindowSize,
+        conversationFixtureModuleID: String? = nil
+    ) {
         self.state = state
         self.activatesApplication = activatesApplication
+        self.foregroundsWindow = foregroundsWindow
+        self.joinsAllSpaces = joinsAllSpaces
+        self.usesSavedFrame = usesSavedFrame
+        self.initialWindowSize = initialWindowSize
+        self.conversationFixtureModuleID = conversationFixtureModuleID
     }
 
     @discardableResult
     func show(_ sender: Any? = nil) -> NSWindow {
         let panel = panel ?? makeDashboardWindow()
         panel.level = state.pinned ? .floating : .normal
-        panel.makeKeyAndOrderFront(sender)
-        panel.orderFrontRegardless()
+        if foregroundsWindow {
+            panel.makeKeyAndOrderFront(sender)
+            panel.orderFrontRegardless()
+        } else {
+            panel.orderFront(sender)
+        }
         if activatesApplication {
             NSApplication.shared.activate(ignoringOtherApps: true)
         }
@@ -186,7 +278,7 @@ final class DashboardWindowController {
         let panel = NSWindow(
             contentRect: NSRect(
                 origin: .zero,
-                size: DashboardLayoutMetrics.defaultWindowSize
+                size: initialWindowSize
             ),
             styleMask: [.titled, .closable, .resizable, .utilityWindow, .fullSizeContentView],
             backing: .buffered,
@@ -197,13 +289,20 @@ final class DashboardWindowController {
         panel.isMovableByWindowBackground = true
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.collectionBehavior = Self.collectionBehavior(joinsAllSpaces: joinsAllSpaces)
         panel.tabbingMode = .disallowed
-        panel.setFrameAutosaveName(Self.frameAutosaveName)
+        if usesSavedFrame {
+            panel.setFrameAutosaveName(Self.frameAutosaveName)
+        }
         panel.level = state.pinned ? .floating : .normal
         panel.minSize = DashboardLayoutMetrics.minimumWindowSize
         panel.center()
-        panel.contentView = NSHostingView(rootView: DashboardView(state: state))
+        panel.contentView = NSHostingView(
+            rootView: DashboardView(
+                state: state,
+                conversationFixtureModuleID: conversationFixtureModuleID
+            )
+        )
         state.onPinnedChange = { [weak panel] isPinned in
             panel?.level = isPinned ? .floating : .normal
         }
@@ -214,7 +313,7 @@ final class DashboardWindowController {
 
 @MainActor
 final class DashboardState: ObservableObject {
-    @Published var pinned = true { didSet { onPinnedChange?(pinned) } }
+    @Published var pinned: Bool { didSet { onPinnedChange?(pinned) } }
     @Published private(set) var snapshot: DashboardSnapshot
     @Published private(set) var sourceDescription: String
     @Published private(set) var canRestorePreviousSnapshot: Bool
@@ -231,7 +330,8 @@ final class DashboardState: ObservableObject {
     }()
     private let store: LocalSnapshotStore
 
-    init(snapshotURL: URL? = nil) {
+    init(snapshotURL: URL? = nil, initialPinned: Bool = false) {
+        pinned = initialPinned
         store = LocalSnapshotStore(snapshotURL: snapshotURL ?? Self.defaultSnapshotURL)
         snapshot = .sample
         sourceDescription = "Generic sample — local only"
@@ -273,10 +373,17 @@ final class DashboardState: ObservableObject {
 
 private struct DashboardView: View {
     @StateObject private var state: DashboardState
-    @StateObject private var chat = RouterChatSession()
+    @StateObject private var chat: RouterChatSession
+    @State private var didPrepareConversationFixture = false
+    private let conversationFixtureModuleID: String?
 
-    init(state: DashboardState) {
+    init(
+        state: DashboardState,
+        conversationFixtureModuleID: String? = nil
+    ) {
         _state = StateObject(wrappedValue: state)
+        _chat = StateObject(wrappedValue: RouterChatSession())
+        self.conversationFixtureModuleID = conversationFixtureModuleID
     }
 
     var body: some View {
@@ -302,6 +409,16 @@ private struct DashboardView: View {
             minHeight: DashboardLayoutMetrics.minimumWindowSize.height
         )
         .background(.regularMaterial)
+        .task {
+            guard let conversationFixtureModuleID,
+                  !didPrepareConversationFixture else {
+                return
+            }
+            didPrepareConversationFixture = true
+            await chat.prepareSyntheticConversationUITest(
+                moduleID: conversationFixtureModuleID
+            )
+        }
         .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
             state.reload()
         }

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import SwiftUI
 
@@ -31,8 +32,6 @@ struct RouterResponder: Equatable, Sendable {
             kind = reportedKind
         } else if let reportedProvider = Self.classify(cleanProvider, includeLocal: true) {
             kind = reportedProvider
-        } else if let reportedModel = Self.classify(cleanModel, includeLocal: false) {
-            kind = reportedModel
         } else if cleanProvider != nil || cleanKind != nil {
             kind = .reportedProvider
         } else {
@@ -52,11 +51,11 @@ struct RouterResponder: Equatable, Sendable {
         case .codex:
             "Codex"
         case .localLLM:
-            "Local LLM"
+            "local-LLM"
         case .reportedProvider:
-            "Router · \(provider ?? "provider reported")"
+            "Provider identity unavailable"
         case .unreported:
-            "Router · provider not reported"
+            "Provider identity unavailable"
         }
     }
 
@@ -81,12 +80,16 @@ struct RouterResponder: Equatable, Sendable {
 
     var helpText: String {
         switch kind {
-        case .unreported:
-            "The Router returned no provider identity. The dashboard will not guess who answered."
+        case .reportedProvider, .unreported:
+            "The Router did not return a closed Claude, Codex, or local-LLM identity."
         default:
             modelDetail.map { "\(displayName) reported model \($0)." }
                 ?? "\(displayName) was reported by the Router."
         }
+    }
+
+    var hasClosedProviderIdentity: Bool {
+        kind == .claude || kind == .codex || kind == .localLLM
     }
 
     private static func boundedSingleLine(_ value: String?) -> String? {
@@ -129,18 +132,29 @@ struct RouterChatMessage: Identifiable, Equatable, Sendable {
     let role: Role
     let text: String
     let responder: RouterResponder?
+    let module: ConversationModuleAttribution?
+    let isPendingVoice: Bool
 
     init(
         id: UUID = UUID(),
         role: Role,
         text: String,
-        responder: RouterResponder? = nil
+        responder: RouterResponder? = nil,
+        module: ConversationModuleAttribution? = nil,
+        isPendingVoice: Bool = false
     ) {
         self.id = id
         self.role = role
         self.text = text
         self.responder = responder
+        self.module = module
+        self.isPendingVoice = isPendingVoice
     }
+}
+
+struct ConversationModuleAttribution: Equatable, Sendable {
+    let moduleID: String
+    let displayName: String
 }
 
 struct RouterChatReply: Equatable, Sendable {
@@ -192,6 +206,7 @@ struct RouterChatClient: RouterChatTransport {
         case invalidResponse
         case emptyResponse
         case responseTooLarge
+        case providerIdentityUnavailable
         case rejected(Int)
 
         var errorDescription: String? {
@@ -202,6 +217,8 @@ struct RouterChatClient: RouterChatTransport {
                 "The local AI Router returned no assistant message."
             case .responseTooLarge:
                 "The local AI Router response exceeded the safety limit."
+            case .providerIdentityUnavailable:
+                "The Router did not report a closed Claude, Codex, or local-LLM identity."
             case let .rejected(status):
                 "The local AI Router declined the request (HTTP \(status))."
             }
@@ -379,6 +396,9 @@ struct RouterChatClient: RouterChatTransport {
             provider: envelope.responder?.provider ?? envelope.provider,
             model: envelope.responder?.model ?? envelope.model
         )
+        guard responder.hasClosedProviderIdentity else {
+            throw ClientError.providerIdentityUnavailable
+        }
         return RouterChatReply(
             text: text,
             model: responder.model,
@@ -535,18 +555,40 @@ final class RouterChatSession: ObservableObject {
     @Published private(set) var critiques: [UUID: RouterChatCritique] = [:]
     @Published private(set) var reviewingMessageIDs: Set<UUID> = []
 
+    let modules: ConversationModuleHostSession
+    var onAssistantReply: ((String) -> Void)?
+    var onAssistantFailure: (() -> Void)?
+    var onConversationControlChanged: (() -> Void)?
+
     private let transport: any RouterChatTransport
     private var sendTask: Task<Void, Never>?
     private var reviewTasks: [UUID: Task<Void, Never>] = [:]
+    private var moduleObservation: AnyCancellable?
+    private var moduleContextFloorToken: String?
+    private var moduleContextTurns: [ConversationModuleContextTurn] = []
+    private var pendingVoiceMessageID: UUID?
 
-    init(transport: any RouterChatTransport = RouterChatClient()) {
+    init(
+        transport: any RouterChatTransport = RouterChatClient(),
+        modules: ConversationModuleHostSession = ConversationModuleHostSession()
+    ) {
         self.transport = transport
+        self.modules = modules
+        moduleObservation = modules.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
     }
 
     var canSend: Bool {
         isEnabled
             && !isSending
+            && composerAcceptsTypedInput
             && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var composerAcceptsTypedInput: Bool {
+        guard let manifest = modules.activeManifest else { return true }
+        return manifest.allowedTranscriptProviders.contains(.typedKeyboard)
     }
 
     func enable() async {
@@ -556,8 +598,12 @@ final class RouterChatSession: ObservableObject {
     }
 
     func disable() {
+        onConversationControlChanged?()
         isEnabled = false
         automaticReviewEnabled = false
+        Task {
+            await revokeModuleFloor()
+        }
         clear()
         availability = .disabled
         modelLabel = "auto"
@@ -577,25 +623,166 @@ final class RouterChatSession: ObservableObject {
         availability = routerIsAvailable ? .online : .offline
     }
 
+    func prepareSyntheticConversationUITest(moduleID: String) async {
+        guard !isEnabled else { return }
+        isEnabled = true
+        availability = .offline
+        guard modules.manifests.contains(where: { $0.moduleID == moduleID }) else {
+            return
+        }
+        modules.selectedModuleID = moduleID
+        await modules.grantSelectedFloor()
+        guard modules.activeFloor != nil else { return }
+        send(
+            text: moduleID
+                == ConversationModuleAllowlist.geometryRecorderManifest.moduleID
+                ? "Synthetic geometry narration"
+                : "Synthetic conversation fixture",
+            transcriptProvider: .syntheticFixture
+        )
+        for _ in 0..<100 where isSending {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     func send() {
         guard canSend else { return }
+        discardPendingVoiceTranscript()
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        send(text: text, transcriptProvider: .typedKeyboard)
+    }
+
+    func stageVoiceTranscript(_ rawText: String) {
+        guard isEnabled else { return }
         let text = String(
-            draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            rawText
+                .trimmingCharacters(in: .whitespacesAndNewlines)
                 .prefix(Self.maximumMessageCharacters)
         )
-        let userMessage = RouterChatMessage(role: .user, text: text)
-        messages.append(userMessage)
+        guard !text.isEmpty else {
+            discardPendingVoiceTranscript()
+            return
+        }
+        if let messageID = pendingVoiceMessageID,
+           let index = messages.firstIndex(where: { $0.id == messageID }) {
+            messages[index] = RouterChatMessage(
+                id: messageID,
+                role: .user,
+                text: text,
+                isPendingVoice: true
+            )
+        } else {
+            let message = RouterChatMessage(
+                role: .user,
+                text: text,
+                isPendingVoice: true
+            )
+            pendingVoiceMessageID = message.id
+            messages.append(message)
+        }
+    }
+
+    func discardPendingVoiceTranscript() {
+        guard let messageID = pendingVoiceMessageID else { return }
+        messages.removeAll { $0.id == messageID }
+        pendingVoiceMessageID = nil
+    }
+
+    func send(
+        text rawText: String,
+        transcriptProvider: ConversationTranscriptProvider
+    ) {
+        guard isEnabled, !isSending else { return }
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= Self.maximumMessageCharacters else {
+            lastError = "The message is empty or exceeds the 4,000-character limit."
+            onAssistantFailure?()
+            return
+        }
+        let text = trimmed
+        if transcriptProvider != .typedKeyboard,
+           let messageID = pendingVoiceMessageID,
+           let index = messages.firstIndex(where: { $0.id == messageID }) {
+            messages[index] = RouterChatMessage(
+                id: messageID,
+                role: .user,
+                text: text,
+                isPendingVoice: false
+            )
+            pendingVoiceMessageID = nil
+        } else {
+            messages.append(RouterChatMessage(role: .user, text: text))
+        }
         draft = ""
         lastError = nil
         isSending = true
 
-        let context = Self.boundedContext(messages)
         sendTask?.cancel()
+        if modules.activeFloor != nil {
+            sendTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let floorToken = modules.activeFloor?.token
+                    if moduleContextFloorToken != floorToken {
+                        moduleContextFloorToken = floorToken
+                        moduleContextTurns = []
+                    }
+                    let fixture = Self.syntheticFixtureInput(
+                        for: modules.activeManifest
+                    )
+                    let reply = try await modules.submit(
+                        narration: text,
+                        transcriptProvider: transcriptProvider,
+                        context: Self.boundedModuleContext(moduleContextTurns),
+                        events: fixture.events,
+                        window: fixture.window
+                    )
+                    try Task.checkCancellation()
+                    let responseText = Self.moduleResponseText(reply)
+                    if !responseText.isEmpty,
+                       let manifest = modules.activeManifest {
+                        recordModuleContext(
+                            userText: text,
+                            moduleText: responseText
+                        )
+                        messages.append(
+                            RouterChatMessage(
+                                role: .assistant,
+                                text: responseText,
+                                module: ConversationModuleAttribution(
+                                    moduleID: manifest.moduleID,
+                                    displayName: manifest.displayName
+                                )
+                            )
+                        )
+                        onAssistantReply?(responseText)
+                    } else {
+                        onAssistantFailure?()
+                    }
+                    isSending = false
+                } catch is CancellationError {
+                    return
+                } catch {
+                    onConversationControlChanged?()
+                    discardPendingVoiceTranscript()
+                    clearModuleContext()
+                    lastError = error.localizedDescription
+                    isSending = false
+                    onAssistantFailure?()
+                }
+            }
+            return
+        }
+
+        let context = Self.boundedContext(messages)
         sendTask = Task { [weak self] in
             guard let self else { return }
             do {
                 let reply = try await transport.complete(messages: context)
                 try Task.checkCancellation()
+                guard reply.responder.hasClosedProviderIdentity else {
+                    throw RouterChatClient.ClientError.providerIdentityUnavailable
+                }
                 let assistantMessage = RouterChatMessage(
                     role: .assistant,
                     text: reply.text,
@@ -605,6 +792,7 @@ final class RouterChatSession: ObservableObject {
                 modelLabel = reply.model
                 availability = .online
                 isSending = false
+                onAssistantReply?(reply.text)
                 if automaticReviewEnabled {
                     review(
                         messageID: assistantMessage.id,
@@ -615,14 +803,18 @@ final class RouterChatSession: ObservableObject {
             } catch is CancellationError {
                 return
             } catch {
-                availability = .offline
                 if let clientError = error as? RouterChatClient.ClientError {
+                    availability = clientError == .providerIdentityUnavailable
+                        ? .online
+                        : .offline
                     lastError = clientError.localizedDescription
                 } else {
+                    availability = .offline
                     lastError =
                         "The assistant request failed. Check that the local AI Router is running."
                 }
                 isSending = false
+                onAssistantFailure?()
             }
         }
     }
@@ -642,6 +834,7 @@ final class RouterChatSession: ObservableObject {
     }
 
     func clear() {
+        onConversationControlChanged?()
         sendTask?.cancel()
         sendTask = nil
         reviewTasks.values.forEach { $0.cancel() }
@@ -652,6 +845,26 @@ final class RouterChatSession: ObservableObject {
         draft = ""
         lastError = nil
         isSending = false
+        clearModuleContext()
+        pendingVoiceMessageID = nil
+    }
+
+    func revokeModuleFloor() async {
+        onConversationControlChanged?()
+        discardPendingVoiceTranscript()
+        clearModuleContext()
+        await modules.revokeFloor()
+    }
+
+    func selectConversationTarget(_ moduleID: String?) {
+        guard modules.activeFloor == nil,
+              modules.selectedModuleID != moduleID else {
+            return
+        }
+        onConversationControlChanged?()
+        discardPendingVoiceTranscript()
+        clearModuleContext()
+        modules.selectedModuleID = moduleID
     }
 
     private func review(
@@ -687,6 +900,7 @@ final class RouterChatSession: ObservableObject {
         var selected: [RouterChatMessage] = []
 
         for message in messages.suffix(maximumContextMessages).reversed() {
+            guard !message.isPendingVoice else { continue }
             guard remaining > 0 else { break }
             let text = String(message.text.suffix(min(message.text.count, remaining)))
             selected.append(
@@ -694,18 +908,109 @@ final class RouterChatSession: ObservableObject {
                     id: message.id,
                     role: message.role,
                     text: text,
-                    responder: message.responder
+                    responder: message.responder,
+                    module: nil,
+                    isPendingVoice: false
                 )
             )
             remaining -= text.count
         }
         return selected.reversed()
     }
+
+    static func boundedModuleContext(
+        _ turns: [ConversationModuleContextTurn]
+    ) -> ConversationModuleContext {
+        var remaining = ConversationModuleContract.maximumContextCharacters
+        var selected: [ConversationModuleContextTurn] = []
+        for turn in turns
+            .suffix(ConversationModuleContract.maximumContextTurns)
+            .reversed() {
+            guard remaining > 0 else { break }
+            let text = String(turn.text.suffix(min(turn.text.count, min(1_000, remaining))))
+            selected.append(
+                ConversationModuleContextTurn(
+                    role: turn.role,
+                    text: text
+                )
+            )
+            remaining -= text.count
+        }
+        return ConversationModuleContext(turns: selected.reversed())
+    }
+
+    private func recordModuleContext(userText: String, moduleText: String) {
+        moduleContextTurns.append(
+            ConversationModuleContextTurn(
+                role: .user,
+                text: String(userText.prefix(1_000))
+            )
+        )
+        moduleContextTurns.append(
+            ConversationModuleContextTurn(
+                role: .module,
+                text: String(moduleText.prefix(1_000))
+            )
+        )
+        moduleContextTurns = Array(
+            moduleContextTurns.suffix(ConversationModuleContract.maximumContextTurns)
+        )
+    }
+
+    private func clearModuleContext() {
+        moduleContextFloorToken = nil
+        moduleContextTurns = []
+    }
+
+    static func moduleResponseText(_ response: ConversationModuleResponse) -> String {
+        [response.reply, response.question]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+    }
+
+    static func syntheticFixtureInput(
+        for manifest: ConversationModuleManifest?
+    ) -> (
+        events: [ConversationModuleEvent],
+        window: ConversationModuleWindowContext?
+    ) {
+        guard manifest?.moduleID
+                == ConversationModuleAllowlist.geometryRecorderManifest.moduleID else {
+            return ([], nil)
+        }
+        return (
+            [
+                ConversationModuleEvent(
+                    eventID: "event_synthetic-canvas-1",
+                    sequence: 1,
+                    kind: .placeholder,
+                    pointerPhase: nil,
+                    normalizedX: nil,
+                    normalizedY: nil,
+                    navigationKey: nil,
+                    placeholder: .canvasRegion
+                ),
+            ],
+            ConversationModuleWindowContext(
+                bindingID: "verbal-orders.synthetic.geometry-canvas",
+                width: 1_280,
+                height: 720
+            )
+        )
+    }
 }
 
 struct RouterChatPanel: View {
     @ObservedObject var session: RouterChatSession
+    @StateObject private var voice: VoiceConversationSession
     let metrics: DashboardLayoutMetrics
+
+    init(session: RouterChatSession, metrics: DashboardLayoutMetrics) {
+        _session = ObservedObject(wrappedValue: session)
+        _voice = StateObject(wrappedValue: VoiceConversationSession())
+        self.metrics = metrics
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -722,6 +1027,7 @@ struct RouterChatPanel: View {
                         .font(.caption2)
                         .help("When enabled, the Router reviews each assistant reply.")
                     Button("Disable") {
+                        voice.stop()
                         session.disable()
                     }
                     .buttonStyle(.plain)
@@ -738,6 +1044,10 @@ struct RouterChatPanel: View {
                 }
                 if session.isEnabled, !session.messages.isEmpty {
                     Button("Clear") {
+                        voice.stop()
+                        Task {
+                            await session.revokeModuleFloor()
+                        }
                         session.clear()
                     }
                     .buttonStyle(.plain)
@@ -757,6 +1067,39 @@ struct RouterChatPanel: View {
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 11))
         .clipShape(RoundedRectangle(cornerRadius: 11))
+        .onAppear {
+            voice.onTranscriptStaged = { [weak session] text in
+                session?.stageVoiceTranscript(text)
+            }
+            voice.onFinalTranscript = { [weak session] text, provider in
+                session?.send(text: text, transcriptProvider: provider)
+            }
+            voice.onPendingTranscriptCancelled = { [weak session] in
+                session?.discardPendingVoiceTranscript()
+            }
+            session.onConversationControlChanged = { [weak voice] in
+                voice?.cancelPendingSubmission()
+            }
+            session.onAssistantReply = { [weak voice] text in
+                voice?.handleReply(text)
+            }
+            session.onAssistantFailure = { [weak voice] in
+                voice?.handleReplyFailure()
+            }
+        }
+        .onExitCommand {
+            guard session.modules.activeFloor != nil else { return }
+            voice.cancelPendingSubmission()
+            Task {
+                await session.revokeModuleFloor()
+            }
+        }
+        .onDisappear {
+            voice.stop()
+            Task {
+                await session.revokeModuleFloor()
+            }
+        }
     }
 
     private var disabledChat: some View {
@@ -780,6 +1123,8 @@ struct RouterChatPanel: View {
 
     private var enabledChat: some View {
         VStack(alignment: .leading, spacing: 9) {
+            moduleControls
+            voiceControls
             chatHistory
 
             if let error = session.lastError {
@@ -808,13 +1153,17 @@ struct RouterChatPanel: View {
                         .padding(.vertical, 1)
                         .accessibilityLabel("Assistant message")
                         .accessibilityHint(
-                            "Return sends. Shift-Return inserts a new line."
+                            session.composerAcceptsTypedInput
+                                ? "Return sends. Shift-Return inserts a new line."
+                                : "This module accepts only on-device voice narration."
                         )
+                        .disabled(!session.composerAcceptsTypedInput)
                         .onKeyPress(.return, phases: .down) { keyPress in
                             switch RouterChatComposerReturnAction.resolve(
                                 isShiftPressed: keyPress.modifiers.contains(.shift)
                             ) {
                             case .send:
+                                voice.cancelPendingSubmission()
                                 session.send()
                                 return .handled
                             case .insertNewline:
@@ -830,6 +1179,7 @@ struct RouterChatPanel: View {
                 }
 
                 Button {
+                    voice.cancelPendingSubmission()
                     session.send()
                 } label: {
                     if session.isSending {
@@ -850,9 +1200,24 @@ struct RouterChatPanel: View {
                 .font(.system(size: 9))
                 .foregroundStyle(.tertiary)
 
+            if !session.composerAcceptsTypedInput {
+                Text(
+                    "This recorder accepts on-device voice only. Return to the dashboard "
+                        + "to type, or use the synthetic checkpoint module for typed testing."
+                )
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(.orange)
+            }
+
+            if voice.hasPendingSubmission {
+                Text("Voice turn staged · sends after 2.000 seconds of continuous pause")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
             Text(
-                "Fixed loopback Router · Router selects the model · "
-                    + "this app does not store chat or reviews"
+                "Fixed loopback only · Router selects its model · modules are statically "
+                    + "allowlisted · this app does not store chat, voice, or reviews"
             )
             .font(.system(size: 9))
             .foregroundStyle(.tertiary)
@@ -865,6 +1230,197 @@ struct RouterChatPanel: View {
             .foregroundStyle(.orange)
         }
         .padding(metrics.recordPadding)
+    }
+
+    private var moduleControls: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 7) {
+                Label("Conversation floor", systemImage: "square.stack.3d.up")
+                    .font(.caption2.weight(.semibold))
+                Picker(
+                    "Conversation target",
+                    selection: Binding(
+                        get: { session.modules.selectedModuleID },
+                        set: { session.selectConversationTarget($0) }
+                    )
+                ) {
+                    Text("Dashboard assistant").tag(nil as String?)
+                    ForEach(session.modules.manifests) { manifest in
+                        Text(manifest.displayName).tag(manifest.moduleID as String?)
+                    }
+                }
+                .labelsHidden()
+                .controlSize(.mini)
+                .disabled(session.modules.activeFloor != nil)
+
+                if session.modules.activeFloor == nil {
+                    Button("Give floor") {
+                        Task {
+                            await session.modules.grantSelectedFloor()
+                        }
+                    }
+                    .controlSize(.mini)
+                    .disabled(
+                        session.modules.selectedModuleID == nil
+                            || session.modules.isWorking
+                    )
+                } else {
+                    Button("Return to dashboard") {
+                        voice.cancelPendingSubmission()
+                        Task {
+                            await session.revokeModuleFloor()
+                        }
+                    }
+                    .controlSize(.mini)
+                    .keyboardShortcut(.escape, modifiers: [])
+                }
+            }
+
+            if let manifest = session.modules.activeManifest {
+                HStack(spacing: 5) {
+                    Label(manifest.displayName, systemImage: "checkmark.shield")
+                        .font(.caption2.weight(.semibold))
+                    Text("HAS FLOOR")
+                        .font(.system(size: 8, weight: .bold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.14), in: Capsule())
+                    Text("Ephemeral · host mic/UI/TTS · no capture, replay, or persistence")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                }
+                .help(
+                    "Escape returns control to the dashboard. The module receives only "
+                        + "its allowlisted bounded contract fields."
+                )
+            }
+
+            if let response = session.modules.lastResponse {
+                moduleResult(response)
+            }
+            if let error = session.modules.lastError {
+                Label(error, systemImage: "xmark.shield")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(7)
+        .background(.background.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func moduleResult(_ response: ConversationModuleResponse) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(response.state.rawValue.uppercased())
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(.secondary)
+            ForEach(response.statuses, id: \.code) { status in
+                Text(status.summary)
+                    .font(.caption2)
+            }
+            ForEach(response.checkpoints, id: \.checkpointID) { checkpoint in
+                Text("Checkpoint: \(checkpoint.summary)")
+                    .font(.caption2)
+            }
+            ForEach(response.proposedActions, id: \.actionID) { action in
+                Label(
+                    "\(action.title) · separate approval required",
+                    systemImage: "hand.raised.fill"
+                )
+                .font(.caption2)
+                .foregroundStyle(.orange)
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var voiceControls: some View {
+        HStack(spacing: 7) {
+            Label(voice.state.displayName, systemImage: voiceSystemImage)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(voice.state == .unavailable ? .orange : .secondary)
+                .accessibilityLabel("Voice conversation status: \(voice.state.displayName)")
+
+            switch voice.state {
+            case .off, .unavailable:
+                Button("Start voice") {
+                    Task {
+                        await voice.start()
+                    }
+                }
+                .controlSize(.mini)
+            case .listening:
+                Button("Pause") {
+                    voice.pause()
+                }
+                .controlSize(.mini)
+                Button("Stop") {
+                    voice.stop()
+                }
+                .controlSize(.mini)
+            case .paused:
+                Button("Resume") {
+                    voice.resume()
+                }
+                .controlSize(.mini)
+                Button("Stop") {
+                    voice.stop()
+                }
+                .controlSize(.mini)
+            case .responding:
+                Button("Interrupt") {
+                    voice.interruptSpokenReply()
+                }
+                .controlSize(.mini)
+                Button("Stop") {
+                    voice.stop()
+                }
+                .controlSize(.mini)
+            case .requestingPermission, .thinking:
+                Button("Stop") {
+                    voice.stop()
+                }
+                .controlSize(.mini)
+            }
+
+            Toggle("Speak replies", isOn: $voice.spokenRepliesEnabled)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .font(.caption2)
+                .help("Off by default. Uses the Mac's local speech synthesizer.")
+
+            if !voice.transcriptPreview.isEmpty {
+                Text(voice.transcriptPreview)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if let error = voice.lastError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var voiceSystemImage: String {
+        switch voice.state {
+        case .off:
+            "mic.slash"
+        case .requestingPermission:
+            "lock.shield"
+        case .listening:
+            "waveform"
+        case .paused:
+            "pause.circle"
+        case .thinking:
+            "ellipsis.bubble"
+        case .responding:
+            "speaker.wave.2"
+        case .unavailable:
+            "exclamationmark.mic"
+        }
     }
 
     private var chatHistory: some View {
@@ -910,13 +1466,29 @@ struct RouterChatPanel: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 7) {
                     if message.role == .user {
-                        Text("You")
+                        Text(
+                            message.isPendingVoice
+                                ? "You · waiting for 2s pause"
+                                : "You"
+                        )
                             .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(
+                                message.isPendingVoice ? Color.orange : Color.secondary
+                            )
                     } else {
-                        responderLabel(message.responder ?? RouterResponder())
+                        if let module = message.module {
+                            Label(module.displayName, systemImage: "square.stack.3d.up.fill")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .help("Conversation module \(module.moduleID)")
+                                .accessibilityLabel(
+                                    "Response from module \(module.displayName)"
+                                )
+                        } else {
+                            responderLabel(message.responder ?? RouterResponder())
+                        }
                     }
-                    if message.role == .assistant {
+                    if message.role == .assistant, message.module == nil {
                         reviewControl(message)
                     }
                 }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationModuleTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationModuleTests.swift
@@ -1,0 +1,456 @@
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Conversation module contract")
+struct ConversationModuleTests {
+    private let floor = ConversationFloorGrant(
+        state: .granted,
+        moduleID: ConversationModuleAllowlist.syntheticManifest.moduleID,
+        token: "floor_00000000-0000-0000-0000-000000000001"
+    )
+    private let provenance = ConversationModuleProvenance(
+        sourceID: "firestarter.operations-floater.synthetic",
+        buildDigest: "7e3b6a1b0d4586f3d3b99a8e4b5114ca4f963f1b6ce974cf81682433c73547de"
+    )
+
+    @Test("The static allowlist accepts only host-controlled privacy")
+    func allowlistPrivacy() throws {
+        try ConversationModuleAllowlist.syntheticManifest.validate()
+        try ConversationModuleAllowlist.geometryRecorderManifest.validate()
+
+        for manifest in [
+            ConversationModuleAllowlist.syntheticManifest,
+            ConversationModuleAllowlist.geometryRecorderManifest,
+        ] {
+            #expect(manifest.privacy == .hostControlled)
+            #expect(manifest.privacy.ephemeralOnly)
+            #expect(!manifest.privacy.moduleOwnsMicrophone)
+            #expect(!manifest.privacy.moduleOwnsUI)
+            #expect(!manifest.privacy.moduleOwnsTTS)
+            #expect(!manifest.privacy.arbitraryNetwork)
+            #expect(!manifest.privacy.persistence)
+            #expect(!manifest.privacy.screenCapture)
+            #expect(!manifest.privacy.inputInjection)
+            #expect(!manifest.privacy.executableReplay)
+        }
+    }
+
+    @Test("A module cannot request microphone, UI, network, persistence, capture, or replay")
+    func forbiddenPrivacyCapabilityFailsClosed() {
+        let rejected = ConversationModuleManifest(
+            contractVersion: ConversationModuleContract.version,
+            moduleID: "firestarter.synthetic.rejected",
+            displayName: "Rejected synthetic module",
+            capabilities: [.narration],
+            privacy: ConversationModulePrivacy(
+                ephemeralOnly: true,
+                moduleOwnsMicrophone: true,
+                moduleOwnsUI: false,
+                moduleOwnsTTS: false,
+                arbitraryNetwork: false,
+                persistence: false,
+                screenCapture: false,
+                inputInjection: false,
+                executableReplay: false
+            ),
+            provenanceSourceID: "firestarter.synthetic.rejected",
+            allowedTranscriptProviders: [.syntheticFixture],
+            allowedWindowBindingIDs: []
+        )
+
+        #expect(throws: ConversationModuleError.privacyContractRejected) {
+            try rejected.validate()
+        }
+    }
+
+    @Test("Pointer and window context are bounded and capability-gated")
+    func boundedEventsAndWindow() throws {
+        let event = ConversationModuleEvent(
+            eventID: "event_pointer-1",
+            sequence: 1,
+            kind: .normalizedPointer,
+            pointerPhase: .move,
+            normalizedX: 0.25,
+            normalizedY: 0.75,
+            navigationKey: nil,
+            placeholder: nil
+        )
+        let validRequest = request(
+            manifest: ConversationModuleAllowlist.geometryRecorderManifest,
+            floor: ConversationFloorGrant(
+                state: .granted,
+                moduleID: ConversationModuleAllowlist.geometryRecorderManifest.moduleID,
+                token: floor.token
+            ),
+            provenance: ConversationModuleProvenance(
+                sourceID: "auggie.project-verbal-orders.geometry-recorder",
+                buildDigest: provenance.buildDigest
+            ),
+            events: [event],
+            window: ConversationModuleWindowContext(
+                bindingID: "verbal-orders.synthetic.geometry-canvas",
+                width: 1280,
+                height: 720
+            )
+        )
+
+        try validRequest.validate(
+            for: ConversationModuleAllowlist.geometryRecorderManifest
+        )
+
+        let drifted = request(
+            manifest: ConversationModuleAllowlist.geometryRecorderManifest,
+            floor: validRequest.floor,
+            provenance: validRequest.provenance,
+            events: [event],
+            window: ConversationModuleWindowContext(
+                bindingID: "private.unallowlisted.window",
+                width: 1280,
+                height: 720
+            )
+        )
+        #expect(throws: ConversationModuleError.windowBindingRejected) {
+            try drifted.validate(
+                for: ConversationModuleAllowlist.geometryRecorderManifest
+            )
+        }
+    }
+
+    @Test("Event sequences are contiguous and Escape is reserved to the host")
+    func eventSequenceAndEscapePolicy() {
+        let keys = ConversationNavigationKey.allCasesForTests
+        #expect(!keys.map(\.rawValue).contains("escape"))
+
+        let event = ConversationModuleEvent(
+            eventID: "event_key-2",
+            sequence: 2,
+            kind: .navigationKey,
+            pointerPhase: nil,
+            normalizedX: nil,
+            normalizedY: nil,
+            navigationKey: .tab,
+            placeholder: nil
+        )
+        let request = request(
+            manifest: ConversationModuleAllowlist.geometryRecorderManifest,
+            floor: ConversationFloorGrant(
+                state: .granted,
+                moduleID: ConversationModuleAllowlist.geometryRecorderManifest.moduleID,
+                token: floor.token
+            ),
+            provenance: ConversationModuleProvenance(
+                sourceID: "auggie.project-verbal-orders.geometry-recorder",
+                buildDigest: provenance.buildDigest
+            ),
+            events: [event]
+        )
+
+        #expect(throws: ConversationModuleError.sequenceMismatch) {
+            try request.validate(
+                for: ConversationModuleAllowlist.geometryRecorderManifest
+            )
+        }
+    }
+
+    @Test("Every proposed module action remains separately human-approved")
+    func actionsRequireHumanApproval() {
+        let action = ConversationModuleProposedAction(
+            actionID: "action_replay-1",
+            kind: .reviewReplayProposal,
+            title: "Review replay proposal",
+            humanApprovalRequired: false
+        )
+
+        #expect(throws: ConversationModuleError.invalidResponse) {
+            try action.validate()
+        }
+    }
+
+    @Test("Revoke and end control envelopes do not need a transcript provider")
+    func controlEnvelopeProviderIsExempt() throws {
+        let manifest = ConversationModuleAllowlist.geometryRecorderManifest
+        let controlRequest = ConversationModuleRequest(
+            contractVersion: ConversationModuleContract.version,
+            kind: .revoke,
+            moduleID: manifest.moduleID,
+            requestID: "request_00000000-0000-0000-0000-000000000010",
+            turnID: "turn_00000000-0000-0000-0000-000000000010",
+            sequence: 2,
+            floor: ConversationFloorGrant(
+                state: .revoked,
+                moduleID: manifest.moduleID,
+                token: floor.token
+            ),
+            transcriptProvider: .typedKeyboard,
+            narration: "",
+            context: .empty,
+            events: [],
+            window: nil,
+            provenance: ConversationModuleProvenance(
+                sourceID: manifest.provenanceSourceID,
+                buildDigest: provenance.buildDigest
+            )
+        )
+
+        try controlRequest.validate(for: manifest)
+    }
+
+    @Test("Geometry demo input is a neutral allowlisted synthetic fixture")
+    @MainActor
+    func geometryFixtureIsClosedAndValid() throws {
+        let manifest = ConversationModuleAllowlist.geometryRecorderManifest
+        let fixture = RouterChatSession.syntheticFixtureInput(for: manifest)
+        let geometryRequest = ConversationModuleRequest(
+            contractVersion: ConversationModuleContract.version,
+            kind: .turn,
+            moduleID: manifest.moduleID,
+            requestID: "request_00000000-0000-0000-0000-000000000011",
+            turnID: "turn_00000000-0000-0000-0000-000000000011",
+            sequence: 1,
+            floor: ConversationFloorGrant(
+                state: .granted,
+                moduleID: manifest.moduleID,
+                token: floor.token
+            ),
+            transcriptProvider: .syntheticFixture,
+            narration: "Synthetic geometry narration",
+            context: .empty,
+            events: fixture.events,
+            window: fixture.window,
+            provenance: ConversationModuleProvenance(
+                sourceID: manifest.provenanceSourceID,
+                buildDigest: provenance.buildDigest
+            )
+        )
+
+        try geometryRequest.validate(for: manifest)
+        #expect(fixture.events.count == 1)
+        #expect(fixture.events.first?.placeholder == .canvasRegion)
+        #expect(fixture.window?.bindingID == "verbal-orders.synthetic.geometry-canvas")
+    }
+
+    @Test("Unknown response and nested health fields fail closed")
+    func strictUnknownFields() throws {
+        let health = ConversationModuleHealth(
+            contractVersion: ConversationModuleContract.version,
+            moduleID: ConversationModuleAllowlist.syntheticManifest.moduleID,
+            state: .ready,
+            privacy: .hostControlled,
+            provenance: provenance
+        )
+        let encoder = JSONEncoder()
+        let healthObject = try #require(
+            JSONSerialization.jsonObject(with: encoder.encode(health))
+                as? [String: Any]
+        )
+        var healthWithUnknown = healthObject
+        healthWithUnknown["endpoint"] = "https://not-allowed.example"
+        let unknownHealthData = try JSONSerialization.data(
+            withJSONObject: healthWithUnknown
+        )
+        #expect(throws: ConversationModuleError.invalidResponse) {
+            _ = try ConversationModuleCodec.decodeHealth(unknownHealthData)
+        }
+
+        let validResponse = response(for: request())
+        let responseObject = try #require(
+            JSONSerialization.jsonObject(with: encoder.encode(validResponse))
+                as? [String: Any]
+        )
+        var responseWithUnknown = responseObject
+        responseWithUnknown["executableReplay"] = ["steps": ["click"]]
+        let unknownResponseData = try JSONSerialization.data(
+            withJSONObject: responseWithUnknown
+        )
+        #expect(throws: ConversationModuleError.invalidResponse) {
+            _ = try ConversationModuleCodec.decodeResponse(unknownResponseData)
+        }
+
+        var nullQuestionResponse = responseObject
+        nullQuestionResponse["question"] = NSNull()
+        let nullQuestionData = try JSONSerialization.data(
+            withJSONObject: nullQuestionResponse
+        )
+        #expect(throws: ConversationModuleError.invalidResponse) {
+            _ = try ConversationModuleCodec.decodeResponse(nullQuestionData)
+        }
+    }
+
+    @Test("A sequence gap refuses without advancing the synthetic module")
+    func syntheticRollbackOnSequenceGap() async throws {
+        let module = SyntheticConversationModule()
+        let manifest = ConversationModuleAllowlist.syntheticManifest
+        let first = request(sequence: 1)
+        _ = try await module.perform(first, manifest: manifest)
+
+        let gap = request(sequence: 3)
+        await #expect(throws: ConversationModuleError.sequenceMismatch) {
+            _ = try await module.perform(gap, manifest: manifest)
+        }
+
+        let second = request(sequence: 2)
+        let response = try await module.perform(second, manifest: manifest)
+        #expect(response.sequence == 2)
+        #expect(response.state == .checkpointReady)
+    }
+
+    @Test("Revocation clears ephemeral state and a new floor starts at sequence one")
+    @MainActor
+    func hostFloorLifecycle() async throws {
+        let host = ConversationModuleHostSession(
+            registrations: [
+                ConversationModuleRegistration(
+                    manifest: ConversationModuleAllowlist.syntheticManifest,
+                    transport: SyntheticConversationModule()
+                ),
+            ],
+            tokenFactory: { floor.token }
+        )
+
+        await host.grantSelectedFloor()
+        #expect(host.activeFloor == floor)
+        let reply = try await host.submit(
+            narration: "Synthetic narration",
+            transcriptProvider: .syntheticFixture,
+            context: .empty
+        )
+        #expect(reply.state == .checkpointReady)
+        #expect(reply.checkpoints.count == 1)
+
+        await host.revokeFloor()
+        #expect(host.activeFloor == nil)
+        #expect(host.activeState == .idle)
+        #expect(host.lastResponse == nil)
+
+        await host.grantSelectedFloor()
+        let freshReply = try await host.submit(
+            narration: "Fresh synthetic narration",
+            transcriptProvider: .syntheticFixture,
+            context: .empty
+        )
+        #expect(freshReply.sequence == 1)
+        #expect(freshReply.checkpoints.first?.checkpointID == "checkpoint_1")
+    }
+
+    @Test("A refused response revokes the floor and restores dashboard control")
+    @MainActor
+    func refusedResponseRevokesFloor() async {
+        let host = ConversationModuleHostSession(
+            registrations: [
+                ConversationModuleRegistration(
+                    manifest: ConversationModuleAllowlist.syntheticManifest,
+                    transport: RefusingConversationModule()
+                ),
+            ],
+            tokenFactory: { floor.token }
+        )
+
+        await host.grantSelectedFloor()
+        await #expect(throws: ConversationModuleError.moduleRefused) {
+            _ = try await host.submit(
+                narration: "Synthetic refusal",
+                transcriptProvider: .syntheticFixture,
+                context: .empty
+            )
+        }
+        #expect(host.activeFloor == nil)
+        #expect(host.activeState == .idle)
+        #expect(host.lastResponse == nil)
+    }
+
+    private func request(
+        manifest: ConversationModuleManifest =
+            ConversationModuleAllowlist.syntheticManifest,
+        floor: ConversationFloorGrant? = nil,
+        provenance: ConversationModuleProvenance? = nil,
+        sequence: Int = 1,
+        events: [ConversationModuleEvent] = [],
+        window: ConversationModuleWindowContext? = nil
+    ) -> ConversationModuleRequest {
+        ConversationModuleRequest(
+            contractVersion: ConversationModuleContract.version,
+            kind: .turn,
+            moduleID: manifest.moduleID,
+            requestID: "request_00000000-0000-0000-0000-000000000001",
+            turnID: "turn_00000000-0000-0000-0000-000000000001",
+            sequence: sequence,
+            floor: floor ?? self.floor,
+            transcriptProvider: .syntheticFixture,
+            narration: "Synthetic narration",
+            context: .empty,
+            events: events,
+            window: window,
+            provenance: provenance ?? self.provenance
+        )
+    }
+
+    private func response(
+        for request: ConversationModuleRequest
+    ) -> ConversationModuleResponse {
+        ConversationModuleResponse(
+            contractVersion: request.contractVersion,
+            moduleID: request.moduleID,
+            requestID: request.requestID,
+            turnID: request.turnID,
+            sequence: request.sequence,
+            floor: request.floor,
+            state: .checkpointReady,
+            reply: "Synthetic reply",
+            statuses: [],
+            checkpoints: [],
+            question: nil,
+            proposedActions: [],
+            provenance: request.provenance
+        )
+    }
+}
+
+private actor RefusingConversationModule: ConversationModuleTransport {
+    private let provenance = ConversationModuleProvenance(
+        sourceID: "firestarter.operations-floater.synthetic",
+        buildDigest: "7e3b6a1b0d4586f3d3b99a8e4b5114ca4f963f1b6ce974cf81682433c73547de"
+    )
+
+    func health(
+        for manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleHealth {
+        ConversationModuleHealth(
+            contractVersion: manifest.contractVersion,
+            moduleID: manifest.moduleID,
+            state: .ready,
+            privacy: manifest.privacy,
+            provenance: provenance
+        )
+    }
+
+    func perform(
+        _ request: ConversationModuleRequest,
+        manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleResponse {
+        ConversationModuleResponse(
+            contractVersion: request.contractVersion,
+            moduleID: request.moduleID,
+            requestID: request.requestID,
+            turnID: request.turnID,
+            sequence: request.sequence,
+            floor: request.floor,
+            state: request.kind == .turn ? .refused : .idle,
+            reply: request.kind == .turn ? "Synthetic refusal" : nil,
+            statuses: [],
+            checkpoints: [],
+            question: nil,
+            proposedActions: [],
+            provenance: provenance
+        )
+    }
+}
+
+private extension ConversationNavigationKey {
+    static var allCasesForTests: [ConversationNavigationKey] {
+        [
+            .tab, .returnKey, .space, .arrowLeft, .arrowRight, .arrowUp,
+            .arrowDown, .delete,
+        ]
+    }
+}

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
@@ -1,0 +1,397 @@
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Voice conversation lifecycle")
+@MainActor
+struct ConversationVoiceTests {
+    @Test("Voice and spoken replies are explicitly off by default")
+    func defaultsAreOff() {
+        let engine = SyntheticTranscriptionEngine()
+        let speech = SyntheticSpeechOutput()
+        let session = VoiceConversationSession(engine: engine, speechOutput: speech)
+
+        #expect(session.state == .off)
+        #expect(!session.spokenRepliesEnabled)
+        #expect(engine.startCount == 0)
+        #expect(speech.spokenTexts.isEmpty)
+    }
+
+    @Test("Permission denial fails closed without starting audio")
+    func permissionDenialFailsClosed() async {
+        let engine = SyntheticTranscriptionEngine(authorization: .denied)
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput()
+        )
+
+        await session.start()
+
+        #expect(session.state == .unavailable)
+        #expect(engine.startCount == 0)
+        #expect(session.lastError == ConversationVoiceError.permissionDenied.localizedDescription)
+    }
+
+    @Test("Missing or unallowlisted provider metadata fails closed")
+    func providerMetadataFailsClosed() async {
+        let engine = SyntheticTranscriptionEngine(provider: .typedKeyboard)
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput()
+        )
+
+        await session.start()
+
+        #expect(session.state == .unavailable)
+        #expect(engine.startCount == 0)
+        #expect(
+            session.lastError
+                == ConversationVoiceError.providerMetadataUnavailable.localizedDescription
+        )
+    }
+
+    @Test("Stopping while permission is pending cannot start the microphone later")
+    func stopCancelsPendingPermissionStart() async {
+        let engine = SuspendedAuthorizationEngine()
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput()
+        )
+
+        let startTask = Task {
+            await session.start()
+        }
+        for _ in 0..<20 where !engine.isAwaitingAuthorization {
+            await Task.yield()
+        }
+        #expect(engine.isAwaitingAuthorization)
+        #expect(session.state == .requestingPermission)
+
+        session.stop()
+        engine.resolveAuthorization(.authorized)
+        await startTask.value
+
+        #expect(session.state == .off)
+        #expect(engine.startCount == 0)
+        #expect(!engine.isRunning)
+    }
+
+    @Test("A finalized transcript stages immediately and submits after exactly two seconds")
+    func syntheticTranscriptLifecycle() async {
+        let engine = SyntheticTranscriptionEngine()
+        let sleeper = ControlledDebounceSleeper()
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput(),
+            debounceSleeper: { duration in
+                try await sleeper.sleep(for: duration)
+            }
+        )
+        var staged: [String] = []
+        var submitted: (String, ConversationTranscriptProvider)?
+        session.onTranscriptStaged = { staged.append($0) }
+        session.onFinalTranscript = { text, provider in
+            submitted = (text, provider)
+        }
+
+        await session.start()
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "Synthetic narration",
+            isFinal: true
+        )))
+        await waitForSleeper(sleeper, count: 1)
+
+        #expect(staged == ["Synthetic narration"])
+        #expect(session.state == .listening)
+        #expect(session.hasPendingSubmission)
+        #expect(submitted == nil)
+        #expect(await sleeper.requestedDurations() == [.seconds(2)])
+
+        await sleeper.resumeNext()
+        await settle()
+
+        #expect(session.state == .thinking)
+        #expect(submitted?.0 == "Synthetic narration")
+        #expect(submitted?.1 == .syntheticFixture)
+        #expect(!engine.isRunning)
+
+        session.handleReplyFailure()
+        #expect(session.state == .listening)
+        session.stop()
+        #expect(session.state == .off)
+        #expect(session.transcriptPreview.isEmpty)
+    }
+
+    @Test("Resumed speech cancels and restarts the two-second pause")
+    func resumedSpeechRestartsDebounce() async {
+        let engine = SyntheticTranscriptionEngine()
+        let sleeper = ControlledDebounceSleeper()
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput(),
+            debounceSleeper: { duration in
+                try await sleeper.sleep(for: duration)
+            }
+        )
+        var staged: [String] = []
+        var submitted: [String] = []
+        session.onTranscriptStaged = { staged.append($0) }
+        session.onFinalTranscript = { text, _ in submitted.append(text) }
+
+        await session.start()
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "First segment",
+            isFinal: true
+        )))
+        await waitForSleeper(sleeper, count: 1)
+
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "resumed",
+            isFinal: false
+        )))
+        await settle()
+        #expect(!session.hasPendingSubmission)
+        #expect(submitted.isEmpty)
+        #expect(staged.last == "First segment resumed")
+
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "resumed",
+            isFinal: true
+        )))
+        await waitForSleeper(sleeper, count: 1)
+        #expect(await sleeper.requestedDurations() == [.seconds(2), .seconds(2)])
+
+        await sleeper.resumeNext()
+        await settle()
+        #expect(submitted == ["First segment resumed"])
+    }
+
+    @Test("Pause and explicit cancellation remove a pending stale turn")
+    func pauseCancelsPendingSubmission() async {
+        let engine = SyntheticTranscriptionEngine()
+        let sleeper = ControlledDebounceSleeper()
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput(),
+            debounceSleeper: { duration in
+                try await sleeper.sleep(for: duration)
+            }
+        )
+        var cancelled = 0
+        var submitted = 0
+        session.onPendingTranscriptCancelled = { cancelled += 1 }
+        session.onFinalTranscript = { _, _ in submitted += 1 }
+
+        await session.start()
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "Stale synthetic turn",
+            isFinal: true
+        )))
+        await waitForSleeper(sleeper, count: 1)
+
+        session.pause()
+        await settle()
+
+        #expect(session.state == .paused)
+        #expect(!session.hasPendingSubmission)
+        #expect(session.transcriptPreview.isEmpty)
+        #expect(cancelled == 1)
+        #expect(submitted == 0)
+        #expect(await sleeper.activeWaiterCount() == 0)
+    }
+
+    @Test("Pause, resume, optional speech, and interruption remain explicit")
+    func controlsAreExplicit() async {
+        let engine = SyntheticTranscriptionEngine()
+        let speech = SyntheticSpeechOutput()
+        let session = VoiceConversationSession(engine: engine, speechOutput: speech)
+
+        await session.start()
+        session.pause()
+        #expect(session.state == .paused)
+        #expect(!engine.isRunning)
+
+        session.resume()
+        #expect(session.state == .listening)
+
+        session.spokenRepliesEnabled = true
+        session.markThinking()
+        session.handleReply("Synthetic reply")
+        #expect(session.state == .responding)
+        #expect(speech.spokenTexts == ["Synthetic reply"])
+
+        session.interruptSpokenReply()
+        #expect(speech.stopCount >= 1)
+        #expect(session.state == .listening)
+        #expect(engine.isRunning)
+    }
+
+    private func settle() async {
+        for _ in 0..<4 {
+            await Task.yield()
+        }
+    }
+
+    private func waitForSleeper(
+        _ sleeper: ControlledDebounceSleeper,
+        count: Int
+    ) async {
+        for _ in 0..<100 {
+            if await sleeper.activeWaiterCount() == count {
+                return
+            }
+            await Task.yield()
+        }
+    }
+}
+
+private final class SyntheticTranscriptionEngine: ConversationTranscriptionEngine,
+    @unchecked Sendable {
+    let provider: ConversationTranscriptProvider?
+    let supportsOnDeviceRecognition: Bool
+    private(set) var isRunning = false
+    var resultHandler: (@Sendable (
+        Result<ConversationTranscriptResult, ConversationVoiceError>
+    ) -> Void)?
+
+    private let authorization: ConversationVoiceAuthorization
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(
+        provider: ConversationTranscriptProvider? = .syntheticFixture,
+        authorization: ConversationVoiceAuthorization = .authorized,
+        supportsOnDeviceRecognition: Bool = true
+    ) {
+        self.provider = provider
+        self.authorization = authorization
+        self.supportsOnDeviceRecognition = supportsOnDeviceRecognition
+    }
+
+    func currentAuthorization() -> ConversationVoiceAuthorization {
+        authorization
+    }
+
+    func requestAuthorization() async -> ConversationVoiceAuthorization {
+        authorization
+    }
+
+    func start() throws {
+        startCount += 1
+        isRunning = true
+    }
+
+    func stop() {
+        stopCount += 1
+        isRunning = false
+    }
+
+    func emit(
+        _ result: Result<ConversationTranscriptResult, ConversationVoiceError>
+    ) {
+        resultHandler?(result)
+    }
+}
+
+private final class SyntheticSpeechOutput: ConversationSpeechOutput,
+    @unchecked Sendable {
+    private(set) var isSpeaking = false
+    var completionHandler: (@Sendable () -> Void)?
+    private(set) var spokenTexts: [String] = []
+    private(set) var stopCount = 0
+
+    func speak(_ text: String) {
+        spokenTexts.append(text)
+        isSpeaking = true
+    }
+
+    func stop() {
+        stopCount += 1
+        isSpeaking = false
+    }
+}
+
+private final class SuspendedAuthorizationEngine: ConversationTranscriptionEngine,
+    @unchecked Sendable {
+    let provider: ConversationTranscriptProvider? = .syntheticFixture
+    let supportsOnDeviceRecognition = true
+    private(set) var isRunning = false
+    var resultHandler: (@Sendable (
+        Result<ConversationTranscriptResult, ConversationVoiceError>
+    ) -> Void)?
+    private(set) var startCount = 0
+    private(set) var isAwaitingAuthorization = false
+    private var authorizationContinuation:
+        CheckedContinuation<ConversationVoiceAuthorization, Never>?
+
+    func currentAuthorization() -> ConversationVoiceAuthorization {
+        .notDetermined
+    }
+
+    func requestAuthorization() async -> ConversationVoiceAuthorization {
+        await withCheckedContinuation { continuation in
+            isAwaitingAuthorization = true
+            authorizationContinuation = continuation
+        }
+    }
+
+    func resolveAuthorization(_ value: ConversationVoiceAuthorization) {
+        authorizationContinuation?.resume(returning: value)
+        authorizationContinuation = nil
+        isAwaitingAuthorization = false
+    }
+
+    func start() throws {
+        startCount += 1
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+    }
+}
+
+private actor ControlledDebounceSleeper {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var durations: [Duration] = []
+    private var waiters: [Waiter] = []
+
+    func sleep(for duration: Duration) async throws {
+        let id = UUID()
+        durations.append(duration)
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters.append(Waiter(id: id, continuation: continuation))
+            }
+        } onCancel: {
+            Task {
+                await self.cancel(id: id)
+            }
+        }
+    }
+
+    func requestedDurations() -> [Duration] {
+        durations
+    }
+
+    func activeWaiterCount() -> Int {
+        waiters.count
+    }
+
+    func resumeNext() {
+        guard !waiters.isEmpty else { return }
+        waiters.removeFirst().continuation.resume()
+    }
+
+    private func cancel(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        waiters.remove(at: index).continuation.resume(throwing: CancellationError())
+    }
+}

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -6,6 +6,53 @@ import Testing
 @Suite("Dashboard state")
 @MainActor
 struct DashboardStateTests {
+    @Test("Interactive launch is unpinned while retaining explicit foreground behavior")
+    func interactiveLaunchConfiguration() {
+        let configuration = DashboardLaunchConfiguration(arguments: ["/tmp/Operations Floater"])
+
+        #expect(!configuration.isBackgroundUITest)
+        #expect(!configuration.initialPinned)
+        #expect(configuration.activatesApplication)
+        #expect(configuration.foregroundsWindow)
+        #expect(configuration.joinsAllSpaces)
+        #expect(configuration.usesSavedFrame)
+        #expect(!configuration.usesSyntheticConversationFixture)
+    }
+
+    @Test("Background UI testing is unpinned, nonactivating, and single-Space")
+    func backgroundUITestLaunchConfiguration() {
+        let configuration = DashboardLaunchConfiguration(
+            arguments: [
+                "/tmp/Operations Floater",
+                DashboardLaunchConfiguration.backgroundUITestArgument,
+                DashboardLaunchConfiguration.syntheticConversationUITestArgument,
+                DashboardLaunchConfiguration.compactUITestArgument,
+            ]
+        )
+
+        #expect(configuration.isBackgroundUITest)
+        #expect(!configuration.initialPinned)
+        #expect(!configuration.activatesApplication)
+        #expect(!configuration.foregroundsWindow)
+        #expect(!configuration.joinsAllSpaces)
+        #expect(!configuration.usesSavedFrame)
+        #expect(configuration.usesSyntheticConversationFixture)
+        #expect(
+            configuration.initialWindowSize
+                == DashboardLayoutMetrics.minimumWindowSize
+        )
+    }
+
+    @Test("Background UI testing starts with Keep in front disabled")
+    func backgroundUITestInitialPinning() {
+        let state = DashboardState(
+            snapshotURL: missingFixtureURL(),
+            initialPinned: false
+        )
+
+        #expect(!state.pinned)
+    }
+
     @Test("Missing local state uses the canonical generic sample")
     func missingLocalStateUsesSample() {
         let state = DashboardState(snapshotURL: missingFixtureURL())
@@ -208,7 +255,10 @@ struct DashboardStateTests {
     @Test("Window opens frontmost, unpins, closes, and reopens as the same retained window")
     func windowLifecycleAndPinning() {
         _ = NSApplication.shared
-        let state = DashboardState(snapshotURL: missingFixtureURL())
+        let state = DashboardState(
+            snapshotURL: missingFixtureURL(),
+            initialPinned: true
+        )
         let controller = DashboardWindowController(state: state, activatesApplication: false)
 
         let firstWindow = controller.show()
@@ -231,6 +281,14 @@ struct DashboardStateTests {
         #expect(reopenedWindow.isVisible)
         #expect(reopenedWindow.level == .normal)
         controller.close()
+    }
+
+    @Test("Single-Space presentation does not opt into following the user")
+    func singleSpaceWindowPresentation() {
+        let behavior = DashboardWindowController.collectionBehavior(joinsAllSpaces: false)
+
+        #expect(behavior.contains(.managed))
+        #expect(!behavior.contains(.canJoinAllSpaces))
     }
 
     private func missingFixtureURL() -> URL {

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -170,7 +170,7 @@ struct GuidePresentationTests {
         #expect(minimumMetrics.estimatedCardWidth(containerWidth: 380) == 352)
     }
 
-    @Test("Application entitlements allow only user-selected files and outbound networking")
+    @Test("Application entitlements allow only explicit audio input, selected files, and outbound networking")
     func entitlementsRemainLocalOnly() throws {
         let data = try Data(
             contentsOf: packageRoot().appendingPathComponent("OperationsFloater.entitlements")
@@ -182,14 +182,14 @@ struct GuidePresentationTests {
         )
         let entitlements = try #require(value as? [String: Any])
 
-        #expect(entitlements.count == 3)
+        #expect(entitlements.count == 4)
         #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(
             entitlements["com.apple.security.files.user-selected.read-only"] as? Bool == true
         )
         #expect(entitlements["com.apple.security.network.client"] as? Bool == true)
         #expect(entitlements["com.apple.security.network.server"] == nil)
-        #expect(entitlements["com.apple.security.device.audio-input"] == nil)
+        #expect(entitlements["com.apple.security.device.audio-input"] as? Bool == true)
         #expect(entitlements["com.apple.security.device.camera"] == nil)
     }
 

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -53,8 +53,8 @@ struct RouterChatClientTests {
         #expect(messages.last?["role"] as? String == "user")
     }
 
-    @Test("A valid OpenAI-compatible response becomes a chat reply")
-    func validResponse() throws {
+    @Test("A providerless response fails closed instead of guessing attribution")
+    func providerlessResponseFailsClosed() throws {
         let data = Data(
             """
             {
@@ -74,14 +74,12 @@ struct RouterChatClientTests {
             )
         )
 
-        let reply = try RouterChatClient.decodeReply(data: data, response: response)
-
-        #expect(reply == RouterChatReply(text: "Synthetic answer.", model: "auto"))
-        #expect(reply.responder.kind == .unreported)
-        #expect(reply.responder.displayName == "Router · provider not reported")
+        #expect(throws: RouterChatClient.ClientError.providerIdentityUnavailable) {
+            _ = try RouterChatClient.decodeReply(data: data, response: response)
+        }
     }
 
-    @Test("Responder provenance distinguishes Claude, Codex, local, and unreported replies")
+    @Test("Responder provenance distinguishes closed and rejected identities")
     func responderClassification() {
         let cases: [
             (
@@ -94,10 +92,16 @@ struct RouterChatClientTests {
         ] = [
             ("assistant", "anthropic", "claude-sonnet", .claude, "Claude"),
             ("assistant", "openai/codex", "codex-1", .codex, "Codex"),
-            ("local_llm", "ollama", "synthetic-local-model", .localLLM, "Local LLM"),
-            ("local_llm", "ollama", "claude-compatible-tag", .localLLM, "Local LLM"),
-            (nil, nil, "auto", .unreported, "Router · provider not reported"),
-            ("assistant", "vertex-ai", "gemini", .reportedProvider, "Router · vertex-ai"),
+            ("local_llm", "ollama", "synthetic-local-model", .localLLM, "local-LLM"),
+            ("local_llm", "ollama", "claude-compatible-tag", .localLLM, "local-LLM"),
+            (nil, nil, "auto", .unreported, "Provider identity unavailable"),
+            (
+                "assistant",
+                "vertex-ai",
+                "gemini",
+                .reportedProvider,
+                "Provider identity unavailable"
+            ),
         ]
 
         for item in cases {
@@ -141,7 +145,7 @@ struct RouterChatClientTests {
 
         #expect(reply.model == "synthetic-local-model")
         #expect(reply.responder.kind == .localLLM)
-        #expect(reply.responder.displayName == "Local LLM")
+        #expect(reply.responder.displayName == "local-LLM")
         #expect(reply.responder.modelDetail == "synthetic-local-model")
     }
 
@@ -195,7 +199,12 @@ struct RouterChatClientTests {
     func modelLabelIsBounded() throws {
         let data = try JSONSerialization.data(
             withJSONObject: [
-                "model": String(repeating: "m", count: 200),
+                "model": "auto",
+                "responder": [
+                    "kind": "local_llm",
+                    "provider": "synthetic-local",
+                    "model": String(repeating: "m", count: 200),
+                ],
                 "choices": [["message": ["content": "Synthetic answer."]]],
             ]
         )
@@ -227,8 +236,8 @@ struct RouterChatClientTests {
         )
     }
 
-    @Test("Malformed optional provenance does not hide a valid assistant reply")
-    func malformedOptionalProvenanceIsIgnored() throws {
+    @Test("Malformed optional provenance fails closed")
+    func malformedOptionalProvenanceFailsClosed() throws {
         let data = Data(
             """
             {
@@ -250,10 +259,9 @@ struct RouterChatClientTests {
             )
         )
 
-        let reply = try RouterChatClient.decodeReply(data: data, response: response)
-
-        #expect(reply.text == "Synthetic answer.")
-        #expect(reply.responder.kind == .unreported)
+        #expect(throws: RouterChatClient.ClientError.providerIdentityUnavailable) {
+            _ = try RouterChatClient.decodeReply(data: data, response: response)
+        }
     }
 
     @Test("A bounded JSON monitor response becomes an improvement suggestion")
@@ -421,7 +429,7 @@ struct RouterChatSessionTests {
     func multilineDraftIsPreserved() async {
         let transport = StubRouterTransport(
             available: true,
-            result: .success(RouterChatReply(text: "Synthetic reply", model: "auto"))
+            result: .success(localReply(text: "Synthetic reply"))
         )
         let session = RouterChatSession(transport: transport)
         await session.enable()
@@ -438,7 +446,7 @@ struct RouterChatSessionTests {
     func disabledByDefault() async {
         let transport = StubRouterTransport(
             available: true,
-            result: .success(RouterChatReply(text: "Synthetic reply", model: "auto"))
+            result: .success(localReply(text: "Synthetic reply"))
         )
         let session = RouterChatSession(transport: transport)
         session.draft = "Synthetic request"
@@ -506,7 +514,7 @@ struct RouterChatSessionTests {
         )
         let transport = StubRouterTransport(
             available: true,
-            result: .success(RouterChatReply(text: "Maybe.", model: "auto")),
+            result: .success(localReply(text: "Maybe.")),
             critiqueResult: .success(critique)
         )
         let session = RouterChatSession(transport: transport)
@@ -543,10 +551,106 @@ struct RouterChatSessionTests {
         )
     }
 
+    @Test("An identity refusal keeps a reachable Router online")
+    func providerIdentityRefusalDoesNotMisreportConnectivity() async {
+        let transport = StubRouterTransport(
+            available: true,
+            result: .success(
+                RouterChatReply(
+                    text: "Synthetic answer",
+                    model: "auto",
+                    responder: RouterResponder(
+                        provider: "unsupported-provider",
+                        model: "auto"
+                    )
+                )
+            )
+        )
+        let session = RouterChatSession(transport: transport)
+        await session.enable()
+        session.draft = "Synthetic request"
+
+        session.send()
+        await waitUntilSettled(session)
+
+        #expect(session.availability == .online)
+        #expect(session.messages.map(\.text) == ["Synthetic request"])
+        #expect(
+            session.lastError
+                == "The Router did not report a closed Claude, Codex, or local-LLM identity."
+        )
+    }
+
+    @Test("Voice transcript is staged as the user and submitted without duplication")
+    func stagedVoiceTranscriptUsesSharedSendPath() async {
+        let transport = StubRouterTransport(
+            available: true,
+            result: .success(localReply(text: "Synthetic voice reply"))
+        )
+        let session = RouterChatSession(transport: transport)
+        await session.enable()
+
+        session.stageVoiceTranscript("Synthetic voice narration")
+        #expect(session.messages.count == 1)
+        #expect(session.messages.first?.role == .user)
+        #expect(session.messages.first?.isPendingVoice == true)
+
+        session.send(
+            text: "Synthetic voice narration",
+            transcriptProvider: .syntheticFixture
+        )
+        await waitUntilSettled(session)
+
+        #expect(session.messages.count == 2)
+        #expect(session.messages.first?.isPendingVoice == false)
+        #expect(session.messages.first?.text == "Synthetic voice narration")
+        #expect(session.messages.last?.responder?.displayName == "local-LLM")
+    }
+
+    @Test("Module switch and floor revoke cancel staged host voice")
+    func conversationControlCancelsStagedVoice() async {
+        let session = RouterChatSession(
+            transport: StubRouterTransport(
+                available: true,
+                result: .success(localReply(text: "Unused"))
+            )
+        )
+        await session.enable()
+        var controlChanges = 0
+        session.onConversationControlChanged = {
+            controlChanges += 1
+        }
+
+        session.stageVoiceTranscript("Pending synthetic narration")
+        session.selectConversationTarget(
+            ConversationModuleAllowlist.geometryRecorderManifest.moduleID
+        )
+        #expect(controlChanges == 1)
+        #expect(session.messages.isEmpty)
+
+        session.stageVoiceTranscript("Another pending narration")
+        await session.revokeModuleFloor()
+        #expect(controlChanges == 2)
+        #expect(session.messages.isEmpty)
+    }
+
     private func waitUntilSettled(_ session: RouterChatSession) async {
         for _ in 0..<100 where session.isSending {
             try? await Task.sleep(for: .milliseconds(10))
         }
+    }
+
+    private func localReply(text: String) -> RouterChatReply {
+        let responder = RouterResponder(
+            kindHint: "local_llm",
+            provider: "synthetic-local",
+            model: "synthetic-local-model"
+        )
+        return RouterChatReply(
+            text: text,
+            model: responder.model,
+            responder: responder
+        )
     }
 
     private func waitUntilReviewed(_ session: RouterChatSession) async {

--- a/prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md
+++ b/prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md
@@ -1,0 +1,75 @@
+# Low-disruption macOS UI testing
+
+The least disruptive local workflow uses a spare macOS Desktop that the user
+creates once and leaves available for dashboard testing. macOS does not expose
+a supported API for silently creating or deleting Desktops, so that one-time
+Mission Control step remains user-controlled.
+
+## One-time setup
+
+1. Open Mission Control with **Control-Up**.
+2. Select **+** to create a spare Desktop.
+3. Switch to the spare Desktop and launch the dashboard once in background test
+   mode:
+
+   ```bash
+   open -g -n "/path/to/Operations Floater.app" \
+     --args --background-ui-test
+   ```
+
+4. To launch from the normal work Desktop without switching first, use the
+   dashboard's Dock item on the spare Desktop:
+   **Options → Assign To → This Desktop**. Leave the spare Desktop available.
+5. Return to the normal work Desktop.
+
+The Dock assignment is required for automatic routing when launch begins on a
+different Desktop. It is keyed to the built app's bundle identifier and stored
+as macOS user state, not as a repository or application setting. A newly built
+candidate with a different bundle identifier needs its own one-time assignment.
+
+## Test-mode contract
+
+`--background-ui-test` changes presentation behavior only:
+
+- **Keep in front** starts off and the window uses normal level;
+- the window does not opt into **Join All Spaces**;
+- launch does not activate Operations Floater;
+- launch does not call force-front window ordering; and
+- snapshots, validation, privacy boundaries, chat defaults, and schema `1.0`
+  remain unchanged.
+
+Normal launches intentionally retain the existing foreground, pinned, and
+all-Spaces behavior.
+
+```text
+User creates spare Desktop once
+              |
+              v
+Assign app to that Desktop (optional but recommended)
+              |
+              v
+open -g ... --args --background-ui-test
+              |
+              +--> normal-level window on one Desktop
+              +--> foreground app remains unchanged
+              +--> pointer is not moved by the launch command
+```
+
+## Limits and fallbacks
+
+- The initial Desktop creation and first Dock assignment are visible user
+  actions. Later assigned launches can begin from the work Desktop.
+- macOS may animate a Desktop switch; Reduce Motion can reduce but not eliminate
+  every transition.
+- A single physical display cannot show two Desktops simultaneously.
+- If assignment is unavailable or unreliable, switch to the spare Desktop
+  before launching, then return to the work Desktop.
+- Automated structural checks should prefer background accessibility
+  inspection. Pixel-regression work that must be completely isolated belongs
+  on a secondary display, a separate GUI login session, or a virtual machine.
+- This mode reduces interruption; it does not claim that every macOS release,
+  window manager, or third-party utility will preserve focus identically.
+
+Before each run, verify that no old Operations Floater process remains. Start
+one instance, record its exact executable path and PID, and terminate that exact
+test instance during cleanup.

--- a/prototypes/operations-floater/docs/CHAT_COMPOSER_STATE.md
+++ b/prototypes/operations-floater/docs/CHAT_COMPOSER_STATE.md
@@ -24,23 +24,21 @@ bounded completion response:
 ```text
 completion response
 ├─ responder kind/provider says Anthropic or Claude ─> Claude
-├─ responder kind/provider/model says Codex ─────────> Codex
-├─ responder kind/provider says local/Ollama/MLX ────> Local LLM
-├─ another provider is reported ─────────────────────> Router · <provider>
-└─ no provider identity; model is auto ──────────────> Router · provider not reported
+├─ responder kind/provider says Codex ───────────────> Codex
+├─ responder kind/provider says local/Ollama/MLX ────> local-LLM
+├─ another provider is reported ─────────────────────> reject reply
+└─ no provider identity; model is auto ──────────────> reject reply
 ```
 
 The top status capsule reports only Router reachability. It does not present
-`auto` as a model or responder identity. Optional malformed provenance is
-ignored without hiding an otherwise valid answer; missing provenance remains
-visibly unreported.
+`auto` as a model or responder identity. Missing, malformed, or non-closed
+provenance fails visibly and no assistant bubble is added.
 
 ## Rebuilt-app evidence
 
-The rebuilt Release frame below uses only synthetic text. The live loopback
-Router returned `model: "auto"` without provider metadata, so the assistant
-bubble visibly and correctly says **Router · provider not reported** while the
-top capsule says only **Router online**.
+The frame below is retained as historical evidence of the former compatibility
+behavior. Current builds reject its providerless `model: "auto"` response
+instead of rendering a generically attributed assistant bubble.
 
 ![Native responder provenance label](media/chat-responder-provenance.jpg)
 

--- a/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
+++ b/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
@@ -1,0 +1,102 @@
+# Conversation module contract 1.0
+
+Operations Floater owns the conversation UI, microphone permission, on-device
+transcription, optional local speech output, ephemeral transcript, and the
+single active conversation floor. A module never supplies UI and is never
+dynamically loaded. Eligibility comes only from the app's compiled static
+allowlist.
+
+The machine-readable closed envelope is
+[`conversation-module-contract-1.0.schema.json`](conversation-module-contract-1.0.schema.json).
+Unknown fields fail closed.
+
+## Fixed IPC
+
+- Base URL: `http://127.0.0.1:11510/v1/conversation-modules`
+- Health: `GET /{moduleID}/health`
+- Turn, revoke, and end: `POST /{moduleID}/turn`
+- Client header: `X-Client-App: operations-floater`
+- Transport: ephemeral URL session, no cache, cookies, credentials, redirects,
+  authentication headers, discovery, or alternate host.
+- Limits: health 16,384 bytes; response 65,536 bytes; health timeout 2 seconds;
+  turn timeout 10 seconds.
+
+The allowlisted geometry adapter is:
+
+- module ID: `auggie.verbal-orders.synthetic-geometry-recorder`
+- provenance source: `auggie.project-verbal-orders.geometry-recorder`
+- transcript providers: `onDevice`, `syntheticFixture`
+- window binding: `verbal-orders.synthetic.geometry-canvas`
+
+The built-in checkpoint reference additionally permits `typed-keyboard`.
+The geometry recorder does not, so the typed composer is disabled while it has
+the floor.
+
+## Bounds
+
+| Field | Bound |
+|---|---:|
+| narration | 2,000 characters |
+| context | 6 turns, 1,000 characters each, 6,000 total |
+| normalized events | 32 |
+| allowlisted window bindings per manifest | 8 |
+| window width and height | 100 through 8,192 |
+| reply | 4,000 characters |
+| question | one, 600 characters |
+| statuses | 4; summary 240 characters |
+| checkpoints | 8; summary 400 characters |
+| proposed actions | 4; title 120 characters |
+
+Event sequences start at one and are contiguous within each request. Pointer
+coordinates are normalized to `0...1`. Navigation keys are closed to Tab,
+Return, Space, arrows, and Delete. Escape is intentionally absent because the
+host always reserves it for returning to the dashboard.
+
+## Floor and transaction semantics
+
+The host creates a fresh `floor_<lowercase UUID>` token after a ready health
+response and pins the returned 64-character lowercase SHA-256 provenance
+digest. One module may have the floor. Request sequence starts at one and
+increments only after a fully validated, non-refused response.
+
+Every response must echo the contract version, module, request, turn, sequence,
+floor grant, and pinned provenance exactly. A refusal, provider omission,
+provider mismatch, floor mismatch, sequence gap or replay, binding drift,
+provenance drift, malformed or oversized envelope, unknown field, or
+out-of-capability value fails closed. The host attempts a revoke and always
+clears its local floor. The module must restore its exact pre-turn snapshot on
+failure.
+
+Revoke and end use the same token with `state: revoked`, carry no narration,
+context, events, or window, and clear ephemeral module state. Their required
+`transcriptProvider` field is control-envelope metadata and is not checked
+against the turn-provider allowlist.
+
+## Privacy and actions
+
+Every accepted manifest has exactly this privacy posture:
+
+- `ephemeralOnly: true`
+- module microphone, UI, TTS, arbitrary network, persistence, screen capture,
+  input injection, and executable replay: `false`
+
+The recorder receives only bounded narration, closed normalized events, and an
+allowlisted neutral synthetic window binding. It may return calibrated
+checkpoints, at most one question, statuses, and proposals. Every proposed
+action must set `humanApprovalRequired: true`; executable replay is not part of
+this contract.
+
+The host's voice mode is off by default. Start is explicit and may trigger the
+macOS Microphone and Speech Recognition prompts. Production transcription sets
+`requiresOnDeviceRecognition = true` and fails closed if provider metadata or
+on-device support is unavailable. Spoken replies are separately default-off,
+local, and interruptible. Finalized text appears immediately as a pending human
+chat turn and auto-submits after exactly 2.000 seconds of continuous pause.
+Resumed speech cancels and restarts the timer. Pause, stop, floor revoke, module
+switch, clear, and teardown cancel the staged turn. Transcript/session memory is
+in-memory only and is cleared on stop, disable, revoke, or app exit.
+
+Dashboard Router replies are labeled only from bounded Router-reported
+`responder.kind` or `responder.provider` metadata. The accepted identities are
+Claude, Codex, and local-LLM. The host does not infer identity from a model
+string; missing, malformed, or other identity metadata rejects the reply.

--- a/prototypes/operations-floater/docs/conversation-module-contract-1.0.schema.json
+++ b/prototypes/operations-floater/docs/conversation-module-contract-1.0.schema.json
@@ -1,0 +1,361 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://firestarter.invalid/operations-floater/conversation-module-contract-1.0.schema.json",
+  "title": "Operations Floater conversation module contract 1.0",
+  "oneOf": [
+    {"$ref": "#/$defs/manifest"},
+    {"$ref": "#/$defs/health"},
+    {"$ref": "#/$defs/request"},
+    {"$ref": "#/$defs/response"}
+  ],
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ephemeralOnly",
+        "moduleOwnsMicrophone",
+        "moduleOwnsUI",
+        "moduleOwnsTTS",
+        "arbitraryNetwork",
+        "persistence",
+        "screenCapture",
+        "inputInjection",
+        "executableReplay"
+      ],
+      "properties": {
+        "ephemeralOnly": {"const": true},
+        "moduleOwnsMicrophone": {"const": false},
+        "moduleOwnsUI": {"const": false},
+        "moduleOwnsTTS": {"const": false},
+        "arbitraryNetwork": {"const": false},
+        "persistence": {"const": false},
+        "screenCapture": {"const": false},
+        "inputInjection": {"const": false},
+        "executableReplay": {"const": false}
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceID", "buildDigest"],
+      "properties": {
+        "sourceID": {"$ref": "#/$defs/identifier"},
+        "buildDigest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contractVersion",
+        "moduleID",
+        "displayName",
+        "capabilities",
+        "privacy",
+        "provenanceSourceID",
+        "allowedTranscriptProviders",
+        "allowedWindowBindingIDs"
+      ],
+      "properties": {
+        "contractVersion": {"const": "1.0"},
+        "moduleID": {"$ref": "#/$defs/identifier"},
+        "displayName": {"type": "string", "minLength": 1, "maxLength": 80},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "narration",
+              "normalized-pointer-events",
+              "navigation-keys",
+              "placeholder-events",
+              "neutral-window-context",
+              "checkpoints",
+              "proposed-actions"
+            ]
+          }
+        },
+        "privacy": {"$ref": "#/$defs/privacy"},
+        "provenanceSourceID": {"$ref": "#/$defs/identifier"},
+        "allowedTranscriptProviders": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["typed-keyboard", "onDevice", "syntheticFixture"]}
+        },
+        "allowedWindowBindingIDs": {
+          "type": "array",
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/identifier"}
+        }
+      }
+    },
+    "health": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contractVersion", "moduleID", "state", "privacy", "provenance"],
+      "properties": {
+        "contractVersion": {"const": "1.0"},
+        "moduleID": {"$ref": "#/$defs/identifier"},
+        "state": {"enum": ["ready", "degraded", "unavailable"]},
+        "privacy": {"$ref": "#/$defs/privacy"},
+        "provenance": {"$ref": "#/$defs/provenance"}
+      }
+    },
+    "floor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "moduleID", "token"],
+      "properties": {
+        "state": {"enum": ["granted", "revoked"]},
+        "moduleID": {"$ref": "#/$defs/identifier"},
+        "token": {
+          "type": "string",
+          "pattern": "^floor_[a-f0-9-]{36}$"
+        }
+      }
+    },
+    "contextTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "text"],
+      "properties": {
+        "role": {"enum": ["user", "module"]},
+        "text": {"type": "string", "minLength": 1, "maxLength": 1000}
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventID",
+        "sequence",
+        "kind"
+      ],
+      "properties": {
+        "eventID": {
+          "type": "string",
+          "pattern": "^event_[a-z0-9-]{1,64}$"
+        },
+        "sequence": {"type": "integer", "minimum": 1},
+        "kind": {"enum": ["normalized-pointer", "navigation-key", "placeholder"]},
+        "pointerPhase": {
+          "type": ["string", "null"],
+          "enum": ["move", "down", "up", "drag", null]
+        },
+        "normalizedX": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "normalizedY": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "navigationKey": {
+          "type": ["string", "null"],
+          "enum": [
+            "tab",
+            "return",
+            "space",
+            "arrow-left",
+            "arrow-right",
+            "arrow-up",
+            "arrow-down",
+            "delete",
+            null
+          ]
+        },
+        "placeholder": {
+          "type": ["string", "null"],
+          "enum": [
+            "primary-action",
+            "secondary-action",
+            "text-field",
+            "canvas-region",
+            null
+          ]
+        }
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bindingID", "width", "height"],
+      "properties": {
+        "bindingID": {"$ref": "#/$defs/identifier"},
+        "width": {"type": "integer", "minimum": 100, "maximum": 8192},
+        "height": {"type": "integer", "minimum": 100, "maximum": 8192}
+      }
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contractVersion",
+        "kind",
+        "moduleID",
+        "requestID",
+        "turnID",
+        "sequence",
+        "floor",
+        "transcriptProvider",
+        "narration",
+        "context",
+        "events",
+        "provenance"
+      ],
+      "properties": {
+        "contractVersion": {"const": "1.0"},
+        "kind": {"enum": ["turn", "revoke", "end"]},
+        "moduleID": {"$ref": "#/$defs/identifier"},
+        "requestID": {
+          "type": "string",
+          "pattern": "^request_[a-f0-9-]{36}$"
+        },
+        "turnID": {
+          "type": "string",
+          "pattern": "^turn_[a-f0-9-]{36}$"
+        },
+        "sequence": {"type": "integer", "minimum": 1},
+        "floor": {"$ref": "#/$defs/floor"},
+        "transcriptProvider": {
+          "enum": ["typed-keyboard", "onDevice", "syntheticFixture"]
+        },
+        "narration": {"type": "string", "maxLength": 2000},
+        "context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["turns"],
+          "properties": {
+            "turns": {
+              "type": "array",
+              "maxItems": 6,
+              "items": {"$ref": "#/$defs/contextTurn"}
+            }
+          }
+        },
+        "events": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {"$ref": "#/$defs/event"}
+        },
+        "window": {
+          "oneOf": [
+            {"$ref": "#/$defs/window"},
+            {"type": "null"}
+          ]
+        },
+        "provenance": {"$ref": "#/$defs/provenance"}
+      }
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "kind", "summary"],
+      "properties": {
+        "code": {"$ref": "#/$defs/identifier"},
+        "kind": {"enum": ["info", "attention", "error"]},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 240}
+      }
+    },
+    "checkpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpointID", "summary", "confidence"],
+      "properties": {
+        "checkpointID": {
+          "type": "string",
+          "pattern": "^checkpoint_[a-z0-9-]{1,64}$"
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 400},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actionID", "kind", "title", "humanApprovalRequired"],
+      "properties": {
+        "actionID": {
+          "type": "string",
+          "pattern": "^action_[a-z0-9-]{1,64}$"
+        },
+        "kind": {
+          "enum": [
+            "acknowledge-checkpoint",
+            "discard-checkpoint",
+            "review-replay-proposal",
+            "end-module"
+          ]
+        },
+        "title": {"type": "string", "minLength": 1, "maxLength": 120},
+        "humanApprovalRequired": {"const": true}
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contractVersion",
+        "moduleID",
+        "requestID",
+        "turnID",
+        "sequence",
+        "floor",
+        "state",
+        "statuses",
+        "checkpoints",
+        "proposedActions",
+        "provenance"
+      ],
+      "properties": {
+        "contractVersion": {"const": "1.0"},
+        "moduleID": {"$ref": "#/$defs/identifier"},
+        "requestID": {
+          "type": "string",
+          "pattern": "^request_[a-f0-9-]{36}$"
+        },
+        "turnID": {
+          "type": "string",
+          "pattern": "^turn_[a-f0-9-]{36}$"
+        },
+        "sequence": {"type": "integer", "minimum": 1},
+        "floor": {"$ref": "#/$defs/floor"},
+        "state": {
+          "enum": [
+            "idle",
+            "observing",
+            "checkpoint-ready",
+            "awaiting-answer",
+            "completed",
+            "refused"
+          ]
+        },
+        "reply": {"type": "string", "minLength": 1, "maxLength": 4000},
+        "statuses": {
+          "type": "array",
+          "maxItems": 4,
+          "items": {"$ref": "#/$defs/status"}
+        },
+        "checkpoints": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {"$ref": "#/$defs/checkpoint"}
+        },
+        "question": {"type": "string", "minLength": 1, "maxLength": 600},
+        "proposedActions": {
+          "type": "array",
+          "maxItems": 4,
+          "items": {"$ref": "#/$defs/action"}
+        },
+        "provenance": {"$ref": "#/$defs/provenance"}
+      }
+    }
+  }
+}

--- a/prototypes/operations-floater/project.yml
+++ b/prototypes/operations-floater/project.yml
@@ -21,6 +21,8 @@ targets:
         LSApplicationCategoryType: public.app-category.productivity
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
+        NSMicrophoneUsageDescription: Start Voice Conversation uses the microphone only while you explicitly listen.
+        NSSpeechRecognitionUsageDescription: Voice Conversation requires on-device speech recognition and keeps transcripts ephemeral.
     settings:
       base:
         CODE_SIGN_ENTITLEMENTS: OperationsFloater.entitlements


### PR DESCRIPTION
## What changed

- adds a versioned, closed Operations Floater conversation-module contract with a compiled allowlist, one explicit floor, fixed loopback IPC, provenance pinning, and transactional failure handling
- adds the allowlisted synthetic geometry recorder adapter and neutral fixture path while keeping replay, capture, input injection, module UI/mic/TTS/network/persistence, and arbitrary plugin loading disabled
- adds dashboard-owned on-device speech transcription, optional interruptible local TTS, an ephemeral transcript, and exact two-second pause submission
- attributes Router replies only when the Router reports a closed Claude, Codex, or local-LLM identity
- adds an unpinned, nonactivating, single-Desktop background UI test mode
- documents the manifest/envelope bounds, privacy posture, teardown behavior, and background-test limitations

## Why

The merged project-verbal-orders geometry recorder needs one reusable native host for typed/voice conversation without receiving UI, microphone, replay, or persistence authority. The Floater now validates the recorder at a narrow loopback boundary, explicitly grants and revokes the floor, and rolls back on malformed, refused, stale, or provenance-drifted responses.

## Compatibility evidence

- project-verbal-orders exact merged `master`: `5f816b235f0a8c431c3379b5120ab34a25c45a7e`
- exact merged module health digest: `c90caea40147e619049b72c27085335e3dfdbbdc31b93d0369bbe31b4383cbef`
- the host pins the returned health digest dynamically rather than hard-coding a workstation or build

## Validation

- `swift test -j 1 --no-parallel` — 73 tests passed
- `swift build -j 1 -Xswiftc -warnings-as-errors` — passed
- unsigned Release `xcodebuild` with signing disabled — passed
- web privacy contract — 9 tests passed
- web validator — 4 tests passed
- shared contract/publication checks — 15 tests passed
- `git diff --check` and module JSON schema parse — passed
