### PR TITLE
feat(template): add voice countdown and chat timestamps

### DIFF
--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -109,9 +109,10 @@ snapshot remains schema version `1.0`.
   on-device transcript update is staged immediately as a pending **You**
   bubble, then follows the same host send path after exactly 2.000 seconds
   without another update. This does not depend on Apple's optional final-result
-  signal. Resumed speech cancels and restarts that timer. Pause, stop, floor
-  revoke, module switch, clear, and window teardown cancel the pending turn;
-  transcript/session memory is ephemeral.
+  signal. A visible linear countdown resets whenever speech resumes. Every
+  human and assistant bubble shows its local creation time beside the reported
+  sender. Pause, stop, floor revoke, module switch, clear, and window teardown
+  cancel the pending turn; transcript/session memory is ephemeral.
 - The UI warns that private or patient data must not be entered because an
   already-configured Router escalation may leave the device. Router policy
   remains the authoritative egress guard.

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
@@ -8,6 +8,20 @@ struct ConversationTranscriptResult: Equatable, Sendable {
     let isFinal: Bool
 }
 
+struct VoiceSubmissionWindow: Equatable, Sendable {
+    let startedAt: Date
+    let deadline: Date
+
+    func progress(at date: Date) -> Double {
+        let duration = deadline.timeIntervalSince(startedAt)
+        guard duration > 0 else { return 1 }
+        return min(
+            max(date.timeIntervalSince(startedAt) / duration, 0),
+            1
+        )
+    }
+}
+
 enum ConversationVoiceAuthorization: String, Equatable, Sendable {
     case notDetermined
     case denied
@@ -276,12 +290,14 @@ final class LocalConversationSpeechOutput: NSObject, ConversationSpeechOutput,
 
 @MainActor
 final class VoiceConversationSession: ObservableObject {
+    static let submissionPauseSeconds: TimeInterval = 2
     static let submissionPause: Duration = .seconds(2)
 
     @Published private(set) var state: ConversationVoiceState = .off
     @Published private(set) var authorization: ConversationVoiceAuthorization
     @Published private(set) var transcriptPreview = ""
     @Published private(set) var hasPendingSubmission = false
+    @Published private(set) var pendingSubmissionWindow: VoiceSubmissionWindow?
     @Published var spokenRepliesEnabled = false
     @Published private(set) var lastError: String?
 
@@ -292,6 +308,7 @@ final class VoiceConversationSession: ObservableObject {
     private let engine: any ConversationTranscriptionEngine
     private let speechOutput: any ConversationSpeechOutput
     private let debounceSleeper: @Sendable (Duration) async throws -> Void
+    private let now: () -> Date
     private var conversationActive = false
     private var startGeneration = 0
     private var committedSegments: [String] = []
@@ -304,11 +321,13 @@ final class VoiceConversationSession: ObservableObject {
             LocalConversationSpeechOutput(),
         debounceSleeper: @escaping @Sendable (Duration) async throws -> Void = {
             try await Task.sleep(for: $0)
-        }
+        },
+        now: @escaping () -> Date = Date.init
     ) {
         self.engine = engine
         self.speechOutput = speechOutput
         self.debounceSleeper = debounceSleeper
+        self.now = now
         authorization = engine.currentAuthorization()
         installCallbacks()
     }
@@ -380,6 +399,7 @@ final class VoiceConversationSession: ObservableObject {
         pendingSubmissionTask?.cancel()
         pendingSubmissionTask = nil
         hasPendingSubmission = false
+        pendingSubmissionWindow = nil
         engine.stop()
         state = .thinking
     }
@@ -393,6 +413,7 @@ final class VoiceConversationSession: ObservableObject {
         pendingSubmissionTask?.cancel()
         pendingSubmissionTask = nil
         hasPendingSubmission = false
+        pendingSubmissionWindow = nil
         committedSegments = []
         transcriptPreview = ""
         if hadPendingContent {
@@ -473,6 +494,7 @@ final class VoiceConversationSession: ObservableObject {
             pendingSubmissionTask?.cancel()
             pendingSubmissionTask = nil
             hasPendingSubmission = false
+            pendingSubmissionWindow = nil
 
             if transcript.isFinal {
                 committedSegments.append(boundedSegment)
@@ -505,7 +527,12 @@ final class VoiceConversationSession: ObservableObject {
         text: String,
         provider: ConversationTranscriptProvider
     ) {
+        let startedAt = now()
         hasPendingSubmission = true
+        pendingSubmissionWindow = VoiceSubmissionWindow(
+            startedAt: startedAt,
+            deadline: startedAt.addingTimeInterval(Self.submissionPauseSeconds)
+        )
         pendingSubmissionTask = Task { [weak self, debounceSleeper] in
             do {
                 try await debounceSleeper(Self.submissionPause)
@@ -513,6 +540,7 @@ final class VoiceConversationSession: ObservableObject {
                 guard let self, self.conversationActive else { return }
                 self.pendingSubmissionTask = nil
                 self.hasPendingSubmission = false
+                self.pendingSubmissionWindow = nil
                 self.committedSegments = []
                 self.markThinking()
                 self.onFinalTranscript?(text, provider)

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -134,6 +134,7 @@ struct RouterChatMessage: Identifiable, Equatable, Sendable {
     let responder: RouterResponder?
     let module: ConversationModuleAttribution?
     let isPendingVoice: Bool
+    let createdAt: Date
 
     init(
         id: UUID = UUID(),
@@ -141,7 +142,8 @@ struct RouterChatMessage: Identifiable, Equatable, Sendable {
         text: String,
         responder: RouterResponder? = nil,
         module: ConversationModuleAttribution? = nil,
-        isPendingVoice: Bool = false
+        isPendingVoice: Bool = false,
+        createdAt: Date = Date()
     ) {
         self.id = id
         self.role = role
@@ -149,6 +151,7 @@ struct RouterChatMessage: Identifiable, Equatable, Sendable {
         self.responder = responder
         self.module = module
         self.isPendingVoice = isPendingVoice
+        self.createdAt = createdAt
     }
 }
 
@@ -669,7 +672,8 @@ final class RouterChatSession: ObservableObject {
                 id: messageID,
                 role: .user,
                 text: text,
-                isPendingVoice: true
+                isPendingVoice: true,
+                createdAt: messages[index].createdAt
             )
         } else {
             let message = RouterChatMessage(
@@ -707,7 +711,8 @@ final class RouterChatSession: ObservableObject {
                 id: messageID,
                 role: .user,
                 text: text,
-                isPendingVoice: false
+                isPendingVoice: false,
+                createdAt: messages[index].createdAt
             )
             pendingVoiceMessageID = nil
         } else {
@@ -910,7 +915,8 @@ final class RouterChatSession: ObservableObject {
                     text: text,
                     responder: message.responder,
                     module: nil,
-                    isPendingVoice: false
+                    isPendingVoice: false,
+                    createdAt: message.createdAt
                 )
             )
             remaining -= text.count
@@ -1209,10 +1215,26 @@ struct RouterChatPanel: View {
                 .foregroundStyle(.orange)
             }
 
-            if voice.hasPendingSubmission {
-                Text("Voice turn staged · sends after 2.000 seconds of continuous pause")
+            if let submissionWindow = voice.pendingSubmissionWindow {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack {
+                        Text("Quiet-time countdown")
+                        Spacer()
+                        Text("2.000 seconds")
+                            .monospacedDigit()
+                    }
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
+
+                    TimelineView(.animation(minimumInterval: 0.05)) { context in
+                        ProgressView(value: submissionWindow.progress(at: context.date))
+                            .progressViewStyle(.linear)
+                            .accessibilityLabel("Quiet-time submission countdown")
+                            .accessibilityValue(
+                                "\(Int(submissionWindow.progress(at: context.date) * 100)) percent"
+                            )
+                    }
+                }
             }
 
             Text(
@@ -1466,11 +1488,7 @@ struct RouterChatPanel: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 7) {
                     if message.role == .user {
-                        Text(
-                            message.isPendingVoice
-                                ? "You · waiting for 2s pause"
-                                : "You"
-                        )
+                        Text("You")
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundStyle(
                                 message.isPendingVoice ? Color.orange : Color.secondary
@@ -1490,6 +1508,18 @@ struct RouterChatPanel: View {
                     }
                     if message.role == .assistant, message.module == nil {
                         reviewControl(message)
+                    }
+                    Text(message.createdAt, style: .time)
+                        .font(.system(size: 9))
+                        .monospacedDigit()
+                        .foregroundStyle(.tertiary)
+                        .accessibilityLabel(
+                            "Sent at \(message.createdAt.formatted(date: .omitted, time: .shortened))"
+                        )
+                    if message.isPendingVoice {
+                        Text("waiting for quiet")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.orange)
                     }
                 }
                 Text(message.text)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationVoiceTests.swift
@@ -80,12 +80,14 @@ struct ConversationVoiceTests {
     func syntheticTranscriptLifecycle() async {
         let engine = SyntheticTranscriptionEngine()
         let sleeper = ControlledDebounceSleeper()
+        let startedAt = Date(timeIntervalSince1970: 1_000)
         let session = VoiceConversationSession(
             engine: engine,
             speechOutput: SyntheticSpeechOutput(),
             debounceSleeper: { duration in
                 try await sleeper.sleep(for: duration)
-            }
+            },
+            now: { startedAt }
         )
         var staged: [String] = []
         var submitted: (String, ConversationTranscriptProvider)?
@@ -104,6 +106,13 @@ struct ConversationVoiceTests {
         #expect(staged == ["Synthetic narration"])
         #expect(session.state == .listening)
         #expect(session.hasPendingSubmission)
+        #expect(
+            session.pendingSubmissionWindow
+                == VoiceSubmissionWindow(
+                    startedAt: startedAt,
+                    deadline: startedAt.addingTimeInterval(2)
+                )
+        )
         #expect(submitted == nil)
         #expect(await sleeper.requestedDurations() == [.seconds(2)])
 
@@ -114,12 +123,26 @@ struct ConversationVoiceTests {
         #expect(submitted?.0 == "Synthetic narration")
         #expect(submitted?.1 == .syntheticFixture)
         #expect(!engine.isRunning)
+        #expect(session.pendingSubmissionWindow == nil)
 
         session.handleReplyFailure()
         #expect(session.state == .listening)
         session.stop()
         #expect(session.state == .off)
         #expect(session.transcriptPreview.isEmpty)
+    }
+
+    @Test("Quiet-time progress is bounded before, during, and after two seconds")
+    func quietTimeProgressIsBounded() {
+        let startedAt = Date(timeIntervalSince1970: 2_000)
+        let window = VoiceSubmissionWindow(
+            startedAt: startedAt,
+            deadline: startedAt.addingTimeInterval(2)
+        )
+
+        #expect(window.progress(at: startedAt.addingTimeInterval(-1)) == 0)
+        #expect(window.progress(at: startedAt.addingTimeInterval(1)) == 0.5)
+        #expect(window.progress(at: startedAt.addingTimeInterval(3)) == 1)
     }
 
     @Test("A stable partial transcript submits after exactly two seconds")
@@ -232,6 +255,7 @@ struct ConversationVoiceTests {
 
         #expect(session.state == .paused)
         #expect(!session.hasPendingSubmission)
+        #expect(session.pendingSubmissionWindow == nil)
         #expect(session.transcriptPreview.isEmpty)
         #expect(cancelled == 1)
         #expect(submitted == 0)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -361,6 +361,7 @@ struct RouterChatClientTests {
         #expect(context.count == 8)
         #expect(context.reduce(0) { $0 + $1.text.count } == 24_000)
         #expect(context.last?.id == messages.last?.id)
+        #expect(context.last?.createdAt == messages.last?.createdAt)
     }
 }
 
@@ -594,6 +595,10 @@ struct RouterChatSessionTests {
         #expect(session.messages.count == 1)
         #expect(session.messages.first?.role == .user)
         #expect(session.messages.first?.isPendingVoice == true)
+        let stagedAt = session.messages.first?.createdAt
+
+        session.stageVoiceTranscript("Synthetic voice narration")
+        #expect(session.messages.first?.createdAt == stagedAt)
 
         session.send(
             text: "Synthetic voice narration",
@@ -604,6 +609,7 @@ struct RouterChatSessionTests {
         #expect(session.messages.count == 2)
         #expect(session.messages.first?.isPendingVoice == false)
         #expect(session.messages.first?.text == "Synthetic voice narration")
+        #expect(session.messages.first?.createdAt == stagedAt)
         #expect(session.messages.last?.responder?.displayName == "local-LLM")
     }
 

--- a/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
+++ b/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
@@ -93,10 +93,11 @@ on-device support is unavailable. Spoken replies are separately default-off,
 local, and interruptible. Each non-empty transcript update appears immediately
 as a pending human chat turn and auto-submits after exactly 2.000 seconds
 without another update, whether or not the recognition provider emits its
-optional final-result signal. Resumed speech cancels and restarts the timer.
-Pause, stop, floor revoke, module switch, clear, and teardown cancel the staged
-turn. Transcript/session memory is in-memory only and is cleared on stop,
-disable, revoke, or app exit.
+optional final-result signal. A visible linear countdown covers that exact
+window and resets when speech resumes. Human and assistant bubbles show their
+local creation time beside the sender attribution. Pause, stop, floor revoke,
+module switch, clear, and teardown cancel the staged turn. Transcript/session
+memory is in-memory only and is cleared on stop, disable, revoke, or app exit.
 
 Dashboard Router replies are labeled only from bounded Router-reported
 `responder.kind` or `responder.provider` metadata. The accepted identities are


### PR DESCRIPTION
## What changed
- show a live linear bar for the exact 2.000-second quiet-time submission window
- reset and cancel that visual window with the existing voice lifecycle
- show local creation time beside every human and assistant sender label
- preserve the first staged voice timestamp through partial updates and final submission
- document the interaction and add deterministic lifecycle/unit coverage

## Why
The voice UI previously said it was waiting for two seconds without showing elapsed progress, and chat attribution omitted message times. This makes the hands-free geometry-recorder conversation legible without changing routing, persistence, privacy, or microphone policy.

## Validation
- `swift test` — 75/75
- `swift build -Xswiftc -warnings-as-errors`
- unsigned Release `xcodebuild`
- web privacy 9/9
- web validator 4/4
- shared contract/publication 15/15
- all three generator stacks, generated shell syntax, Python compile, token-leak guard, diff check
- bounded added-line credential-pattern scan

No signing, deployment, release, telemetry, private data, or production state change.