### PR TITLE
fix(operations-floater): show real or empty work lanes

### DIFF
--- a/prototypes/operations-dashboard/README.md
+++ b/prototypes/operations-dashboard/README.md
@@ -2,13 +2,14 @@
 
 Firestarter preserves two complementary dashboard surfaces:
 
-- `../operations-floater/` is the native macOS control surface. It may read
-  locally verified state from its sandboxed Application Support container. It
-  never transmits that state. Its default-off assistant chat uses a separate
+- `../operations-floater/` is the native macOS control surface. It accepts
+  locally verified state from the fixed loopback Router metrics endpoint, then
+  a sandboxed Application Support snapshot, and otherwise renders empty lanes.
+  It never transmits that state. Its default-off assistant chat uses a separate
   fixed loopback Router contract and is not persisted by the app. Optional reply
   review uses the same Router-owned model-selection contract and surfaces
-  actionable coaching for concrete failures. Neither path includes dashboard
-  state unless the user explicitly types it into the chat.
+  actionable coaching for concrete failures. Neither chat path includes
+  dashboard state unless the user explicitly types it into the chat.
 - `../operations-dashboard-web/` is the browser snapshot surface. It renders
   only an explicitly supplied, sanitized snapshot. It never fetches from or
   bridges to a Mac.

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */; };
 		9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */; };
 		A705BC6F0D3A543F75D84535 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D7388421B1A4219EF55A7B2 /* Assets.xcassets */; };
+		A8C223AF7E4BCD86BEDCAF80 /* LoopbackOperationsSnapshotClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28190247462D6C55127EABE8 /* LoopbackOperationsSnapshotClient.swift */; };
 		B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */; };
 		C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */; };
 		C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9DF97AD77E17679BD52803 /* QueueRace.swift */; };
@@ -22,6 +23,7 @@
 /* Begin PBXFileReference section */
 		02D2103622C4FB3754F316FE /* DashboardContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContract.swift; sourceTree = "<group>"; };
 		1879896A7B14D79C647AA2C1 /* OperationsFloater.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OperationsFloater.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		28190247462D6C55127EABE8 /* LoopbackOperationsSnapshotClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopbackOperationsSnapshotClient.swift; sourceTree = "<group>"; };
 		36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidePresentation.swift; sourceTree = "<group>"; };
 		42AF18361984088F8616CB04 /* RouterChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterChat.swift; sourceTree = "<group>"; };
 		4A9DF97AD77E17679BD52803 /* QueueRace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueRace.swift; sourceTree = "<group>"; };
@@ -51,6 +53,7 @@
 				02D2103622C4FB3754F316FE /* DashboardContract.swift */,
 				36310E1C2D59EB7955C2B76F /* GuidePresentation.swift */,
 				CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */,
+				28190247462D6C55127EABE8 /* LoopbackOperationsSnapshotClient.swift */,
 				98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */,
 				62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */,
 				4A9DF97AD77E17679BD52803 /* QueueRace.swift */,
@@ -143,6 +146,7 @@
 				FD43F65E79771F0CB6719A1D /* DashboardContract.swift in Sources */,
 				C3C29CC6F7D8859A4E569D23 /* GuidePresentation.swift in Sources */,
 				2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */,
+				A8C223AF7E4BCD86BEDCAF80 /* LoopbackOperationsSnapshotClient.swift in Sources */,
 				9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */,
 				B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */,
 				C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */,

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -16,13 +16,19 @@ The app consumes the canonical contract in `../operations-dashboard/contract/`:
 the record arrays `queue`, `tests`, `resourceBudget`, and `signals`, with
 per-record `exposure` and `verification`.
 
