### PR TITLE
fix(template): submit voice after partial-result silence

### DIFF
--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -105,12 +105,13 @@ snapshot remains schema version `1.0`.
   recognition requires an on-device provider and fails closed when permission,
   provider metadata, or on-device support is unavailable. Start, pause, resume,
   stop, listening, thinking, and responding states remain visible. Optional
-  local spoken replies are default-off and interruptible. Finalized speech is
-  staged immediately as a pending **You** bubble, then follows the same host
-  send path after exactly 2.000 seconds of continuous pause. Resumed speech
-  cancels and restarts that timer. Pause, stop, floor revoke, module switch,
-  clear, and window teardown cancel the pending turn; transcript/session memory
-  is ephemeral.
+  local spoken replies are default-off and interruptible. Each non-empty
+  on-device transcript update is staged immediately as a pending **You**
+  bubble, then follows the same host send path after exactly 2.000 seconds
+  without another update. This does not depend on Apple's optional final-result
+  signal. Resumed speech cancels and restarts that timer. Pause, stop, floor
+  revoke, module switch, clear, and window teardown cancel the pending turn;
+  transcript/session memory is ephemeral.
 - The UI warns that private or patient data must not be entered because an
   already-configured Router escalation may leave the device. Router policy
   remains the authoritative egress guard.

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
@@ -483,9 +483,10 @@ final class VoiceConversationSession: ObservableObject {
             transcriptPreview = stagedText
             onTranscriptStaged?(stagedText)
 
-            guard transcript.isFinal else { return }
             scheduleSubmission(text: stagedText, provider: provider)
-            startEngine()
+            if transcript.isFinal {
+                startEngine()
+            }
         case let .failure(error):
             fail(error)
         }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
@@ -122,6 +122,46 @@ struct ConversationVoiceTests {
         #expect(session.transcriptPreview.isEmpty)
     }
 
+    @Test("A stable partial transcript submits after exactly two seconds")
+    func partialTranscriptLifecycle() async {
+        let engine = SyntheticTranscriptionEngine()
+        let sleeper = ControlledDebounceSleeper()
+        let session = VoiceConversationSession(
+            engine: engine,
+            speechOutput: SyntheticSpeechOutput(),
+            debounceSleeper: { duration in
+                try await sleeper.sleep(for: duration)
+            }
+        )
+        var staged: [String] = []
+        var submitted: (String, ConversationTranscriptProvider)?
+        session.onTranscriptStaged = { staged.append($0) }
+        session.onFinalTranscript = { text, provider in
+            submitted = (text, provider)
+        }
+
+        await session.start()
+        engine.emit(.success(ConversationTranscriptResult(
+            text: "Stable partial narration",
+            isFinal: false
+        )))
+        await waitForSleeper(sleeper, count: 1)
+
+        #expect(staged == ["Stable partial narration"])
+        #expect(session.state == .listening)
+        #expect(session.hasPendingSubmission)
+        #expect(submitted == nil)
+        #expect(await sleeper.requestedDurations() == [.seconds(2)])
+
+        await sleeper.resumeNext()
+        await settle()
+
+        #expect(session.state == .thinking)
+        #expect(submitted?.0 == "Stable partial narration")
+        #expect(submitted?.1 == .syntheticFixture)
+        #expect(!engine.isRunning)
+    }
+
     @Test("Resumed speech cancels and restarts the two-second pause")
     func resumedSpeechRestartsDebounce() async {
         let engine = SyntheticTranscriptionEngine()
@@ -141,24 +181,22 @@ struct ConversationVoiceTests {
         await session.start()
         engine.emit(.success(ConversationTranscriptResult(
             text: "First segment",
-            isFinal: true
-        )))
-        await waitForSleeper(sleeper, count: 1)
-
-        engine.emit(.success(ConversationTranscriptResult(
-            text: "resumed",
             isFinal: false
         )))
-        await settle()
-        #expect(!session.hasPendingSubmission)
-        #expect(submitted.isEmpty)
-        #expect(staged.last == "First segment resumed")
+        await waitForSleeper(sleeper, count: 1)
 
         engine.emit(.success(ConversationTranscriptResult(
-            text: "resumed",
-            isFinal: true
+            text: "First segment resumed",
+            isFinal: false
         )))
-        await waitForSleeper(sleeper, count: 1)
+        await waitForSleeperState(
+            sleeper,
+            requestedCount: 2,
+            activeCount: 1
+        )
+        #expect(session.hasPendingSubmission)
+        #expect(submitted.isEmpty)
+        #expect(staged.last == "First segment resumed")
         #expect(await sleeper.requestedDurations() == [.seconds(2), .seconds(2)])
 
         await sleeper.resumeNext()
@@ -238,6 +276,20 @@ struct ConversationVoiceTests {
     ) async {
         for _ in 0..<100 {
             if await sleeper.activeWaiterCount() == count {
+                return
+            }
+            await Task.yield()
+        }
+    }
+
+    private func waitForSleeperState(
+        _ sleeper: ControlledDebounceSleeper,
+        requestedCount: Int,
+        activeCount: Int
+    ) async {
+        for _ in 0..<100 {
+            if await sleeper.requestedDurations().count == requestedCount,
+               await sleeper.activeWaiterCount() == activeCount {
                 return
             }
             await Task.yield()

--- a/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
+++ b/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
@@ -90,11 +90,13 @@ The host's voice mode is off by default. Start is explicit and may trigger the
 macOS Microphone and Speech Recognition prompts. Production transcription sets
 `requiresOnDeviceRecognition = true` and fails closed if provider metadata or
 on-device support is unavailable. Spoken replies are separately default-off,
-local, and interruptible. Finalized text appears immediately as a pending human
-chat turn and auto-submits after exactly 2.000 seconds of continuous pause.
-Resumed speech cancels and restarts the timer. Pause, stop, floor revoke, module
-switch, clear, and teardown cancel the staged turn. Transcript/session memory is
-in-memory only and is cleared on stop, disable, revoke, or app exit.
+local, and interruptible. Each non-empty transcript update appears immediately
+as a pending human chat turn and auto-submits after exactly 2.000 seconds
+without another update, whether or not the recognition provider emits its
+optional final-result signal. Resumed speech cancels and restarts the timer.
+Pause, stop, floor revoke, module switch, clear, and teardown cancel the staged
+turn. Transcript/session memory is in-memory only and is cleared on stop,
+disable, revoke, or app exit.
 
 Dashboard Router replies are labeled only from bounded Router-reported
 `responder.kind` or `responder.provider` metadata. The accepted identities are


### PR DESCRIPTION
## What changed
- start/restart the host's exact two-second voice pause timer for every non-empty on-device transcript update
- keep Apple's optional final-result signal only for segment rollover, not as a prerequisite for submission
- add deterministic partial-only and resumed-speech regression coverage
- align the native README and conversation-module contract with the actual lifecycle

## Root cause
Apple on-device dictation can leave a stable partial result after ordinary silence. The host staged that text in the UI but only scheduled submission for `isFinal == true`, so the pending **You** turn could wait forever and no recorder request was sent.

## Validation
- focused voice lifecycle: 9/9
- complete Swift suite: 74/74
- warnings-as-errors Swift build
- unsigned Release Xcode build
- web privacy: 9/9
- web validator: 4/4
- shared contract/publication: 15/15
- all declared generator stack stamps, add-on/default checks, shell parses, generator compile, workflow YAML parse
- `git diff --check`

No module capability, Router endpoint, persistence, capture, input injection, signing, deployment, or release behavior changed.
