### PR TITLE
fix(recorder): start floor, voice, and capture together

### DIFF
--- a/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
@@ -254,6 +254,22 @@ final class NeutralGeometryCaptureSession: ObservableObject {
         }
     }
 
+    func setInputMonitoringToggle(_ enabled: Bool) {
+        if enabled {
+            requestInputMonitoring()
+            return
+        }
+
+        // macOS does not let an app revoke its own Input Monitoring grant. Keep
+        // the switch truthful and direct the user to the system permission pane.
+        inputMonitoringAvailable = CGPreflightListenEventAccess()
+        if inputMonitoringAvailable {
+            lastError =
+                "To turn off Input Monitoring, remove Operations Floater in "
+                    + "System Settings → Privacy & Security → Input Monitoring."
+        }
+    }
+
     func start() {
         guard selectedWindow != nil else {
             lastError = NeutralGeometryCaptureError.noWindow.localizedDescription
@@ -824,12 +840,20 @@ struct NeutralGeometryCapturePanel: View {
                     }
                     .controlSize(.mini)
                 }
-                if !capture.inputMonitoringAvailable {
-                    Button("Enable input monitoring") {
-                        capture.requestInputMonitoring()
-                    }
-                    .controlSize(.mini)
-                }
+                Toggle(
+                    "Input monitoring",
+                    isOn: Binding(
+                        get: { capture.inputMonitoringAvailable },
+                        set: { capture.setInputMonitoringToggle($0) }
+                    )
+                )
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .help(
+                    capture.inputMonitoringAvailable
+                        ? "Input Monitoring is enabled for this app."
+                        : "Turn on to request macOS Input Monitoring permission."
+                )
             }
 
             Text(

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -1083,6 +1083,36 @@ final class RouterChatSession: ObservableObject {
         await modules.revokeFloor()
     }
 
+    func activateSelectedRecorder(with voice: VoiceConversationSession) async {
+        guard modules.selectedModuleID
+                == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID else {
+            await modules.grantSelectedFloor()
+            return
+        }
+
+        geometryCapture.refreshWindows()
+        guard geometryCapture.selectedWindow != nil else {
+            lastError = "Choose a visible window before giving the recorder the floor."
+            return
+        }
+
+        await modules.grantSelectedFloor()
+        guard modules.activeFloor != nil else { return }
+
+        geometryCapture.start()
+        guard geometryCapture.mode == .recording else {
+            await revokeModuleFloor()
+            return
+        }
+
+        await voice.start()
+        guard voice.state == .listening else {
+            geometryCapture.revoke(reason: voice.lastError ?? "Voice could not start.")
+            await revokeModuleFloor()
+            return
+        }
+    }
+
     func selectConversationTarget(_ moduleID: String?) {
         guard modules.activeFloor == nil,
               modules.selectedModuleID != moduleID else {
@@ -1549,17 +1579,23 @@ struct RouterChatPanel: View {
                 .disabled(session.modules.activeFloor != nil)
 
                 if session.modules.activeFloor == nil {
-                    Button("Give floor") {
+                    Button(
+                        session.modules.selectedModuleID
+                            == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+                            ? "Give floor · start voice + recording"
+                            : "Give floor"
+                    ) {
                         Task {
-                            if session.modules.selectedModuleID
-                                == ConversationModuleAllowlist
-                                    .relativeXYRecorderManifest.moduleID {
-                                session.geometryCapture.refreshWindows()
-                            }
-                            await session.modules.grantSelectedFloor()
+                            await session.activateSelectedRecorder(with: voice)
                         }
                     }
                     .controlSize(.mini)
+                    .help(
+                        session.modules.selectedModuleID
+                            == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+                            ? "Give the Relative XY recorder the floor to start voice and recording together."
+                            : "Give the selected conversation module the floor."
+                    )
                     .disabled(
                         session.modules.selectedModuleID == nil
                             || session.modules.isWorking
@@ -1567,6 +1603,7 @@ struct RouterChatPanel: View {
                 } else {
                     Button("Return to dashboard") {
                         voice.cancelPendingSubmission()
+                        voice.stop()
                         Task {
                             await session.revokeModuleFloor()
                         }
@@ -1757,12 +1794,20 @@ struct RouterChatPanel: View {
 
             switch voice.state {
             case .off, .unavailable:
-                Button("Start voice") {
-                    Task {
-                        await voice.start()
+                if session.modules.activeFloor == nil,
+                   session.modules.selectedModuleID
+                        == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID {
+                    Text("Give floor starts voice + recording")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                } else {
+                    Button("Start voice") {
+                        Task {
+                            await voice.start()
+                        }
                     }
+                    .controlSize(.mini)
                 }
-                .controlSize(.mini)
             case .listening:
                 Button("Pause") {
                     voice.pause()

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -1097,18 +1097,30 @@ final class RouterChatSession: ObservableObject {
         }
 
         await modules.grantSelectedFloor()
-        guard modules.activeFloor != nil else { return }
+        guard modules.activeFloor != nil else {
+            lastError = modules.lastError
+                ?? "The selected recorder could not receive the floor."
+            return
+        }
 
         geometryCapture.start()
         guard geometryCapture.mode == .recording else {
-            await revokeModuleFloor()
+            let reason = geometryCapture.lastError
+                ?? "Input monitoring is required before recording can start."
+            geometryCapture.revoke(reason: reason)
+            await modules.revokeFloor()
+            lastError = reason
+            onConversationControlChanged?()
             return
         }
 
         await voice.start()
         guard voice.state == .listening else {
-            geometryCapture.revoke(reason: voice.lastError ?? "Voice could not start.")
-            await revokeModuleFloor()
+            let reason = voice.lastError ?? "Voice could not start."
+            geometryCapture.revoke(reason: reason)
+            await modules.revokeFloor()
+            lastError = reason
+            onConversationControlChanged?()
             return
         }
     }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -640,6 +640,30 @@ struct RouterChatSessionTests {
         #expect(session.messages.isEmpty)
     }
 
+    @Test("Giving the recorder floor without a selected window stays actionable")
+    func recorderFloorRequiresSelectedWindow() async {
+        let session = RouterChatSession(
+            transport: StubRouterTransport(
+                available: true,
+                result: .success(localReply(text: "Unused"))
+            )
+        )
+        await session.enable()
+        session.selectConversationTarget(
+            ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+        )
+        let voice = VoiceConversationSession()
+
+        await session.activateSelectedRecorder(with: voice)
+
+        #expect(session.modules.activeFloor == nil)
+        #expect(voice.state == .off)
+        #expect(
+            session.lastError
+                == "Choose a visible window before giving the recorder the floor."
+        )
+    }
+
     @Test("Collapsing chat suspends and clears its ephemeral lifecycle")
     func collapsedChatIsInactive() async {
         let session = RouterChatSession(

--- a/prototypes/operations-floater/docs/RECORDER_LIVE_TRACE.md
+++ b/prototypes/operations-floater/docs/RECORDER_LIVE_TRACE.md
@@ -27,6 +27,12 @@ and after the turn, the selected-window dimensions, accepted event count,
 normalizer model, and the module result. A refusal remains visible at the stage
 that rejected it instead of being flattened into a generic chat error.
 
+For the Relative XY recorder, **Give floor** is the single start action. It
+grants the module floor, starts selected-window recording, and starts on-device
+voice together. If either recording or voice cannot start, the host revokes the
+floor and leaves the dashboard in control; the user does not need to recover
+from a half-started recorder.
+
 The normalization boundary is deliberately narrow:
 
 - the transcript and recorder question are JSON-encoded as untrusted data;


### PR DESCRIPTION
## What changed

- makes **Give floor** the single Relative XY recorder start action: floor grant, selected-window recording, and on-device voice start together
- replaces the separate Input Monitoring button with a truthful switch that requests access when enabled and explains that revocation happens in System Settings
- rolls back partial activation and preserves the exact actionable startup failure instead of clearing it
- stops voice when control returns to the dashboard
- documents the unified start and fail-closed rollback behavior
- adds regression coverage for a missing selected window

## Why

The previous flow required the user to remember three separate controls. A failed recording start could also revoke the floor and erase the reason, leaving the user without a useful next action.

## User impact

Relative XY training now starts from one explicit control. If window selection, Input Monitoring, module health, or voice startup is unavailable, the recorder returns control to the dashboard and keeps the reason visible. No microphone or input capture starts merely by opening the app.

## Validation

- `swift test --package-path prototypes/operations-floater` — 93/93 passed
- unsigned Release `xcodebuild` with `CODE_SIGNING_ALLOWED=NO` — passed
- web dashboard Node tests — 4/4 passed
- web privacy tests — 9/9 passed
- all four Firestarter example stacks generated in Docker; token, shell syntax, and generator compile checks passed
- `git diff --check origin/master...HEAD` — passed

## Safety

No install, signing, permission prompt, microphone/input capture, release, deployment, or production state change is part of this PR.