-An optional runtime snapshot may be placed in the app's sandboxed Application
-Support container as `OperationsFloater/dashboard-state.json`. That local path
-is resolved by the app at runtime and is never committed or transmitted. The
-native adapter rejects unknown contract fields and rejects every `local-only`
-record unless it is marked `verified`. Invalid or missing input fails closed to
-the committed generic sample. Imports must be regular files no larger than one
-megabyte.
+The native app first polls only the fixed loopback Router metrics endpoint at
+`http://127.0.0.1:11500/metrics` and accepts its nested `operations` object only
+when it is a verified canonical `local` snapshot. It sends no credentials,
+cookies, dashboard state, or private file content, and follows no redirect.
+
+An optional runtime snapshot may also be placed in the app's sandboxed
+Application Support container as `OperationsFloater/dashboard-state.json`.
+That local path is resolved by the app at runtime and is never committed or
+transmitted. The native adapter rejects unknown contract fields and rejects
+every `local-only` record unless it is marked `verified`. Invalid or missing
+live and saved input fails closed to an empty dashboard; the committed generic
+sample remains storyboard/test data only. Imports must be regular files no
+larger than one megabyte.
 
 Choose **Import Local Snapshot…** to select and install a canonical local file.
 The app does not retain the selected source path. Installation validates before

--- a/prototypes/operations-floater/Sources/OperationsFloater/DashboardContract.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/DashboardContract.swift
@@ -365,6 +365,15 @@ struct DashboardSnapshot: Decodable, Hashable {
         ]
     )
 
