### PR TITLE
feat(template): add selected-window relative XY recorder

### DIFF
--- a/prototypes/operations-floater/OperationsFloater.entitlements
+++ b/prototypes/operations-floater/OperationsFloater.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */; };
+		9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */; };
 		A705BC6F0D3A543F75D84535 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D7388421B1A4219EF55A7B2 /* Assets.xcassets */; };
 		B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */; };
 		C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */; };
@@ -27,6 +28,7 @@
 		62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsFloaterApp.swift; sourceTree = "<group>"; };
 		675EB43F01F9FDA3CC6763B1 /* ConversationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationModule.swift; sourceTree = "<group>"; };
 		6D7388421B1A4219EF55A7B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeutralGeometryCapture.swift; sourceTree = "<group>"; };
 		A37B6D58036BC8B9F8A47688 /* ConversationVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationVoice.swift; sourceTree = "<group>"; };
 		CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -49,6 +51,7 @@
 				02D2103622C4FB3754F316FE /* DashboardContract.swift */,
 				36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */,
 				CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */,
+				98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */,
 				62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */,
 				4A9DF97AD77E17679BD52803 /* QueueRace.swift */,
 				42AF18361984088F8616CB04 /* RouterChat.swift */,
@@ -140,6 +143,7 @@
 				FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */,
 				C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */,
 				2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */,
+				9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */,
 				B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */,
 				C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */,
 				C8B57BCE1270FE6351B6218A /* RouterChat.swift in Sources */,

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -95,12 +95,22 @@ snapshot remains schema version `1.0`.
   draft, while **Shift-Return** inserts a newline without contacting the
   Router. The same behavior is exposed as an accessibility hint.
 - A compiled static module allowlist can give exactly one bounded conversation
-  module the floor. Modules provide no UI, mic, TTS, persistence, capture,
+  module the floor. Modules provide no UI, mic, TTS, persistence, screen capture,
   input injection, executable replay, arbitrary network, or dynamic code.
   Escape or **Return to dashboard** revokes the floor. The built-in synthetic
   checkpoint module provides deterministic contract testing; the geometry
   recorder adapter uses only fixed loopback IPC and neutral synthetic fixture
   events.
+- The optional **Relative XY recorder** lets the user select any one visible
+  window, then pairs dashboard voice narration with that window's complete
+  mouse, scroll, and key-code event stream. Coordinates are normalized to the
+  selected window. The host retains its exact process/window binding in memory
+  only and rejects events when that window loses the active/topmost binding.
+  It never reads pixels, OCR, window titles, URLs, clipboard data, or printable
+  characters. Recording is explicit, memory-only until **Stop & review**, and
+  export uses a user-selected local JSON file. It contains no replay or input
+  injection path. Calculator and Chess are neutral practice examples, not an
+  application allowlist.
 - Voice conversation is separately explicit and default-off. Production speech
   recognition requires an on-device provider and fails closed when permission,
   provider metadata, or on-device support is unavailable. Start, pause, resume,

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationModule.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationModule.swift
@@ -25,6 +25,8 @@ enum ConversationModuleCapability: String, Codable, CaseIterable, Sendable {
     case narration
     case normalizedPointerEvents = "normalized-pointer-events"
     case navigationKeys = "navigation-keys"
+    case rawKeyboardEvents = "raw-keyboard-events"
+    case scrollEvents = "scroll-events"
     case placeholderEvents = "placeholder-events"
     case neutralWindowContext = "neutral-window-context"
     case checkpoints
@@ -219,6 +221,12 @@ enum ConversationPointerPhase: String, Codable, Sendable {
     case drag
 }
 
+enum ConversationKeyPhase: String, Codable, Sendable {
+    case down
+    case up
+    case flagsChanged = "flags-changed"
+}
+
 enum ConversationNavigationKey: String, Codable, Sendable {
     case tab
     case returnKey = "return"
@@ -240,6 +248,8 @@ enum ConversationPlaceholderKind: String, Codable, Sendable {
 enum ConversationModuleEventKind: String, Codable, Sendable {
     case normalizedPointer = "normalized-pointer"
     case navigationKey = "navigation-key"
+    case rawKeyboard = "raw-keyboard"
+    case scroll
     case placeholder
 }
 
@@ -251,7 +261,48 @@ struct ConversationModuleEvent: Codable, Equatable, Sendable {
     let normalizedX: Double?
     let normalizedY: Double?
     let navigationKey: ConversationNavigationKey?
+    let keyPhase: ConversationKeyPhase?
+    let keyCode: Int?
+    let modifierFlags: UInt64?
+    let buttonNumber: Int?
+    let scrollDeltaX: Double?
+    let scrollDeltaY: Double?
+    let elapsedMilliseconds: Int?
     let placeholder: ConversationPlaceholderKind?
+
+    init(
+        eventID: String,
+        sequence: Int,
+        kind: ConversationModuleEventKind,
+        pointerPhase: ConversationPointerPhase? = nil,
+        normalizedX: Double? = nil,
+        normalizedY: Double? = nil,
+        navigationKey: ConversationNavigationKey? = nil,
+        keyPhase: ConversationKeyPhase? = nil,
+        keyCode: Int? = nil,
+        modifierFlags: UInt64? = nil,
+        buttonNumber: Int? = nil,
+        scrollDeltaX: Double? = nil,
+        scrollDeltaY: Double? = nil,
+        elapsedMilliseconds: Int? = nil,
+        placeholder: ConversationPlaceholderKind? = nil
+    ) {
+        self.eventID = eventID
+        self.sequence = sequence
+        self.kind = kind
+        self.pointerPhase = pointerPhase
+        self.normalizedX = normalizedX
+        self.normalizedY = normalizedY
+        self.navigationKey = navigationKey
+        self.keyPhase = keyPhase
+        self.keyCode = keyCode
+        self.modifierFlags = modifierFlags
+        self.buttonNumber = buttonNumber
+        self.scrollDeltaX = scrollDeltaX
+        self.scrollDeltaY = scrollDeltaY
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.placeholder = placeholder
+    }
 
     func validate() throws {
         guard eventID.range(
@@ -269,6 +320,11 @@ struct ConversationModuleEvent: Codable, Equatable, Sendable {
                   (0...1).contains(normalizedX),
                   (0...1).contains(normalizedY),
                   navigationKey == nil,
+                  keyPhase == nil,
+                  keyCode == nil,
+                  buttonNumber.map({ (0...31).contains($0) }) ?? true,
+                  scrollDeltaX == nil,
+                  scrollDeltaY == nil,
                   placeholder == nil else {
                 throw ConversationModuleError.invalidEvent
             }
@@ -277,6 +333,47 @@ struct ConversationModuleEvent: Codable, Equatable, Sendable {
                   pointerPhase == nil,
                   normalizedX == nil,
                   normalizedY == nil,
+                  keyPhase == nil,
+                  keyCode == nil,
+                  buttonNumber == nil,
+                  scrollDeltaX == nil,
+                  scrollDeltaY == nil,
+                  placeholder == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        case .rawKeyboard:
+            guard keyPhase != nil,
+                  let keyCode,
+                  (0...255).contains(keyCode),
+                  modifierFlags != nil,
+                  pointerPhase == nil,
+                  normalizedX == nil,
+                  normalizedY == nil,
+                  navigationKey == nil,
+                  buttonNumber == nil,
+                  scrollDeltaX == nil,
+                  scrollDeltaY == nil,
+                  placeholder == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        case .scroll:
+            guard pointerPhase == nil,
+                  let normalizedX,
+                  let normalizedY,
+                  normalizedX.isFinite,
+                  normalizedY.isFinite,
+                  (0...1).contains(normalizedX),
+                  (0...1).contains(normalizedY),
+                  let scrollDeltaX,
+                  let scrollDeltaY,
+                  scrollDeltaX.isFinite,
+                  scrollDeltaY.isFinite,
+                  abs(scrollDeltaX) <= 10_000,
+                  abs(scrollDeltaY) <= 10_000,
+                  navigationKey == nil,
+                  keyPhase == nil,
+                  keyCode == nil,
+                  buttonNumber == nil,
                   placeholder == nil else {
                 throw ConversationModuleError.invalidEvent
             }
@@ -285,7 +382,17 @@ struct ConversationModuleEvent: Codable, Equatable, Sendable {
                   pointerPhase == nil,
                   normalizedX == nil,
                   normalizedY == nil,
-                  navigationKey == nil else {
+                  navigationKey == nil,
+                  keyPhase == nil,
+                  keyCode == nil,
+                  buttonNumber == nil,
+                  scrollDeltaX == nil,
+                  scrollDeltaY == nil else {
+                throw ConversationModuleError.invalidEvent
+            }
+        }
+        if let elapsedMilliseconds {
+            guard (0...86_400_000).contains(elapsedMilliseconds) else {
                 throw ConversationModuleError.invalidEvent
             }
         }
@@ -377,6 +484,14 @@ struct ConversationModuleRequest: Codable, Equatable, Sendable {
                 }
             case .navigationKey:
                 guard manifest.capabilities.contains(.navigationKeys) else {
+                    throw ConversationModuleError.capabilityRejected
+                }
+            case .rawKeyboard:
+                guard manifest.capabilities.contains(.rawKeyboardEvents) else {
+                    throw ConversationModuleError.capabilityRejected
+                }
+            case .scroll:
+                guard manifest.capabilities.contains(.scrollEvents) else {
                     throw ConversationModuleError.capabilityRejected
                 }
             case .placeholder:
@@ -749,6 +864,28 @@ enum ConversationModuleAllowlist {
         ]
     )
 
+    static let relativeXYRecorderManifest = ConversationModuleManifest(
+        contractVersion: ConversationModuleContract.version,
+        moduleID: "auggie.verbal-orders.relative-xy-recorder",
+        displayName: "Relative XY recorder",
+        capabilities: [
+            .narration,
+            .normalizedPointerEvents,
+            .navigationKeys,
+            .rawKeyboardEvents,
+            .scrollEvents,
+            .neutralWindowContext,
+            .checkpoints,
+            .proposedActions,
+        ],
+        privacy: .hostControlled,
+        provenanceSourceID: "auggie.project-verbal-orders.relative-xy-recorder",
+        allowedTranscriptProviders: [.onDevice, .syntheticFixture],
+        allowedWindowBindingIDs: [
+            "verbal-orders.neutral.selected-window",
+        ]
+    )
+
     static func liveRegistrations() -> [ConversationModuleRegistration] {
         [
             ConversationModuleRegistration(
@@ -757,6 +894,10 @@ enum ConversationModuleAllowlist {
             ),
             ConversationModuleRegistration(
                 manifest: geometryRecorderManifest,
+                transport: LoopbackConversationModuleClient()
+            ),
+            ConversationModuleRegistration(
+                manifest: relativeXYRecorderManifest,
                 transport: LoopbackConversationModuleClient()
             ),
         ]

--- a/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ConversationVoice.swift
@@ -116,6 +116,7 @@ final class OnDeviceConversationTranscriber: NSObject, ConversationTranscription
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var recognitionGeneration = 0
+    private var tapInstalled = false
 
     init(locale: Locale = Locale(identifier: "en_US")) {
         recognizer = SFSpeechRecognizer(locale: locale)
@@ -192,12 +193,14 @@ final class OnDeviceConversationTranscriber: NSObject, ConversationTranscription
             [weak self] buffer, _ in
             self?.request?.append(buffer)
         }
+        tapInstalled = true
 
         audioEngine.prepare()
         do {
             try audioEngine.start()
         } catch {
             input.removeTap(onBus: 0)
+            tapInstalled = false
             self.request = nil
             throw ConversationVoiceError.audioUnavailable
         }
@@ -236,7 +239,10 @@ final class OnDeviceConversationTranscriber: NSObject, ConversationTranscription
         if audioEngine.isRunning {
             audioEngine.stop()
         }
-        audioEngine.inputNode.removeTap(onBus: 0)
+        if tapInstalled {
+            audioEngine.inputNode.removeTap(onBus: 0)
+            tapInstalled = false
+        }
         request = nil
         recognitionTask = nil
         isRunning = false

--- a/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
@@ -1,0 +1,787 @@
+import AppKit
+import Combine
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+enum NeutralGeometryCaptureMode: String, Codable, Sendable {
+    case disarmed
+    case armed
+    case recording
+    case paused
+    case review
+
+    var displayName: String { rawValue.uppercased() }
+}
+
+struct NeutralGeometryWindow: Identifiable, Equatable, Sendable {
+    let id: CGWindowID
+    let ownerPID: pid_t
+    let ownerName: String
+    let bounds: CGRect
+
+    var displayName: String {
+        "\(ownerName) · \(Int(bounds.width))×\(Int(bounds.height))"
+    }
+}
+
+struct NeutralGeometryCaptureSnapshot: Equatable, Sendable {
+    let events: [ConversationModuleEvent]
+    let window: ConversationModuleWindowContext
+}
+
+struct NeutralGeometryCaptureExport: Codable, Equatable, Sendable {
+    static let schema = "operations-floater-relative-xy-capture/v1"
+
+    struct Event: Codable, Equatable, Sendable {
+        let ordinal: Int
+        let kind: ConversationModuleEventKind
+        let pointerPhase: ConversationPointerPhase?
+        let normalizedX: Double?
+        let normalizedY: Double?
+        let keyPhase: ConversationKeyPhase?
+        let keyCode: Int?
+        let modifierFlags: UInt64?
+        let buttonNumber: Int?
+        let scrollDeltaX: Double?
+        let scrollDeltaY: Double?
+        let elapsedMilliseconds: Int?
+    }
+
+    let schema: String
+    let moduleID: String
+    let windowBindingID: String
+    let windowWidth: Int
+    let windowHeight: Int
+    let eventCount: Int
+    let droppedEventCount: Int
+    let provenanceSourceID: String
+    let buildDigest: String
+    let selectedWindowIdentityPersisted: Bool
+    let charactersRecovered: Bool
+    let screenCaptureUsed: Bool
+    let ocrUsed: Bool
+    let events: [Event]
+}
+
+enum NeutralGeometryCaptureError: LocalizedError, Equatable {
+    case noWindow
+    case windowChanged
+    case inputMonitoringRequired
+    case reviewRequired
+    case noEvents
+    case invalidProvenance
+
+    var errorDescription: String? {
+        switch self {
+        case .noWindow:
+            "Select one visible window before recording."
+        case .windowChanged:
+            "The selected window changed or is no longer the active window."
+        case .inputMonitoringRequired:
+            "Allow Operations Floater in Privacy & Security → Input Monitoring, then retry."
+        case .reviewRequired:
+            "Stop the recorder before exporting."
+        case .noEvents:
+            "No selected-window input events are available to export."
+        case .invalidProvenance:
+            "The relative XY module provenance is unavailable or invalid."
+        }
+    }
+}
+
+struct NeutralGeometryRawEvent: Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case pointer(ConversationPointerPhase, Int)
+        case scroll(Double, Double)
+        case key(ConversationKeyPhase, Int, UInt64)
+    }
+
+    let kind: Kind
+    let location: CGPoint?
+    let timestampNanoseconds: UInt64
+}
+
+enum NeutralGeometryWindowCatalog {
+    static func visibleWindows(
+        excludingPID: pid_t = ProcessInfo.processInfo.processIdentifier
+    ) -> [NeutralGeometryWindow] {
+        guard let values = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return []
+        }
+        return values.compactMap { value in
+            guard let number = value[kCGWindowNumber as String] as? NSNumber,
+                  let pid = value[kCGWindowOwnerPID as String] as? NSNumber,
+                  let layer = value[kCGWindowLayer as String] as? NSNumber,
+                  let owner = value[kCGWindowOwnerName as String] as? String,
+                  let boundsValue = value[kCGWindowBounds as String]
+                    as? [String: Any],
+                  let bounds = CGRect(
+                      dictionaryRepresentation: boundsValue as CFDictionary
+                  ),
+                  layer.intValue == 0,
+                  pid.int32Value != excludingPID,
+                  bounds.width >= 100,
+                  bounds.height >= 100 else {
+                return nil
+            }
+            return NeutralGeometryWindow(
+                id: CGWindowID(number.uint32Value),
+                ownerPID: pid.int32Value,
+                ownerName: owner,
+                bounds: bounds
+            )
+        }
+    }
+
+    static func currentWindow(
+        matching selected: NeutralGeometryWindow
+    ) -> NeutralGeometryWindow? {
+        visibleWindows().first {
+            $0.id == selected.id && $0.ownerPID == selected.ownerPID
+        }
+    }
+
+    static func isActive(_ selected: NeutralGeometryWindow) -> Bool {
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier
+                == selected.ownerPID,
+              let firstForOwner = visibleWindows().first(where: {
+                  $0.ownerPID == selected.ownerPID
+              }) else {
+            return false
+        }
+        return firstForOwner.id == selected.id
+    }
+
+    static func isTopmostAtPoint(
+        _ selected: NeutralGeometryWindow,
+        point: CGPoint
+    ) -> Bool {
+        guard selected.bounds.contains(point),
+              let values = CGWindowListCopyWindowInfo(
+                  [.optionOnScreenOnly, .excludeDesktopElements],
+                  kCGNullWindowID
+              ) as? [[String: Any]] else {
+            return false
+        }
+        for value in values {
+            guard let number = value[kCGWindowNumber as String] as? NSNumber,
+                  let layer = value[kCGWindowLayer as String] as? NSNumber,
+                  let boundsValue = value[kCGWindowBounds as String]
+                    as? [String: Any],
+                  let bounds = CGRect(
+                      dictionaryRepresentation: boundsValue as CFDictionary
+                  ),
+                  layer.intValue >= 0,
+                  bounds.contains(point) else {
+                continue
+            }
+            return CGWindowID(number.uint32Value) == selected.id
+        }
+        return false
+    }
+}
+
+@MainActor
+final class NeutralGeometryCaptureSession: ObservableObject {
+    static let moduleID = "auggie.verbal-orders.relative-xy-recorder"
+    static let bindingID = "verbal-orders.neutral.selected-window"
+    static let maximumSessionEvents = 4_096
+    static let moveCoalescingDistance = 0.0025
+
+    @Published private(set) var mode: NeutralGeometryCaptureMode = .disarmed
+    @Published private(set) var availableWindows: [NeutralGeometryWindow] = []
+    @Published private(set) var selectedWindow: NeutralGeometryWindow?
+    @Published private(set) var capturedEvents: [ConversationModuleEvent] = []
+    @Published private(set) var deliveredEventCount = 0
+    @Published private(set) var droppedEventCount = 0
+    @Published private(set) var lastError: String?
+    @Published private(set) var inputMonitoringAvailable = false
+
+    private var monitor: Any?
+    private var startNanoseconds: UInt64?
+    private var nextEventOrdinal = 1
+
+    var pendingEventCount: Int {
+        max(0, capturedEvents.count - deliveredEventCount)
+    }
+
+    var canExport: Bool {
+        mode == .review && !capturedEvents.isEmpty
+    }
+
+    init() {
+        refreshWindows()
+        inputMonitoringAvailable = CGPreflightListenEventAccess()
+    }
+
+    func refreshWindows() {
+        availableWindows = NeutralGeometryWindowCatalog.visibleWindows()
+        if let selectedWindow,
+           let refreshed = availableWindows.first(where: {
+               $0.id == selectedWindow.id && $0.ownerPID == selectedWindow.ownerPID
+           }) {
+            self.selectedWindow = refreshed
+        } else if selectedWindow != nil {
+            revoke(reason: NeutralGeometryCaptureError.windowChanged.localizedDescription)
+        }
+    }
+
+    func select(windowID: CGWindowID) {
+        guard let window = availableWindows.first(where: { $0.id == windowID }) else {
+            lastError = NeutralGeometryCaptureError.noWindow.localizedDescription
+            return
+        }
+        stopMonitor()
+        capturedEvents = []
+        deliveredEventCount = 0
+        droppedEventCount = 0
+        nextEventOrdinal = 1
+        selectedWindow = window
+        mode = .armed
+        lastError = nil
+    }
+
+    func requestInputMonitoring() {
+        inputMonitoringAvailable =
+            CGPreflightListenEventAccess() || CGRequestListenEventAccess()
+        if !inputMonitoringAvailable {
+            lastError =
+                NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
+        }
+    }
+
+    func start() {
+        guard selectedWindow != nil else {
+            lastError = NeutralGeometryCaptureError.noWindow.localizedDescription
+            return
+        }
+        inputMonitoringAvailable = CGPreflightListenEventAccess()
+        guard inputMonitoringAvailable else {
+            lastError =
+                NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
+            return
+        }
+        guard installMonitor() else {
+            lastError =
+                NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
+            return
+        }
+        startNanoseconds = DispatchTime.now().uptimeNanoseconds
+        mode = .recording
+        lastError = nil
+    }
+
+    func pause() {
+        guard mode == .recording else { return }
+        stopMonitor()
+        mode = .paused
+    }
+
+    func resume() {
+        guard mode == .paused else { return }
+        start()
+    }
+
+    func stop() {
+        guard mode == .recording || mode == .paused else { return }
+        stopMonitor()
+        mode = .review
+    }
+
+    func revoke(reason: String? = nil) {
+        stopMonitor()
+        mode = .disarmed
+        selectedWindow = nil
+        availableWindows = []
+        capturedEvents = []
+        deliveredEventCount = 0
+        droppedEventCount = 0
+        nextEventOrdinal = 1
+        startNanoseconds = nil
+        lastError = reason
+    }
+
+    func snapshot() throws -> NeutralGeometryCaptureSnapshot {
+        guard let selected = selectedWindow,
+              let current = NeutralGeometryWindowCatalog.currentWindow(
+                  matching: selected
+              ) else {
+            throw NeutralGeometryCaptureError.windowChanged
+        }
+        let pending = Array(capturedEvents.dropFirst(deliveredEventCount))
+        let bounded = Array(pending.suffix(ConversationModuleContract.maximumEvents))
+        return NeutralGeometryCaptureSnapshot(
+            events: reindexed(bounded),
+            window: ConversationModuleWindowContext(
+                bindingID: Self.bindingID,
+                width: min(8_192, max(100, Int(current.bounds.width.rounded()))),
+                height: min(8_192, max(100, Int(current.bounds.height.rounded())))
+            )
+        )
+    }
+
+    func accept(
+        _ snapshot: NeutralGeometryCaptureSnapshot,
+        narration: String,
+        response: ConversationModuleResponse
+    ) {
+        deliveredEventCount = capturedEvents.count
+        let words = narration
+            .lowercased()
+            .split(whereSeparator: { !$0.isLetter })
+            .map(String.init)
+        if response.state == .completed || words == ["stop", "recording"] {
+            stop()
+        } else if words == ["pause", "recording"] {
+            pause()
+        } else if words == ["resume", "recording"], mode == .paused {
+            resume()
+        }
+        lastError = nil
+    }
+
+    func preserveAfterFailure(_ error: Error) {
+        lastError = error.localizedDescription
+    }
+
+    func exportData(provenance: ConversationModuleProvenance) throws -> Data {
+        guard mode == .review else {
+            throw NeutralGeometryCaptureError.reviewRequired
+        }
+        guard let selectedWindow, !capturedEvents.isEmpty else {
+            throw NeutralGeometryCaptureError.noEvents
+        }
+        do {
+            try provenance.validate(
+                expectedSourceID:
+                    "auggie.project-verbal-orders.relative-xy-recorder"
+            )
+        } catch {
+            throw NeutralGeometryCaptureError.invalidProvenance
+        }
+        let value = NeutralGeometryCaptureExport(
+            schema: NeutralGeometryCaptureExport.schema,
+            moduleID: Self.moduleID,
+            windowBindingID: Self.bindingID,
+            windowWidth: Int(selectedWindow.bounds.width.rounded()),
+            windowHeight: Int(selectedWindow.bounds.height.rounded()),
+            eventCount: capturedEvents.count,
+            droppedEventCount: droppedEventCount,
+            provenanceSourceID: provenance.sourceID,
+            buildDigest: provenance.buildDigest,
+            selectedWindowIdentityPersisted: false,
+            charactersRecovered: false,
+            screenCaptureUsed: false,
+            ocrUsed: false,
+            events: capturedEvents.enumerated().map { index, event in
+                NeutralGeometryCaptureExport.Event(
+                    ordinal: index + 1,
+                    kind: event.kind,
+                    pointerPhase: event.pointerPhase,
+                    normalizedX: event.normalizedX,
+                    normalizedY: event.normalizedY,
+                    keyPhase: event.keyPhase,
+                    keyCode: event.keyCode,
+                    modifierFlags: event.modifierFlags,
+                    buttonNumber: event.buttonNumber,
+                    scrollDeltaX: event.scrollDeltaX,
+                    scrollDeltaY: event.scrollDeltaY,
+                    elapsedMilliseconds: event.elapsedMilliseconds
+                )
+            }
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(value)
+    }
+
+    func ingestForTesting(_ raw: NeutralGeometryRawEvent) {
+        ingest(raw)
+    }
+
+    static func makeEvent(
+        from raw: NeutralGeometryRawEvent,
+        bounds: CGRect,
+        pointerIsTopmost: Bool,
+        keyWindowIsActive: Bool,
+        eventID: String = "event_input-test",
+        elapsedMilliseconds: Int = 0
+    ) -> ConversationModuleEvent? {
+        switch raw.kind {
+        case let .pointer(phase, button):
+            guard pointerIsTopmost,
+                  let location = raw.location,
+                  let point = normalized(location, within: bounds) else {
+                return nil
+            }
+            return ConversationModuleEvent(
+                eventID: eventID,
+                sequence: 1,
+                kind: .normalizedPointer,
+                pointerPhase: phase,
+                normalizedX: point.x,
+                normalizedY: point.y,
+                buttonNumber: button,
+                elapsedMilliseconds: elapsedMilliseconds
+            )
+        case let .scroll(deltaX, deltaY):
+            guard pointerIsTopmost,
+                  let location = raw.location,
+                  let point = normalized(location, within: bounds) else {
+                return nil
+            }
+            return ConversationModuleEvent(
+                eventID: eventID,
+                sequence: 1,
+                kind: .scroll,
+                normalizedX: point.x,
+                normalizedY: point.y,
+                scrollDeltaX: deltaX,
+                scrollDeltaY: deltaY,
+                elapsedMilliseconds: elapsedMilliseconds
+            )
+        case let .key(phase, code, modifiers):
+            guard keyWindowIsActive else { return nil }
+            return ConversationModuleEvent(
+                eventID: eventID,
+                sequence: 1,
+                kind: .rawKeyboard,
+                keyPhase: phase,
+                keyCode: code,
+                modifierFlags: modifiers,
+                elapsedMilliseconds: elapsedMilliseconds
+            )
+        }
+    }
+
+    private func installMonitor() -> Bool {
+        if monitor != nil { return true }
+        let mask: NSEvent.EventTypeMask = [
+            .mouseMoved,
+            .leftMouseDown, .leftMouseUp,
+            .rightMouseDown, .rightMouseUp,
+            .otherMouseDown, .otherMouseUp,
+            .leftMouseDragged, .rightMouseDragged, .otherMouseDragged,
+            .scrollWheel,
+            .keyDown, .keyUp, .flagsChanged,
+        ]
+        monitor = NSEvent.addGlobalMonitorForEvents(matching: mask) {
+            [weak self] event in
+            let raw = Self.rawEvent(from: event)
+            guard let raw else { return }
+            DispatchQueue.main.async {
+                self?.ingest(raw)
+            }
+        }
+        return monitor != nil
+    }
+
+    private func stopMonitor() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+
+    private static func rawEvent(from event: NSEvent) -> NeutralGeometryRawEvent? {
+        let timestamp = DispatchTime.now().uptimeNanoseconds
+        switch event.type {
+        case .mouseMoved:
+            return .init(
+                kind: .pointer(.move, Int(event.buttonNumber)),
+                location: event.cgEvent?.location,
+                timestampNanoseconds: timestamp
+            )
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            return .init(
+                kind: .pointer(.down, Int(event.buttonNumber)),
+                location: event.cgEvent?.location,
+                timestampNanoseconds: timestamp
+            )
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            return .init(
+                kind: .pointer(.up, Int(event.buttonNumber)),
+                location: event.cgEvent?.location,
+                timestampNanoseconds: timestamp
+            )
+        case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+            return .init(
+                kind: .pointer(.drag, Int(event.buttonNumber)),
+                location: event.cgEvent?.location,
+                timestampNanoseconds: timestamp
+            )
+        case .scrollWheel:
+            return .init(
+                kind: .scroll(event.scrollingDeltaX, event.scrollingDeltaY),
+                location: event.cgEvent?.location,
+                timestampNanoseconds: timestamp
+            )
+        case .keyDown:
+            return .init(
+                kind: .key(
+                    .down,
+                    Int(event.keyCode),
+                    UInt64(event.modifierFlags.rawValue)
+                ),
+                location: nil,
+                timestampNanoseconds: timestamp
+            )
+        case .keyUp:
+            return .init(
+                kind: .key(
+                    .up,
+                    Int(event.keyCode),
+                    UInt64(event.modifierFlags.rawValue)
+                ),
+                location: nil,
+                timestampNanoseconds: timestamp
+            )
+        case .flagsChanged:
+            return .init(
+                kind: .key(
+                    .flagsChanged,
+                    Int(event.keyCode),
+                    UInt64(event.modifierFlags.rawValue)
+                ),
+                location: nil,
+                timestampNanoseconds: timestamp
+            )
+        default:
+            return nil
+        }
+    }
+
+    private func ingest(_ raw: NeutralGeometryRawEvent) {
+        guard mode == .recording,
+              let selected = selectedWindow,
+              let current = NeutralGeometryWindowCatalog.currentWindow(
+                  matching: selected
+              ) else {
+            if mode == .recording {
+                revoke(reason: NeutralGeometryCaptureError.windowChanged.localizedDescription)
+            }
+            return
+        }
+        selectedWindow = current
+        let elapsed = elapsedMilliseconds(raw.timestampNanoseconds)
+        let pointerAccepted = raw.location.map {
+            NeutralGeometryWindowCatalog.isTopmostAtPoint(current, point: $0)
+        } ?? false
+        guard let event = Self.makeEvent(
+            from: raw,
+            bounds: current.bounds,
+            pointerIsTopmost: pointerAccepted,
+            keyWindowIsActive: NeutralGeometryWindowCatalog.isActive(current),
+            eventID: nextEventID(),
+            elapsedMilliseconds: elapsed
+        ) else {
+            return
+        }
+        append(event)
+    }
+
+    private func append(_ event: ConversationModuleEvent) {
+        if event.kind == .normalizedPointer,
+           event.pointerPhase == .move,
+           let last = capturedEvents.last,
+           last.kind == .normalizedPointer,
+           last.pointerPhase == .move,
+           let x = event.normalizedX,
+           let y = event.normalizedY,
+           let lastX = last.normalizedX,
+           let lastY = last.normalizedY,
+           hypot(x - lastX, y - lastY) < Self.moveCoalescingDistance {
+            capturedEvents[capturedEvents.count - 1] = event
+            return
+        }
+        capturedEvents.append(event)
+        if capturedEvents.count > Self.maximumSessionEvents {
+            let overflow = capturedEvents.count - Self.maximumSessionEvents
+            capturedEvents.removeFirst(overflow)
+            deliveredEventCount = max(0, deliveredEventCount - overflow)
+            droppedEventCount += overflow
+        }
+    }
+
+    private func nextEventID() -> String {
+        defer { nextEventOrdinal += 1 }
+        return "event_input-\(nextEventOrdinal)"
+    }
+
+    private func elapsedMilliseconds(_ now: UInt64) -> Int {
+        guard let startNanoseconds else { return 0 }
+        return min(
+            86_400_000,
+            Int((now >= startNanoseconds ? now - startNanoseconds : 0) / 1_000_000)
+        )
+    }
+
+    private static func normalized(
+        _ point: CGPoint,
+        within bounds: CGRect
+    ) -> CGPoint? {
+        guard bounds.width > 0, bounds.height > 0 else { return nil }
+        let x = (point.x - bounds.minX) / bounds.width
+        let y = (point.y - bounds.minY) / bounds.height
+        guard x.isFinite, y.isFinite, (0...1).contains(x), (0...1).contains(y) else {
+            return nil
+        }
+        return CGPoint(x: x, y: y)
+    }
+
+    private func reindexed(
+        _ events: [ConversationModuleEvent]
+    ) -> [ConversationModuleEvent] {
+        events.enumerated().map { index, event in
+            ConversationModuleEvent(
+                eventID: event.eventID,
+                sequence: index + 1,
+                kind: event.kind,
+                pointerPhase: event.pointerPhase,
+                normalizedX: event.normalizedX,
+                normalizedY: event.normalizedY,
+                navigationKey: event.navigationKey,
+                keyPhase: event.keyPhase,
+                keyCode: event.keyCode,
+                modifierFlags: event.modifierFlags,
+                buttonNumber: event.buttonNumber,
+                scrollDeltaX: event.scrollDeltaX,
+                scrollDeltaY: event.scrollDeltaY,
+                elapsedMilliseconds: event.elapsedMilliseconds,
+                placeholder: event.placeholder
+            )
+        }
+    }
+}
+
+struct NeutralGeometryCapturePanel: View {
+    @ObservedObject var capture: NeutralGeometryCaptureSession
+    let provenance: ConversationModuleProvenance?
+
+    @State private var selectedID: CGWindowID?
+    @State private var exportStatus: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("SELECTED-WINDOW INPUT")
+                    .font(.system(size: 8, weight: .bold))
+                Text(capture.mode.displayName)
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(capture.mode == .recording ? .green : .secondary)
+                Spacer()
+                Text(
+                    "\(capture.capturedEvents.count) events · "
+                        + "\(capture.pendingEventCount) pending"
+                )
+                .font(.system(size: 8).monospacedDigit())
+                .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Picker(
+                    "Window",
+                    selection: Binding(
+                        get: { capture.selectedWindow?.id ?? selectedID },
+                        set: { value in
+                            selectedID = value
+                            if let value { capture.select(windowID: value) }
+                        }
+                    )
+                ) {
+                    Text("Choose any visible window").tag(nil as CGWindowID?)
+                    ForEach(capture.availableWindows) { window in
+                        Text(window.displayName).tag(window.id as CGWindowID?)
+                    }
+                }
+                .labelsHidden()
+                .controlSize(.mini)
+
+                Button("Refresh") {
+                    capture.refreshWindows()
+                }
+                .controlSize(.mini)
+            }
+
+            HStack {
+                switch capture.mode {
+                case .disarmed, .armed:
+                    Button("Start recording") { capture.start() }
+                        .controlSize(.mini)
+                        .disabled(capture.selectedWindow == nil)
+                case .recording:
+                    Button("Pause") { capture.pause() }
+                        .controlSize(.mini)
+                    Button("Stop & review") { capture.stop() }
+                        .controlSize(.mini)
+                case .paused:
+                    Button("Resume") { capture.resume() }
+                        .controlSize(.mini)
+                    Button("Stop & review") { capture.stop() }
+                        .controlSize(.mini)
+                case .review:
+                    Button("Export reviewed JSON") { export() }
+                        .controlSize(.mini)
+                        .disabled(!capture.canExport || provenance == nil)
+                    Button("New session") {
+                        capture.refreshWindows()
+                        selectedID = nil
+                        capture.revoke()
+                        capture.refreshWindows()
+                    }
+                    .controlSize(.mini)
+                }
+                if !capture.inputMonitoringAvailable {
+                    Button("Enable input monitoring") {
+                        capture.requestInputMonitoring()
+                    }
+                    .controlSize(.mini)
+                }
+            }
+
+            Text(
+                "Captures all mouse, scroll, and key-code events only while this "
+                    + "single selected window is active. Characters, titles, pixels, "
+                    + "OCR, URLs, and window identity are never recorded."
+            )
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+
+            if let error = capture.lastError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+            if let exportStatus {
+                Text(exportStatus)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(7)
+        .background(.background.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func export() {
+        guard let provenance else {
+            exportStatus = NeutralGeometryCaptureError.invalidProvenance.localizedDescription
+            return
+        }
+        do {
+            let data = try capture.exportData(provenance: provenance)
+            let panel = NSSavePanel()
+            panel.title = "Export Reviewed Relative XY Training"
+            panel.nameFieldStringValue = "relative-xy-training.json"
+            panel.allowedContentTypes = [.json]
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            try data.write(to: url, options: .atomic)
+            exportStatus = "Reviewed artifact exported."
+        } catch {
+            exportStatus = error.localizedDescription
+        }
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -559,6 +559,7 @@ final class RouterChatSession: ObservableObject {
     @Published private(set) var reviewingMessageIDs: Set<UUID> = []
 
     let modules: ConversationModuleHostSession
+    let geometryCapture: NeutralGeometryCaptureSession
     var onAssistantReply: ((String) -> Void)?
     var onAssistantFailure: (() -> Void)?
     var onConversationControlChanged: (() -> Void)?
@@ -567,19 +568,27 @@ final class RouterChatSession: ObservableObject {
     private var sendTask: Task<Void, Never>?
     private var reviewTasks: [UUID: Task<Void, Never>] = [:]
     private var moduleObservation: AnyCancellable?
+    private var geometryCaptureObservation: AnyCancellable?
     private var moduleContextFloorToken: String?
     private var moduleContextTurns: [ConversationModuleContextTurn] = []
     private var pendingVoiceMessageID: UUID?
 
     init(
         transport: any RouterChatTransport = RouterChatClient(),
-        modules: ConversationModuleHostSession = ConversationModuleHostSession()
+        modules: ConversationModuleHostSession = ConversationModuleHostSession(),
+        geometryCapture: NeutralGeometryCaptureSession =
+            NeutralGeometryCaptureSession()
     ) {
         self.transport = transport
         self.modules = modules
+        self.geometryCapture = geometryCapture
         moduleObservation = modules.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
+        geometryCaptureObservation =
+            geometryCapture.objectWillChange.sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
     }
 
     var canSend: Bool {
@@ -732,9 +741,16 @@ final class RouterChatSession: ObservableObject {
                         moduleContextFloorToken = floorToken
                         moduleContextTurns = []
                     }
-                    let fixture = Self.syntheticFixtureInput(
-                        for: modules.activeManifest
-                    )
+                    let isRelativeXY =
+                        modules.activeManifest?.moduleID
+                            == ConversationModuleAllowlist
+                                .relativeXYRecorderManifest.moduleID
+                    let captureSnapshot = try isRelativeXY
+                        ? geometryCapture.snapshot()
+                        : nil
+                    let fixture = captureSnapshot.map {
+                        (events: $0.events, window: Optional($0.window))
+                    } ?? Self.syntheticFixtureInput(for: modules.activeManifest)
                     let reply = try await modules.submit(
                         narration: text,
                         transcriptProvider: transcriptProvider,
@@ -743,6 +759,13 @@ final class RouterChatSession: ObservableObject {
                         window: fixture.window
                     )
                     try Task.checkCancellation()
+                    if let captureSnapshot {
+                        geometryCapture.accept(
+                            captureSnapshot,
+                            narration: text,
+                            response: reply
+                        )
+                    }
                     let responseText = Self.moduleResponseText(reply)
                     if !responseText.isEmpty,
                        let manifest = modules.activeManifest {
@@ -768,6 +791,11 @@ final class RouterChatSession: ObservableObject {
                 } catch is CancellationError {
                     return
                 } catch {
+                    if modules.activeFloor == nil {
+                        geometryCapture.revoke(reason: error.localizedDescription)
+                    } else {
+                        geometryCapture.preserveAfterFailure(error)
+                    }
                     onConversationControlChanged?()
                     discardPendingVoiceTranscript()
                     clearModuleContext()
@@ -852,12 +880,14 @@ final class RouterChatSession: ObservableObject {
         isSending = false
         clearModuleContext()
         pendingVoiceMessageID = nil
+        geometryCapture.revoke()
     }
 
     func revokeModuleFloor() async {
         onConversationControlChanged?()
         discardPendingVoiceTranscript()
         clearModuleContext()
+        geometryCapture.revoke()
         await modules.revokeFloor()
     }
 
@@ -869,6 +899,7 @@ final class RouterChatSession: ObservableObject {
         onConversationControlChanged?()
         discardPendingVoiceTranscript()
         clearModuleContext()
+        geometryCapture.revoke()
         modules.selectedModuleID = moduleID
     }
 
@@ -1278,6 +1309,11 @@ struct RouterChatPanel: View {
                 if session.modules.activeFloor == nil {
                     Button("Give floor") {
                         Task {
+                            if session.modules.selectedModuleID
+                                == ConversationModuleAllowlist
+                                    .relativeXYRecorderManifest.moduleID {
+                                session.geometryCapture.refreshWindows()
+                            }
                             await session.modules.grantSelectedFloor()
                         }
                     }
@@ -1307,13 +1343,30 @@ struct RouterChatPanel: View {
                         .padding(.horizontal, 5)
                         .padding(.vertical, 2)
                         .background(Color.accentColor.opacity(0.14), in: Capsule())
-                    Text("Ephemeral · host mic/UI/TTS · no capture, replay, or persistence")
+                    Text(
+                        manifest.moduleID
+                            == ConversationModuleAllowlist
+                                .relativeXYRecorderManifest.moduleID
+                            ? "Ephemeral · selected-window input only · no pixels, OCR, "
+                                + "character recovery, injection, or replay"
+                            : "Ephemeral · host mic/UI/TTS · no capture, replay, or persistence"
+                    )
                         .font(.system(size: 9))
                         .foregroundStyle(.secondary)
                 }
                 .help(
                     "Escape returns control to the dashboard. The module receives only "
                         + "its allowlisted bounded contract fields."
+                )
+            }
+
+            if session.modules.activeManifest?.moduleID
+                == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID {
+                NeutralGeometryCapturePanel(
+                    capture: session.geometryCapture,
+                    provenance: session.modules.healthByModuleID[
+                        ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+                    ]?.provenance
                 )
             }
 

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationModuleTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ConversationModuleTests.swift
@@ -18,10 +18,12 @@ struct ConversationModuleTests {
     func allowlistPrivacy() throws {
         try ConversationModuleAllowlist.syntheticManifest.validate()
         try ConversationModuleAllowlist.geometryRecorderManifest.validate()
+        try ConversationModuleAllowlist.relativeXYRecorderManifest.validate()
 
         for manifest in [
             ConversationModuleAllowlist.syntheticManifest,
             ConversationModuleAllowlist.geometryRecorderManifest,
+            ConversationModuleAllowlist.relativeXYRecorderManifest,
         ] {
             #expect(manifest.privacy == .hostControlled)
             #expect(manifest.privacy.ephemeralOnly)
@@ -34,6 +36,69 @@ struct ConversationModuleTests {
             #expect(!manifest.privacy.inputInjection)
             #expect(!manifest.privacy.executableReplay)
         }
+    }
+
+    @Test("Relative XY accepts any selected window and the complete input vocabulary")
+    func relativeXYInputVocabulary() throws {
+        let manifest = ConversationModuleAllowlist.relativeXYRecorderManifest
+        #expect(
+            manifest.allowedWindowBindingIDs
+                == ["verbal-orders.neutral.selected-window"]
+        )
+        #expect(manifest.capabilities.contains(.rawKeyboardEvents))
+        #expect(manifest.capabilities.contains(.scrollEvents))
+
+        let events = [
+            ConversationModuleEvent(
+                eventID: "event_pointer-1",
+                sequence: 1,
+                kind: .normalizedPointer,
+                pointerPhase: .drag,
+                normalizedX: 0.45,
+                normalizedY: 0.55,
+                buttonNumber: 0,
+                elapsedMilliseconds: 100
+            ),
+            ConversationModuleEvent(
+                eventID: "event_key-2",
+                sequence: 2,
+                kind: .rawKeyboard,
+                keyPhase: .down,
+                keyCode: 12,
+                modifierFlags: 1 << 17,
+                elapsedMilliseconds: 110
+            ),
+            ConversationModuleEvent(
+                eventID: "event_scroll-3",
+                sequence: 3,
+                kind: .scroll,
+                normalizedX: 0.45,
+                normalizedY: 0.55,
+                scrollDeltaX: 0,
+                scrollDeltaY: -4,
+                elapsedMilliseconds: 120
+            ),
+        ]
+        let value = request(
+            manifest: manifest,
+            floor: ConversationFloorGrant(
+                state: .granted,
+                moduleID: manifest.moduleID,
+                token: floor.token
+            ),
+            provenance: ConversationModuleProvenance(
+                sourceID: manifest.provenanceSourceID,
+                buildDigest: provenance.buildDigest
+            ),
+            events: events,
+            window: ConversationModuleWindowContext(
+                bindingID: "verbal-orders.neutral.selected-window",
+                width: 1_437,
+                height: 913
+            )
+        )
+
+        try value.validate(for: manifest)
     }
 
     @Test("A module cannot request microphone, UI, network, persistence, capture, or replay")

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -185,7 +185,7 @@ struct GuidePresentationTests {
         #expect(entitlements.count == 4)
         #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(
-            entitlements["com.apple.security.files.user-selected.read-only"] as? Bool == true
+            entitlements["com.apple.security.files.user-selected.read-write"] as? Bool == true
         )
         #expect(entitlements["com.apple.security.network.client"] as? Bool == true)
         #expect(entitlements["com.apple.security.network.server"] == nil)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/NeutralGeometryCaptureTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/NeutralGeometryCaptureTests.swift
@@ -1,0 +1,116 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Selected-window relative XY capture")
+struct NeutralGeometryCaptureTests {
+    private let bounds = CGRect(x: 100, y: 200, width: 400, height: 300)
+
+    @Test("Pointer geometry is normalized to the selected window")
+    @MainActor
+    func normalizesPointer() throws {
+        let raw = NeutralGeometryRawEvent(
+            kind: .pointer(.move, 0),
+            location: CGPoint(x: 300, y: 275),
+            timestampNanoseconds: 100
+        )
+        let event = try #require(
+            NeutralGeometryCaptureSession.makeEvent(
+                from: raw,
+                bounds: bounds,
+                pointerIsTopmost: true,
+                keyWindowIsActive: false
+            )
+        )
+        #expect(event.kind == .normalizedPointer)
+        #expect(event.normalizedX == 0.5)
+        #expect(event.normalizedY == 0.25)
+        #expect(event.buttonNumber == 0)
+    }
+
+    @Test("Pointer events outside the selected topmost window are ignored")
+    @MainActor
+    func ignoresOtherWindows() {
+        let raw = NeutralGeometryRawEvent(
+            kind: .pointer(.down, 0),
+            location: CGPoint(x: 300, y: 275),
+            timestampNanoseconds: 100
+        )
+        #expect(
+            NeutralGeometryCaptureSession.makeEvent(
+                from: raw,
+                bounds: bounds,
+                pointerIsTopmost: false,
+                keyWindowIsActive: true
+            ) == nil
+        )
+    }
+
+    @Test("Every key is represented as code, phase, modifiers, and timing")
+    @MainActor
+    func capturesKeyCodeWithoutCharacters() throws {
+        let raw = NeutralGeometryRawEvent(
+            kind: .key(.down, 49, 1 << 17),
+            location: nil,
+            timestampNanoseconds: 100
+        )
+        let event = try #require(
+            NeutralGeometryCaptureSession.makeEvent(
+                from: raw,
+                bounds: bounds,
+                pointerIsTopmost: false,
+                keyWindowIsActive: true,
+                elapsedMilliseconds: 234
+            )
+        )
+        #expect(event.kind == .rawKeyboard)
+        #expect(event.keyPhase == .down)
+        #expect(event.keyCode == 49)
+        #expect(event.modifierFlags == 1 << 17)
+        #expect(event.elapsedMilliseconds == 234)
+        #expect(event.navigationKey == nil)
+        #expect(event.placeholder == nil)
+    }
+
+    @Test("Keys from any other active window are ignored")
+    @MainActor
+    func ignoresOtherWindowKeys() {
+        let raw = NeutralGeometryRawEvent(
+            kind: .key(.up, 12, 0),
+            location: nil,
+            timestampNanoseconds: 100
+        )
+        #expect(
+            NeutralGeometryCaptureSession.makeEvent(
+                from: raw,
+                bounds: bounds,
+                pointerIsTopmost: true,
+                keyWindowIsActive: false
+            ) == nil
+        )
+    }
+
+    @Test("Scroll preserves normalized location and bounded deltas")
+    @MainActor
+    func capturesScroll() throws {
+        let raw = NeutralGeometryRawEvent(
+            kind: .scroll(2.5, -7.25),
+            location: CGPoint(x: 140, y: 470),
+            timestampNanoseconds: 100
+        )
+        let event = try #require(
+            NeutralGeometryCaptureSession.makeEvent(
+                from: raw,
+                bounds: bounds,
+                pointerIsTopmost: true,
+                keyWindowIsActive: false
+            )
+        )
+        #expect(event.kind == .scroll)
+        #expect(event.normalizedX == 0.1)
+        #expect(event.normalizedY == 0.9)
+        #expect(event.scrollDeltaX == 2.5)
+        #expect(event.scrollDeltaY == -7.25)
+    }
+}

--- a/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
+++ b/prototypes/operations-floater/docs/CONVERSATION_MODULE_CONTRACT.md
@@ -28,6 +28,21 @@ The allowlisted geometry adapter is:
 - transcript providers: `onDevice`, `syntheticFixture`
 - window binding: `verbal-orders.synthetic.geometry-canvas`
 
+The selected-window relative-coordinate adapter is:
+
+- module ID: `auggie.verbal-orders.relative-xy-recorder`
+- provenance source: `auggie.project-verbal-orders.relative-xy-recorder`
+- transcript providers: `onDevice`, `syntheticFixture`
+- generic wire binding: `verbal-orders.neutral.selected-window`
+- events: normalized mouse move/down/up/drag, normalized scroll plus bounded
+  deltas, and all keyboard down/up/modifier changes as key code, modifier flags,
+  and elapsed timing
+
+Any visible window may be selected. Application names are UI hints only and
+are not an allowlist. The actual process ID, window ID, title, and bundle
+identity are absent from the wire request and reviewed artifact; the host keeps
+the exact process/window binding in memory only to reject cross-window events.
+
 The built-in checkpoint reference additionally permits `typed-keyboard`.
 The geometry recorder does not, so the typed composer is disabled while it has
 the floor.
@@ -51,6 +66,11 @@ Event sequences start at one and are contiguous within each request. Pointer
 coordinates are normalized to `0...1`. Navigation keys are closed to Tab,
 Return, Space, arrows, and Delete. Escape is intentionally absent because the
 host always reserves it for returning to the dashboard.
+
+The relative XY module additionally admits raw hardware key codes, modifiers,
+key phase, mouse button, scroll deltas, and elapsed milliseconds. It does not
+recover characters. Pointer and scroll events must be within the selected
+topmost window; keyboard events require that same selected window to be active.
 
 ## Floor and transaction semantics
 
@@ -80,8 +100,10 @@ Every accepted manifest has exactly this privacy posture:
 - module microphone, UI, TTS, arbitrary network, persistence, screen capture,
   input injection, and executable replay: `false`
 
-The recorder receives only bounded narration, closed normalized events, and an
-allowlisted neutral synthetic window binding. It may return calibrated
+The synthetic recorder receives only bounded narration, closed normalized
+events, and an allowlisted neutral synthetic window binding. The relative XY
+recorder receives only bounded narration, selected-window normalized input
+events, key codes, modifiers, and timing. It may return calibrated
 checkpoints, at most one question, statuses, and proposals. Every proposed
 action must set `humanApprovalRequired: true`; executable replay is not part of
 this contract.

--- a/prototypes/operations-floater/docs/conversation-module-contract-1.0.schema.json
+++ b/prototypes/operations-floater/docs/conversation-module-contract-1.0.schema.json
@@ -79,6 +79,8 @@
               "narration",
               "normalized-pointer-events",
               "navigation-keys",
+              "raw-keyboard-events",
+              "scroll-events",
               "placeholder-events",
               "neutral-window-context",
               "checkpoints",
@@ -150,7 +152,15 @@
           "pattern": "^event_[a-z0-9-]{1,64}$"
         },
         "sequence": {"type": "integer", "minimum": 1},
-        "kind": {"enum": ["normalized-pointer", "navigation-key", "placeholder"]},
+        "kind": {
+          "enum": [
+            "normalized-pointer",
+            "navigation-key",
+            "raw-keyboard",
+            "scroll",
+            "placeholder"
+          ]
+        },
         "pointerPhase": {
           "type": ["string", "null"],
           "enum": ["move", "down", "up", "drag", null]
@@ -170,6 +180,39 @@
             "delete",
             null
           ]
+        },
+        "keyPhase": {
+          "type": ["string", "null"],
+          "enum": ["down", "up", "flags-changed", null]
+        },
+        "keyCode": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 255
+        },
+        "modifierFlags": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "buttonNumber": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 31
+        },
+        "scrollDeltaX": {
+          "type": ["number", "null"],
+          "minimum": -10000,
+          "maximum": 10000
+        },
+        "scrollDeltaY": {
+          "type": ["number", "null"],
+          "minimum": -10000,
+          "maximum": 10000
+        },
+        "elapsedMilliseconds": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 86400000
         },
         "placeholder": {
           "type": ["string", "null"],


### PR DESCRIPTION
## Summary
- add an explicit selected-window capture panel to Operations Floater for any visible window
- record normalized mouse/drag/scroll and raw key-code/modifier/timing events without pixels, OCR, titles, URLs, or reconstructed characters
- connect voice narration and ephemeral captured input to the merged relative-XY conversation module
- export reviewed local JSON only after Stop & review; no injection or replay path
- fix transcriber teardown so tests do not touch an uninstalled audio tap

## Validation
- Swift 81/81
- warnings-as-errors Swift build
- unsigned Release xcodebuild
- shared/web Node 19/19
- Python privacy 9/9
- all three generator examples stamped in Docker; token, shell, hook, generator, and JSON-schema checks passed
- `git diff --check`

## Privacy and runtime boundaries
Input monitoring is requested only from the explicit button. Selection is user-controlled and application-agnostic. Exact PID/window identity stays in memory and cross-window events are refused. No OCR, screenshot, pixels, title, URL, clipboard, character recovery, persistence before review, network expansion, input injection, replay, signing, install, or deployment is included in this PR.