+    static let emptyLocal = DashboardSnapshot(
+        schemaVersion: "1.0",
+        mode: .local,
+        queue: [],
+        tests: [],
+        resourceBudget: [],
+        signals: []
+    )
+
     private static func requireKeys(
         in object: [String: Any],
         required: Set<String>,

--- a/prototypes/operations-floater/Sources/OperationsFloater/LoopbackOperationsSnapshotClient.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/LoopbackOperationsSnapshotClient.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct LoopbackOperationsSnapshotClient: Sendable {
+    enum ClientError: Error, Equatable {
+        case invalidResponse
+        case rejected(Int)
+        case responseTooLarge
+        case invalidEnvelope
+        case localModeRequired
+    }
+
+    static let metricsURL = URL(string: "http://127.0.0.1:11500/metrics")!
+    static let maximumResponseBytes = 1_048_576
+
+    private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate,
+        @unchecked Sendable
+    {
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void
+        ) {
+            completionHandler(nil)
+        }
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeSession()
+    }
+
+    func fetch() async throws -> DashboardSnapshot {
+        let (data, response) = try await session.data(for: Self.makeRequest())
+        return try Self.decode(data: data, response: response)
+    }
+
+    static func makeRequest() -> URLRequest {
+        var request = URLRequest(url: metricsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 2
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("operations-floater", forHTTPHeaderField: "X-Client-App")
+        return request
+    }
+
+    static func decode(data: Data, response: URLResponse) throws -> DashboardSnapshot {
+        guard let response = response as? HTTPURLResponse else {
+            throw ClientError.invalidResponse
+        }
+        guard response.statusCode == 200 else {
+            throw ClientError.rejected(response.statusCode)
+        }
+        guard data.count <= maximumResponseBytes else {
+            throw ClientError.responseTooLarge
+        }
+        guard
+            let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let operations = root["operations"] as? [String: Any]
+        else {
+            throw ClientError.invalidEnvelope
+        }
+
+        let operationsData = try JSONSerialization.data(
+            withJSONObject: operations,
+            options: [.sortedKeys]
+        )
+        let snapshot = try DashboardSnapshot.decodeValidated(from: operationsData)
+        guard snapshot.mode == .local else {
+            throw ClientError.localModeRequired
+        }
+        return snapshot
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.httpShouldSetCookies = false
+        return URLSession(
+            configuration: configuration,
+            delegate: NoRedirectDelegate(),
+            delegateQueue: nil
+        )
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -329,24 +329,46 @@ final class DashboardState: ObservableObject {
             .appendingPathComponent("dashboard-state.json")
     }()
     private let store: LocalSnapshotStore
+    private let liveClient: LoopbackOperationsSnapshotClient?
+    private var isRefreshing = false
 
-    init(snapshotURL: URL? = nil, initialPinned: Bool = false) {
+    init(
+        snapshotURL: URL? = nil,
+        initialPinned: Bool = false,
+        liveClient: LoopbackOperationsSnapshotClient? = LoopbackOperationsSnapshotClient()
+    ) {
         pinned = initialPinned
         store = LocalSnapshotStore(snapshotURL: snapshotURL ?? Self.defaultSnapshotURL)
-        snapshot = .sample
-        sourceDescription = "Generic sample — local only"
+        self.liveClient = liveClient
+        snapshot = .emptyLocal
+        sourceDescription = "No live or saved operations — lanes empty"
         canRestorePreviousSnapshot = false
         reload()
     }
 
     func reload() {
         guard let decoded = store.load() else {
-            snapshot = .sample
-            sourceDescription = "Generic sample — local only"
+            snapshot = .emptyLocal
+            sourceDescription = "No live or saved operations — lanes empty"
             canRestorePreviousSnapshot = store.hasValidPreviousSnapshot()
             return
         }
         use(decoded)
+    }
+
+    func refreshPreferredSource() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        if let liveClient, let liveSnapshot = try? await liveClient.fetch() {
+            use(
+                liveSnapshot,
+                sourceDescription: "Live loopback operations — local only"
+            )
+            return
+        }
+        reload()
     }
 
     func importLocalSnapshot(from sourceURL: URL) throws {
@@ -361,12 +383,17 @@ final class DashboardState: ObservableObject {
         snapshot.queue.lazy.filter { $0.state == stateToCount }.count
     }
 
-    private func use(_ decoded: DashboardSnapshot) {
+    private func use(
+        _ decoded: DashboardSnapshot,
+        sourceDescription override: String? = nil
+    ) {
         snapshot = decoded
-        sourceDescription =
-            decoded.mode == .local
-            ? "Locally verified snapshot — refreshes automatically"
-            : "Sanitized snapshot — refreshes automatically"
+        sourceDescription = override
+            ?? (
+                decoded.mode == .local
+                    ? "Locally verified snapshot — refreshes automatically"
+                    : "Sanitized snapshot — refreshes automatically"
+            )
         canRestorePreviousSnapshot = store.hasValidPreviousSnapshot()
     }
 }
@@ -410,6 +437,7 @@ private struct DashboardView: View {
         )
         .background(.regularMaterial)
         .task {
+            await state.refreshPreferredSource()
             guard let conversationFixtureModuleID,
                   !didPrepareConversationFixture else {
                 return
@@ -420,7 +448,9 @@ private struct DashboardView: View {
             )
         }
         .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
-            state.reload()
+            Task {
+                await state.refreshPreferredSource()
+            }
         }
     }
 

--- a/prototypes/operations-floater/Sources/OperationsFloater/QueueRace.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/QueueRace.swift
@@ -185,44 +185,54 @@ struct QueueRaceBoard: View {
 
             Divider()
 
-            HStack {
-                Text("0% · START")
-                Spacer()
-                Text("Steps added can move a task backward")
-                Spacer()
-                Text("FINISH · 100%")
-            }
-            .font(.system(size: 8, weight: .semibold))
-            .foregroundStyle(.tertiary)
-            .padding(.horizontal, metrics.recordPadding)
-            .padding(.vertical, 6)
-
-            VStack(spacing: 0) {
-                ForEach(Array(sortedRecords.enumerated()), id: \.element.id) { rank, record in
-                    QueueRaceLane(
-                        record: record,
-                        rank: rank + 1,
-                        metrics: metrics,
-                        isExpanded: expandedRecordID == record.id,
-                        isHovered: hoveredRecordID == record.id,
-                        onToggleExpanded: {
-                            withAnimation(reduceMotion ? nil : .snappy(duration: 0.24)) {
-                                expandedRecordID =
-                                    expandedRecordID == record.id ? nil : record.id
-                            }
-                        },
-                        onHover: { hovering in
-                            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) {
-                                hoveredRecordID = hovering ? record.id : nil
-                            }
-                        }
-                    )
+            if sortedRecords.isEmpty {
+                ContentUnavailableView(
+                    "No active work lanes",
+                    systemImage: "flag.checkered",
+                    description: Text("No verified running, queued, waiting, or ready work was supplied.")
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+            } else {
+                HStack {
+                    Text("0% · START")
+                    Spacer()
+                    Text("Steps added can move a task backward")
+                    Spacer()
+                    Text("FINISH · 100%")
                 }
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, metrics.recordPadding)
+                .padding(.vertical, 6)
+
+                VStack(spacing: 0) {
+                    ForEach(Array(sortedRecords.enumerated()), id: \.element.id) { rank, record in
+                        QueueRaceLane(
+                            record: record,
+                            rank: rank + 1,
+                            metrics: metrics,
+                            isExpanded: expandedRecordID == record.id,
+                            isHovered: hoveredRecordID == record.id,
+                            onToggleExpanded: {
+                                withAnimation(reduceMotion ? nil : .snappy(duration: 0.24)) {
+                                    expandedRecordID =
+                                        expandedRecordID == record.id ? nil : record.id
+                                }
+                            },
+                            onHover: { hovering in
+                                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) {
+                                    hoveredRecordID = hovering ? record.id : nil
+                                }
+                            }
+                        )
+                    }
+                }
+                .animation(
+                    reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.86),
+                    value: sortedRecords.map(\.id)
+                )
             }
-            .animation(
-                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.86),
-                value: sortedRecords.map(\.id)
-            )
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 11))

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -47,24 +47,25 @@ struct DashboardStateTests {
     func backgroundUITestInitialPinning() {
         let state = DashboardState(
             snapshotURL: missingFixtureURL(),
-            initialPinned: false
+            initialPinned: false,
+            liveClient: nil
         )
 
         #expect(!state.pinned)
     }
 
-    @Test("Missing local state uses the canonical generic sample")
-    func missingLocalStateUsesSample() {
-        let state = DashboardState(snapshotURL: missingFixtureURL())
+    @Test("Missing local state renders every lane empty")
+    func missingLocalStateUsesEmptySnapshot() {
+        let state = DashboardState(snapshotURL: missingFixtureURL(), liveClient: nil)
 
-        #expect(state.snapshot == .sample)
-        #expect(state.sourceDescription == "Generic sample — local only")
-        #expect(state.itemCount(for: .running) == 1)
-        #expect(state.itemCount(for: .queued) == 1)
-        #expect(state.itemCount(for: .waiting) == 1)
-        #expect(state.itemCount(for: .ready) == 1)
-        #expect(state.snapshot.queue.first?.progressFraction == 0.625)
-        #expect(state.snapshot.resourceBudget.first?.verification == .unavailable)
+        #expect(state.snapshot == .emptyLocal)
+        #expect(state.sourceDescription == "No live or saved operations — lanes empty")
+        #expect(state.itemCount(for: .running) == 0)
+        #expect(state.itemCount(for: .queued) == 0)
+        #expect(state.itemCount(for: .waiting) == 0)
+        #expect(state.itemCount(for: .ready) == 0)
+        #expect(state.snapshot.queue.isEmpty)
+        #expect(state.snapshot.resourceBudget.isEmpty)
     }
 
     @Test("The native fallback exactly matches the shared committed fixture")
@@ -82,7 +83,7 @@ struct DashboardStateTests {
         let fixtureURL = try makeFixture(contents: localFixture(verification: "verified"))
         defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
 
-        let state = DashboardState(snapshotURL: fixtureURL)
+        let state = DashboardState(snapshotURL: fixtureURL, liveClient: nil)
 
         #expect(state.snapshot.mode == .local)
         #expect(state.sourceDescription == "Locally verified snapshot — refreshes automatically")
@@ -97,17 +98,17 @@ struct DashboardStateTests {
         #expect(state.snapshot.queue.first?.cpuPercent == 42.5)
     }
 
-    @Test("Draft contract aliases fail closed to the generic sample")
-    func legacyShapeUsesSample() throws {
+    @Test("Draft contract aliases fail closed to an empty dashboard")
+    func legacyShapeUsesEmptySnapshot() throws {
         let legacy = localFixture(verification: "verified")
             .replacingOccurrences(of: #""mode": "local""#, with: #""snapshotKind": "local""#)
             .replacingOccurrences(of: #""tests":"#, with: #""qualityChecks":"#)
         let fixtureURL = try makeFixture(contents: legacy)
         defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
 
-        let state = DashboardState(snapshotURL: fixtureURL)
+        let state = DashboardState(snapshotURL: fixtureURL, liveClient: nil)
 
-        #expect(state.snapshot == .sample)
+        #expect(state.snapshot == .emptyLocal)
     }
 
     @Test("Unverified local records fail closed")
@@ -115,11 +116,10 @@ struct DashboardStateTests {
         let fixtureURL = try makeFixture(contents: localFixture(verification: "estimated"))
         defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
 
-        let state = DashboardState(snapshotURL: fixtureURL)
+        let state = DashboardState(snapshotURL: fixtureURL, liveClient: nil)
 
-        #expect(state.snapshot == .sample)
-        #expect(state.snapshot.signals.first?.verification == .notImplemented)
-        #expect(state.snapshot.signals.first?.exposure == .sanitized)
+        #expect(state.snapshot == .emptyLocal)
+        #expect(state.snapshot.signals.isEmpty)
     }
 
     @Test("Import installs a validated local snapshot with private file permissions")
@@ -131,7 +131,7 @@ struct DashboardStateTests {
             .appendingPathComponent("ApplicationSupport", isDirectory: true)
             .appendingPathComponent("dashboard-state.json")
         try Data(localFixture(verification: "verified").utf8).write(to: sourceURL)
-        let state = DashboardState(snapshotURL: installedURL)
+        let state = DashboardState(snapshotURL: installedURL, liveClient: nil)
 
         try state.importLocalSnapshot(from: sourceURL)
 
@@ -150,7 +150,7 @@ struct DashboardStateTests {
         let installedURL = directory
             .appendingPathComponent("ApplicationSupport", isDirectory: true)
             .appendingPathComponent("dashboard-state.json")
-        let state = DashboardState(snapshotURL: installedURL)
+        let state = DashboardState(snapshotURL: installedURL, liveClient: nil)
 
         try Data(
             localFixture(verification: "verified", queueTitle: "First version").utf8
@@ -175,7 +175,7 @@ struct DashboardStateTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         let sourceURL = directory.appendingPathComponent("source.json")
         let installedURL = directory.appendingPathComponent("dashboard-state.json")
-        let state = DashboardState(snapshotURL: installedURL)
+        let state = DashboardState(snapshotURL: installedURL, liveClient: nil)
 
         try Data(
             localFixture(verification: "verified", queueTitle: "Accepted version").utf8
@@ -235,9 +235,9 @@ struct DashboardStateTests {
         )
         defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
 
-        let state = DashboardState(snapshotURL: fixtureURL)
+        let state = DashboardState(snapshotURL: fixtureURL, liveClient: nil)
 
-        #expect(state.snapshot == .sample)
+        #expect(state.snapshot == .emptyLocal)
     }
 
     @Test("Invalid or unpaired progress evidence fails closed")
@@ -247,9 +247,9 @@ struct DashboardStateTests {
         let fixtureURL = try makeFixture(contents: invalid)
         defer { try? FileManager.default.removeItem(at: fixtureURL.deletingLastPathComponent()) }
 
-        let state = DashboardState(snapshotURL: fixtureURL)
+        let state = DashboardState(snapshotURL: fixtureURL, liveClient: nil)
 
-        #expect(state.snapshot == .sample)
+        #expect(state.snapshot == .emptyLocal)
     }
 
     @Test("Window opens frontmost, unpins, closes, and reopens as the same retained window")
@@ -257,7 +257,8 @@ struct DashboardStateTests {
         _ = NSApplication.shared
         let state = DashboardState(
             snapshotURL: missingFixtureURL(),
-            initialPinned: true
+            initialPinned: true,
+            liveClient: nil
         )
         let controller = DashboardWindowController(state: state, activatesApplication: false)
 

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/LoopbackOperationsSnapshotClientTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/LoopbackOperationsSnapshotClientTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Loopback operations snapshot")
+struct LoopbackOperationsSnapshotClientTests {
+    @Test("Metrics request is fixed to loopback without credentials")
+    func requestIsFixedAndCredentialFree() {
+        let request = LoopbackOperationsSnapshotClient.makeRequest()
+
+        #expect(request.url == URL(string: "http://127.0.0.1:11500/metrics"))
+        #expect(request.httpMethod == "GET")
+        #expect(request.timeoutInterval == 2)
+        #expect(request.value(forHTTPHeaderField: "X-Client-App") == "operations-floater")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+        #expect(request.httpBody == nil)
+    }
+
+    @Test("A verified local operations envelope drives real lane counts")
+    func decodeLocalOperationsEnvelope() throws {
+        let data = Data(
+            """
+            {
+              "router": {"status": "online"},
+              "operations": {
+                "schemaVersion": "1.0",
+                "mode": "local",
+                "queue": [
+                  {
+                    "id": "router",
+                    "title": "Router",
+                    "detail": "Loopback service",
+                    "state": "running",
+                    "exposure": "local-only",
+                    "verification": "verified"
+                  }
+                ],
+                "tests": [],
+                "resourceBudget": [],
+                "signals": []
+              }
+            }
+            """.utf8
+        )
+
+        let snapshot = try LoopbackOperationsSnapshotClient.decode(
+            data: data,
+            response: response(status: 200)
+        )
+
+        #expect(snapshot.mode == .local)
+        #expect(snapshot.queue.map(\.id) == ["router"])
+        #expect(snapshot.queue.first?.state == .running)
+    }
+
+    @Test("Missing operations and non-local modes fail closed")
+    func invalidEnvelopeFailsClosed() {
+        let missing = Data(#"{"router":{"status":"online"}}"#.utf8)
+        #expect(throws: LoopbackOperationsSnapshotClient.ClientError.invalidEnvelope) {
+            try LoopbackOperationsSnapshotClient.decode(
+                data: missing,
+                response: response(status: 200)
+            )
+        }
+
+        let sample = Data(
+            """
+            {
+              "operations": {
+                "schemaVersion": "1.0",
+                "mode": "sample",
+                "queue": [],
+                "tests": [],
+                "resourceBudget": [],
+                "signals": []
+              }
+            }
+            """.utf8
+        )
+        #expect(throws: LoopbackOperationsSnapshotClient.ClientError.localModeRequired) {
+            try LoopbackOperationsSnapshotClient.decode(
+                data: sample,
+                response: response(status: 200)
+            )
+        }
+    }
+
+    private func response(status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: LoopbackOperationsSnapshotClient.metricsURL,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+}


### PR DESCRIPTION
## What changed
- poll the fixed loopback Router metrics endpoint for its validated local operations snapshot
- fall back to a validated private snapshot, then a true empty dashboard
- remove the runtime generic-sample fallback and render an explicit empty work-races state

## Root cause
The native dashboard used the committed storyboard sample whenever no Application Support snapshot existed, so it displayed one synthetic item in every lifecycle state.

## Validation
- Swift: 84/84 tests
- warnings-as-errors unsigned Release Xcode build
- shared/native/web contract tests: 19/19 Node + 9/9 Python
- all four Firestarter stack examples generated cleanly with token, shell, and diff checks
- isolated exact candidate UI read the live loopback records Pm, Router, and Stream; no fabricated queued/waiting/ready records

No signing, installation, deployment, release, credentials, or private snapshot was added.