### PR TITLE
fix(build): preserve Operations Floater permission identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the firestarter template. See
 ## [Unreleased]
 
 ### Added
+- Operations Floater 1.1.0 (build 2) permission/install lifecycle: a read-only
+  designated-requirement compatibility preflight, helper-free bundle audit,
+  one-instance recorder host, transactional **Give floor** rollback, and
+  synthetic tests that never sign, install, launch, or request TCC access.
 - Unified operations-dashboard reference sources under `prototypes/`: a strict
   privacy-neutral contract, native macOS floater with validated local snapshot
   import/rollback, sanitized static web renderer, and offline content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the firestarter template. See
   designated-requirement compatibility preflight, helper-free bundle audit,
   one-instance recorder host, transactional **Give floor** rollback, and
   synthetic tests that never sign, install, launch, or request TCC access.
+  Routine validation is bundle-free on the active macOS profile because Xcode
+  26.5 still invokes `lsregister` despite
+  `REGISTER_WITH_LAUNCH_SERVICES=NO`.
 - Unified operations-dashboard reference sources under `prototypes/`: a strict
   privacy-neutral contract, native macOS floater with validated local snapshot
   import/rollback, sanitized static web renderer, and offline content-addressed

--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -8,6 +8,9 @@
   requirements in both directions before replacement.
 - Keep routine unsigned or ad-hoc builds disposable so they cannot silently
   replace the app instance that owns Input Monitoring permission.
+- Keep routine validation bundle-free on the active macOS profile after
+  confirming Xcode 26.5 still invokes `lsregister` when
+  `REGISTER_WITH_LAUNCH_SERVICES=NO` is supplied.
 - Enforce one recorder host with a process-scoped application lease while
   retaining the existing single-Space window policy and Dock launcher.
 - Roll back floor ownership, selected-window recording, the global event

--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Operations Floater changelog
+
+## 1.1.0 (build 2) — unreleased
+
+- Add a read-only signed-code identity preflight for first install and update.
+  Updates must preserve the owner bundle identifier, pass signature and
+  Gatekeeper validation, and satisfy installed/candidate designated
+  requirements in both directions before replacement.
+- Keep routine unsigned or ad-hoc builds disposable so they cannot silently
+  replace the app instance that owns Input Monitoring permission.
+- Enforce one recorder host with a process-scoped application lease while
+  retaining the existing single-Space window policy and Dock launcher.
+- Roll back floor ownership, selected-window recording, the global event
+  monitor, and voice state when either half of **Give floor** fails to start.
+- Reject unexpected embedded login items, agents, daemons, privileged helpers,
+  or launch services in the current helper-free release shape.
+- Add synthetic coverage for compatible and incompatible code identities,
+  helper rejection, Input Monitoring refusal, voice startup failure, successful
+  joint startup, and one-instance locking. The tests do not sign code, request
+  TCC access, launch an installed app, or modify System Settings.

--- a/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
+++ b/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
@@ -3,6 +3,35 @@
 Operations Floater has no network updater. Application replacement and snapshot
 updates are explicit local operations with a retained rollback artifact.
 
+## Permission-bearing identity
+
+Input Monitoring, microphone, and Speech Recognition are privacy-protected
+resources associated with the app's macOS code identity. Apple documents that
+macOS records a signed app's designated requirement (DR) and uses it to
+recognize later versions. An unsigned app has no DR; an ad-hoc signed app's DR
+is tied to that exact code version. Routine unsigned or ad-hoc builds therefore
+must remain disposable and must never replace or launch as the installed,
+permission-bearing app.
+
+The release app must keep all of these stable:
+
+- one owner-controlled bundle identifier, supplied outside Git;
+- one Developer ID team and the Xcode-produced designated requirement;
+- one installed path, normally `/Applications/Operations Floater.app`; and
+- one main application process as the Input Monitoring client.
+
+Do not hand-author a custom DR. If a future Mac App Store variant must share
+privacy grants with a Developer ID variant, follow Apple's mutually compatible
+DR procedure and test both directions before shipping. A change of signing
+channel, development certificate, team, or bundle identifier is a permission
+migration and must not be presented as a routine update.
+
+References:
+
+- [Apple TN3127: Inside Code Signing — Requirements](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements)
+- [Apple: Creating distribution-signed code for macOS](https://developer.apple.com/documentation/xcode/creating-distribution-signed-code-for-the-mac)
+- [Apple: CGPreflightListenEventAccess](https://developer.apple.com/documentation/coregraphics/cgpreflightlisteneventaccess%28%29)
+
 ## Release inputs
 
 Keep these outside Git and set them to operator-controlled locations:
@@ -18,6 +47,15 @@ owner's bundle identifier and signing configuration. Do not place certificates,
 profiles, account identifiers, runtime snapshots, or application backups in this
 repository.
 
+The checked-in `com.example.operationsfloater` identifier is only for unsigned,
+disposable builds. A release archive must override it with the stable value.
+
+Operations Floater currently has no login item, launch agent, daemon, privileged
+helper, or updater. Do not add one to work around TCC. If a future helper is
+actually needed, it must live inside the signed app bundle, use its own unique
+code-signing identifier, and follow `SMAppService`; that is a separate design
+and owner gate.
+
 ## Preflight
 
 Before replacing an installed copy:
@@ -30,11 +68,24 @@ Before replacing an installed copy:
    spctl --assess --type execute --verbose=2 "$CANDIDATE_APP"
    ```
 
-3. Confirm the built metadata contains the productivity category and expected
-   encryption declaration.
-4. Run the native unit/lifecycle tests and unsigned Release build from the same
-   commit.
-5. Export or retain the current local snapshot only in its private local
+3. For an update, prove that the installed app and candidate have mutually
+   compatible DRs and that the build number increases:
+
+   ```bash
+   prototypes/operations-floater/scripts/verify-permission-identity.sh \
+     --candidate "$CANDIDATE_APP" \
+     --installed "$INSTALLED_APP" \
+     --expected-bundle-id "$OPERATIONS_FLOATER_BUNDLE_ID"
+   ```
+
+   For a first install, omit `--installed`. The preflight is read-only: it does
+   not sign, copy, launch, quit, grant/reset TCC, or open System Settings.
+4. Confirm the built metadata contains the Dock icon, productivity category,
+   expected encryption declaration, regular app activation, and no unexpected
+   embedded helper.
+5. Run the native unit/lifecycle tests, synthetic identity-preflight test, and
+   unsigned Release build from the same commit.
+6. Export or retain the current local snapshot only in its private local
    storage. Never copy it into Git or a web publication directory.
 
 Stop if identity, signature, metadata, or tests do not match the intended
@@ -44,16 +95,19 @@ release.
 
 1. Quit any running copy.
 2. Copy the candidate to `INSTALLED_APP` using a metadata-preserving local copy.
-3. Launch it and verify one visible dashboard window, default frontmost state,
+3. Launch only the installed path. Grant Input Monitoring once from the app's
+   explicit toggle if the user approves. Never grant permission to a DerivedData
+   product, SwiftPM executable, or disposable copy.
+4. Verify one visible dashboard window and one app process, default frontmost state,
    unpin behavior, Command-W close, Dock reopen, and Reduce Motion.
    At the default size, confirm queue and supporting panels use two columns.
    Resize to the minimum and confirm they collapse to one column without
    clipping the guide summary or four queue counters.
-4. Confirm each queue race shows a bounded progress chip, hover detail, and
+5. Confirm each queue race shows a bounded progress chip, hover detail, and
    click-to-expand detail. Exercise last-active, completion, memory, CPU, and
    needs-attention sorting. Confirm an increased total-step count can move a
    chip backward and Reduce Motion replaces animation with a stable frame.
-5. Confirm assistant chat initially reports **OFF** and performs no availability
+6. Confirm assistant chat initially reports **OFF** and performs no availability
    probe. Enable it explicitly, use only a synthetic prompt, and verify a
    response. Use **Shift-Return** to create a two-line draft and confirm it
    remains unsent; then press **Return** and confirm one two-line message is
@@ -61,10 +115,10 @@ release.
    **Review** and confirm **CHECKING** becomes **CHECKED** or an actionable
    **IMPROVE** card. Stop if the client contacts anything other than
    `127.0.0.1:11500`, follows a redirect, or silently sends dashboard state.
-6. Choose **Import Local Snapshot…** only if a canonical `local` version `1.0`
+7. Choose **Import Local Snapshot…** only if a canonical `local` version `1.0`
    snapshot is ready. The app validates before writing and gives the stored file
    private permissions.
-7. Confirm the header reports a locally verified snapshot rather than the
+8. Confirm the header reports a locally verified snapshot rather than the
    generic sample.
 
 ## Update
@@ -73,10 +127,17 @@ release.
 2. Quit the installed app.
 3. Copy the existing installed app to `BACKUP_APP`.
 4. Replace `INSTALLED_APP` with the candidate using a metadata-preserving copy.
-5. Launch and repeat the lifecycle smoke checks.
-6. Import the new local snapshot, if needed. A valid current snapshot is saved
+5. Launch only the stable installed path and repeat the lifecycle smoke checks.
+   Do not remove/re-add Input Monitoring. If preflight passed but the existing
+   grant is not recognized, stop and restore the backup; do not mutate TCC as a
+   troubleshooting shortcut.
+6. Press **Give floor** with a selected synthetic window. It must reach floor
+   granted + recording + listening together. Denied Input Monitoring or failed
+   audio startup must leave the floor revoked, voice off, and the event monitor
+   removed with an actionable error.
+7. Import the new local snapshot, if needed. A valid current snapshot is saved
    as the previous snapshot before the update is committed.
-7. Leave `BACKUP_APP` and the previous snapshot intact through the acceptance
+8. Leave `BACKUP_APP` and the previous snapshot intact through the acceptance
    period.
 
 An invalid snapshot cannot replace the active snapshot. No selected source path
@@ -87,7 +148,9 @@ is retained, and no import data is transmitted.
 Rollback triggers include failure to launch, signature or Gatekeeper rejection,
 missing window lifecycle behavior, an unreadable compact layout, motion that
 continues with Reduce Motion enabled, unreadable canonical state, chat egress
-beyond the fixed loopback Router, or a material display regression.
+beyond the fixed loopback Router, loss of the prior Input Monitoring grant
+despite mutually compatible DRs, a duplicate app process, a leaked event
+monitor after failed voice startup, or a material display regression.
 
 1. Quit the app.
 2. Replace `INSTALLED_APP` with the verified `BACKUP_APP`.
@@ -99,6 +162,10 @@ beyond the fixed loopback Router, or a material display regression.
 
 Do not delete the candidate, backup, or previous snapshot until the restored
 state has passed the same acceptance checks.
+
+Do not run `tccutil reset`, remove/re-add the app in System Settings, or alter
+the TCC database during rollback. Those actions destroy the evidence needed to
+distinguish an identity regression from a permission-state problem.
 
 ## Cleanup
 

--- a/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
+++ b/prototypes/operations-floater/INSTALL_UPDATE_ROLLBACK.md
@@ -2,6 +2,8 @@
 
 Operations Floater has no network updater. Application replacement and snapshot
 updates are explicit local operations with a retained rollback artifact.
+The concise architecture contract is also recorded in
+[`docs/PERMISSION_AND_INSTALL_LIFECYCLE.md`](docs/PERMISSION_AND_INSTALL_LIFECYCLE.md).
 
 ## Permission-bearing identity
 
@@ -40,6 +42,8 @@ Keep these outside Git and set them to operator-controlled locations:
 CANDIDATE_APP=...
 INSTALLED_APP=...
 BACKUP_APP=...
+OPERATIONS_FLOATER_BUNDLE_ID=...
+OPERATIONS_FLOATER_TEAM_ID=...
 ```
 
 The candidate must be produced from the reviewed Firestarter commit with the
@@ -55,6 +59,10 @@ helper, or updater. Do not add one to work around TCC. If a future helper is
 actually needed, it must live inside the signed app bundle, use its own unique
 code-signing identifier, and follow `SMAppService`; that is a separate design
 and owner gate.
+
+An old helper from an unrelated or experimental build is not removed
+automatically. Inspecting or removing one is separate owner-controlled
+maintenance; the current app works with no helper.
 
 ## Preflight
 
@@ -75,7 +83,8 @@ Before replacing an installed copy:
    prototypes/operations-floater/scripts/verify-permission-identity.sh \
      --candidate "$CANDIDATE_APP" \
      --installed "$INSTALLED_APP" \
-     --expected-bundle-id "$OPERATIONS_FLOATER_BUNDLE_ID"
+     --expected-bundle-id "$OPERATIONS_FLOATER_BUNDLE_ID" \
+     --expected-team-id "$OPERATIONS_FLOATER_TEAM_ID"
    ```
 
    For a first install, omit `--installed`. The preflight is read-only: it does
@@ -83,8 +92,11 @@ Before replacing an installed copy:
 4. Confirm the built metadata contains the Dock icon, productivity category,
    expected encryption declaration, regular app activation, and no unexpected
    embedded helper.
-5. Run the native unit/lifecycle tests, synthetic identity-preflight test, and
-   unsigned Release build from the same commit.
+5. Run the native unit/lifecycle tests and synthetic identity-preflight test
+   from the same commit. Compile an app bundle only on a disposable macOS
+   account or CI runner: Xcode 26.5 runs `lsregister` during both `build` and
+   `archive`, and `REGISTER_WITH_LAUNCH_SERVICES=NO` did not suppress it in
+   battle testing.
 6. Export or retain the current local snapshot only in its private local
    storage. Never copy it into Git or a web publication directory.
 

--- a/prototypes/operations-floater/Info.plist
+++ b/prototypes/operations-floater/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -165,6 +165,10 @@ snapshot remains schema version `1.0`.
 
 See [INSTALL_UPDATE_ROLLBACK.md](INSTALL_UPDATE_ROLLBACK.md) for the release
 preflight, local update procedure, acceptance checks, and rollback path.
+See
+[`docs/PERMISSION_AND_INSTALL_LIFECYCLE.md`](docs/PERMISSION_AND_INSTALL_LIFECYCLE.md)
+for the stable Input Monitoring identity, no-helper contract, single-instance
+lifecycle, and owner-gated migration plan.
 See [docs/BACKGROUND_UI_TESTING.md](docs/BACKGROUND_UI_TESTING.md) for the
 low-disruption spare-Desktop test workflow and its measured limitations.
 See
@@ -185,16 +189,12 @@ swift test
 bash Tests/permission-identity-preflight.test.sh
 ```
 
-Run an unsigned bounded application build:
-
-```bash
-xcodebuild \
-  -project OperationsFloater.xcodeproj \
-  -scheme OperationsFloater \
-  -configuration Release \
-  CODE_SIGNING_ALLOWED=NO \
-  build
-```
+Routine validation stops at SwiftPM and synthetic fixture tests on the active
+macOS user profile. Xcode 26.5 runs `lsregister` for both `build` and `archive`,
+including when `REGISTER_WITH_LAUNCH_SERVICES=NO` is supplied. Do not rely on
+that setting to isolate a disposable app bundle. App-bundle compilation belongs
+on a disposable macOS account or CI runner; a signed release archive remains an
+owner-gated operation.
 
 A synthetic still-frame walkthrough and compact composer/provenance state map live in
 [`docs/CHAT_COMPOSER_STATE.md`](docs/CHAT_COMPOSER_STATE.md).

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -58,6 +58,9 @@ snapshot remains schema version `1.0`.
 - An explicit user launch opens visibly in front but defaults **Keep in front**
   to off and stays on one macOS Desktop. Pinning and showing the same window on
   every Desktop are never implicit.
+- The app holds one process-scoped lease in its sandboxed Application Support
+  directory. A direct second launch activates the existing bundle instance and
+  exits before starting another recorder host.
 - A deliberate `--background-ui-test` launch mode leaves **Keep in front** off,
   stays on one macOS Desktop, and neither activates the app nor force-orders its
   window above unrelated work. Normal user launches retain the foreground
@@ -154,6 +157,11 @@ snapshot remains schema version `1.0`.
   remains usable down to a 380-by-480 compact single-column layout.
 - The application target is sandboxed, uses hardened runtime, and includes a
   macOS app icon, encryption declaration, and productivity category.
+- The supported release shape is one signed main app with no login item,
+  launch agent, daemon, privileged helper, or updater. Input Monitoring belongs
+  to that app's stable code identity; unsigned and ad-hoc routine builds are
+  disposable test artifacts and must not replace or launch as the permission-
+  bearing installed copy.
 
 See [INSTALL_UPDATE_ROLLBACK.md](INSTALL_UPDATE_ROLLBACK.md) for the release
 preflight, local update procedure, acceptance checks, and rollback path.
@@ -174,6 +182,7 @@ privacy, and lifecycle tests:
 
 ```bash
 swift test
+bash Tests/permission-identity-preflight.test.sh
 ```
 
 Run an unsigned bounded application build:

--- a/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/NeutralGeometryCapture.swift
@@ -187,6 +187,34 @@ enum NeutralGeometryWindowCatalog {
 
 @MainActor
 final class NeutralGeometryCaptureSession: ObservableObject {
+    @MainActor
+    struct SystemInterface {
+        let preflightListenAccess: () -> Bool
+        let requestListenAccess: () -> Bool
+        let visibleWindows: () -> [NeutralGeometryWindow]
+        let currentWindow: (NeutralGeometryWindow) -> NeutralGeometryWindow?
+        let isActive: (NeutralGeometryWindow) -> Bool
+        let isTopmostAtPoint: (NeutralGeometryWindow, CGPoint) -> Bool
+        let addGlobalMonitor:
+            (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any?
+        let removeMonitor: (Any) -> Void
+
+        static let live = SystemInterface(
+            preflightListenAccess: { CGPreflightListenEventAccess() },
+            requestListenAccess: { CGRequestListenEventAccess() },
+            visibleWindows: { NeutralGeometryWindowCatalog.visibleWindows() },
+            currentWindow: { NeutralGeometryWindowCatalog.currentWindow(matching: $0) },
+            isActive: { NeutralGeometryWindowCatalog.isActive($0) },
+            isTopmostAtPoint: {
+                NeutralGeometryWindowCatalog.isTopmostAtPoint($0, point: $1)
+            },
+            addGlobalMonitor: {
+                NSEvent.addGlobalMonitorForEvents(matching: $0, handler: $1)
+            },
+            removeMonitor: { NSEvent.removeMonitor($0) }
+        )
+    }
+
     static let moduleID = "auggie.verbal-orders.relative-xy-recorder"
     static let bindingID = "verbal-orders.neutral.selected-window"
     static let maximumSessionEvents = 4_096
@@ -204,6 +232,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
     private var monitor: Any?
     private var startNanoseconds: UInt64?
     private var nextEventOrdinal = 1
+    private let system: SystemInterface
 
     var pendingEventCount: Int {
         max(0, capturedEvents.count - deliveredEventCount)
@@ -213,13 +242,14 @@ final class NeutralGeometryCaptureSession: ObservableObject {
         mode == .review && !capturedEvents.isEmpty
     }
 
-    init() {
+    init(system: SystemInterface = .live) {
+        self.system = system
         refreshWindows()
-        inputMonitoringAvailable = CGPreflightListenEventAccess()
+        inputMonitoringAvailable = system.preflightListenAccess()
     }
 
     func refreshWindows() {
-        availableWindows = NeutralGeometryWindowCatalog.visibleWindows()
+        availableWindows = system.visibleWindows()
         if let selectedWindow,
            let refreshed = availableWindows.first(where: {
                $0.id == selectedWindow.id && $0.ownerPID == selectedWindow.ownerPID
@@ -247,7 +277,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
 
     func requestInputMonitoring() {
         inputMonitoringAvailable =
-            CGPreflightListenEventAccess() || CGRequestListenEventAccess()
+            system.preflightListenAccess() || system.requestListenAccess()
         if !inputMonitoringAvailable {
             lastError =
                 NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
@@ -262,7 +292,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
 
         // macOS does not let an app revoke its own Input Monitoring grant. Keep
         // the switch truthful and direct the user to the system permission pane.
-        inputMonitoringAvailable = CGPreflightListenEventAccess()
+        inputMonitoringAvailable = system.preflightListenAccess()
         if inputMonitoringAvailable {
             lastError =
                 "To turn off Input Monitoring, remove Operations Floater in "
@@ -275,7 +305,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
             lastError = NeutralGeometryCaptureError.noWindow.localizedDescription
             return
         }
-        inputMonitoringAvailable = CGPreflightListenEventAccess()
+        inputMonitoringAvailable = system.preflightListenAccess()
         guard inputMonitoringAvailable else {
             lastError =
                 NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
@@ -323,9 +353,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
 
     func snapshot() throws -> NeutralGeometryCaptureSnapshot {
         guard let selected = selectedWindow,
-              let current = NeutralGeometryWindowCatalog.currentWindow(
-                  matching: selected
-              ) else {
+              let current = system.currentWindow(selected) else {
             throw NeutralGeometryCaptureError.windowChanged
         }
         let pending = Array(capturedEvents.dropFirst(deliveredEventCount))
@@ -490,7 +518,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
             .scrollWheel,
             .keyDown, .keyUp, .flagsChanged,
         ]
-        monitor = NSEvent.addGlobalMonitorForEvents(matching: mask) {
+        monitor = system.addGlobalMonitor(mask) {
             [weak self] event in
             let raw = Self.rawEvent(from: event)
             guard let raw else { return }
@@ -503,7 +531,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
 
     private func stopMonitor() {
         if let monitor {
-            NSEvent.removeMonitor(monitor)
+            system.removeMonitor(monitor)
             self.monitor = nil
         }
     }
@@ -579,9 +607,7 @@ final class NeutralGeometryCaptureSession: ObservableObject {
     private func ingest(_ raw: NeutralGeometryRawEvent) {
         guard mode == .recording,
               let selected = selectedWindow,
-              let current = NeutralGeometryWindowCatalog.currentWindow(
-                  matching: selected
-              ) else {
+              let current = system.currentWindow(selected) else {
             if mode == .recording {
                 revoke(reason: NeutralGeometryCaptureError.windowChanged.localizedDescription)
             }
@@ -590,13 +616,13 @@ final class NeutralGeometryCaptureSession: ObservableObject {
         selectedWindow = current
         let elapsed = elapsedMilliseconds(raw.timestampNanoseconds)
         let pointerAccepted = raw.location.map {
-            NeutralGeometryWindowCatalog.isTopmostAtPoint(current, point: $0)
+            system.isTopmostAtPoint(current, $0)
         } ?? false
         guard let event = Self.makeEvent(
             from: raw,
             bounds: current.bounds,
             pointerIsTopmost: pointerAccepted,
-            keyWindowIsActive: NeutralGeometryWindowCatalog.isActive(current),
+            keyWindowIsActive: system.isActive(current),
             eventID: nextEventID(),
             elapsedMilliseconds: elapsed
         ) else {

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -1,6 +1,7 @@
 // The executable entry point is intentionally not named main.swift: SwiftPM
 // reserves that filename for top-level program code, which conflicts with @main.
 import AppKit
+import Darwin
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -60,12 +61,55 @@ struct DashboardLaunchConfiguration: Equatable {
     }
 }
 
+/// Holds a process-scoped advisory lock for the lifetime of the application.
+///
+/// Launch Services normally reopens an existing application instance, but a
+/// direct executable launch or `open -n` can bypass that behavior. The lock
+/// keeps those alternate launch paths from creating a second recorder host.
+final class SingleInstanceLease {
+    private let descriptor: Int32
+
+    private init(descriptor: Int32) {
+        self.descriptor = descriptor
+    }
+
+    static func acquire(at lockURL: URL) throws -> SingleInstanceLease? {
+        try FileManager.default.createDirectory(
+            at: lockURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let descriptor = lockURL.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return Int32(-1) }
+            return Darwin.open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        }
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let lockError = errno
+            Darwin.close(descriptor)
+            if lockError == EWOULDBLOCK || lockError == EAGAIN {
+                return nil
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: lockError) ?? .EIO)
+        }
+        return SingleInstanceLease(descriptor: descriptor)
+    }
+
+    deinit {
+        flock(descriptor, LOCK_UN)
+        Darwin.close(descriptor)
+    }
+}
+
 @main
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let shared = AppDelegate()
     private let launchConfiguration: DashboardLaunchConfiguration
     private let dashboardState: DashboardState
+    private var instanceLease: SingleInstanceLease?
     private lazy var windowController = DashboardWindowController(
         state: dashboardState,
         activatesApplication: launchConfiguration.activatesApplication,
@@ -98,6 +142,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard claimSingleInstance() else { return }
         configureMainMenu()
         showDashboard(nil)
     }
@@ -158,6 +203,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.informativeText = message
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+
+    private func claimSingleInstance() -> Bool {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        let lockURL = applicationSupport
+            .appendingPathComponent("OperationsFloater", isDirectory: true)
+            .appendingPathComponent("application.instance.lock")
+        do {
+            guard let lease = try SingleInstanceLease.acquire(at: lockURL) else {
+                if let bundleIdentifier = Bundle.main.bundleIdentifier {
+                    NSRunningApplication.runningApplications(
+                        withBundleIdentifier: bundleIdentifier
+                    )
+                    .first(where: {
+                        $0.processIdentifier
+                            != ProcessInfo.processInfo.processIdentifier
+                    })?
+                    .activate(options: [.activateAllWindows])
+                }
+                NSApplication.shared.terminate(nil)
+                return false
+            }
+            instanceLease = lease
+            return true
+        } catch {
+            showAdapterError(
+                title: "Operations Floater Did Not Start",
+                message:
+                    "The app could not establish its single-instance lock. "
+                    + "No recorder or helper was started."
+            )
+            NSApplication.shared.terminate(nil)
+            return false
+        }
     }
 
     private func configureMainMenu() {

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -1117,6 +1117,7 @@ final class RouterChatSession: ObservableObject {
         await voice.start()
         guard voice.state == .listening else {
             let reason = voice.lastError ?? "Voice could not start."
+            voice.stop()
             geometryCapture.revoke(reason: reason)
             await modules.revokeFloor()
             lastError = reason

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -75,6 +75,21 @@ struct DashboardStateTests {
         #expect(!state.pinned)
     }
 
+    @Test("The application instance lease excludes a second process host")
+    func singleInstanceLeaseIsExclusive() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let lockURL = directory.appendingPathComponent("application.instance.lock")
+
+        var firstLease = try SingleInstanceLease.acquire(at: lockURL)
+        #expect(firstLease != nil)
+        #expect(try SingleInstanceLease.acquire(at: lockURL) == nil)
+
+        firstLease = nil
+        let replacementLease = try SingleInstanceLease.acquire(at: lockURL)
+        #expect(replacementLease != nil)
+    }
+
     @Test("Missing local state renders every lane empty")
     func missingLocalStateUsesEmptySnapshot() {
         let state = DashboardState(snapshotURL: missingFixtureURL(), liveClient: nil)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import OperationsFloater
@@ -411,6 +412,48 @@ private actor StubRouterTransport: RouterChatTransport {
     }
 }
 
+private final class RecorderActivationProbe: @unchecked Sendable {
+    var addMonitorCount = 0
+    var removeMonitorCount = 0
+    var requestPermissionCount = 0
+}
+
+private final class RecorderVoiceEngine: ConversationTranscriptionEngine,
+    @unchecked Sendable
+{
+    let provider: ConversationTranscriptProvider? = .syntheticFixture
+    let supportsOnDeviceRecognition = true
+    private(set) var isRunning = false
+    var resultHandler: (@Sendable (
+        Result<ConversationTranscriptResult, ConversationVoiceError>
+    ) -> Void)?
+
+    private let startError: ConversationVoiceError?
+
+    init(startError: ConversationVoiceError? = nil) {
+        self.startError = startError
+    }
+
+    func currentAuthorization() -> ConversationVoiceAuthorization {
+        .authorized
+    }
+
+    func requestAuthorization() async -> ConversationVoiceAuthorization {
+        .authorized
+    }
+
+    func start() throws {
+        if let startError {
+            throw startError
+        }
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+    }
+}
+
 @Suite("Router chat session")
 @MainActor
 struct RouterChatSessionTests {
@@ -664,6 +707,90 @@ struct RouterChatSessionTests {
         )
     }
 
+    @Test("Input Monitoring refusal rolls the floor back without requesting TCC")
+    func recorderPermissionFailureRollsBack() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: false,
+            monitorStarts: false,
+            probe: probe
+        )
+        let session = makeRecorderSession(capture: capture)
+        await session.enable()
+        let voice = VoiceConversationSession(
+            engine: RecorderVoiceEngine(),
+            speechOutput: SilentSpeechOutput()
+        )
+
+        await session.activateSelectedRecorder(with: voice)
+
+        #expect(session.modules.activeFloor == nil)
+        #expect(capture.mode == .disarmed)
+        #expect(voice.state == .off)
+        #expect(probe.requestPermissionCount == 0)
+        #expect(probe.addMonitorCount == 0)
+        #expect(
+            session.lastError
+                == NeutralGeometryCaptureError.inputMonitoringRequired.localizedDescription
+        )
+    }
+
+    @Test("Voice startup failure removes the event monitor and revokes the floor")
+    func recorderVoiceFailureRollsBack() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: true,
+            monitorStarts: true,
+            probe: probe
+        )
+        let session = makeRecorderSession(capture: capture)
+        await session.enable()
+        let voice = VoiceConversationSession(
+            engine: RecorderVoiceEngine(startError: .audioUnavailable),
+            speechOutput: SilentSpeechOutput()
+        )
+
+        await session.activateSelectedRecorder(with: voice)
+
+        #expect(session.modules.activeFloor == nil)
+        #expect(capture.mode == .disarmed)
+        #expect(voice.state == .off)
+        #expect(probe.addMonitorCount == 1)
+        #expect(probe.removeMonitorCount == 1)
+        #expect(
+            session.lastError == ConversationVoiceError.audioUnavailable.localizedDescription
+        )
+    }
+
+    @Test("Give floor commits only after recording and voice are both active")
+    func recorderAndVoiceStartTogether() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: true,
+            monitorStarts: true,
+            probe: probe
+        )
+        let session = makeRecorderSession(capture: capture)
+        await session.enable()
+        let voice = VoiceConversationSession(
+            engine: RecorderVoiceEngine(),
+            speechOutput: SilentSpeechOutput()
+        )
+
+        await session.activateSelectedRecorder(with: voice)
+
+        #expect(session.modules.activeFloor != nil)
+        #expect(capture.mode == .recording)
+        #expect(voice.state == .listening)
+        #expect(probe.addMonitorCount == 1)
+        #expect(probe.removeMonitorCount == 0)
+
+        voice.stop()
+        await session.revokeModuleFloor()
+        #expect(capture.mode == .disarmed)
+        #expect(probe.removeMonitorCount == 1)
+    }
+
     @Test("Collapsing chat suspends and clears its ephemeral lifecycle")
     func collapsedChatIsInactive() async {
         let session = RouterChatSession(
@@ -709,5 +836,72 @@ struct RouterChatSessionTests {
         for _ in 0..<100 where !session.reviewingMessageIDs.isEmpty {
             try? await Task.sleep(for: .milliseconds(10))
         }
+    }
+
+    private func makeRecorderSession(
+        capture: NeutralGeometryCaptureSession
+    ) -> RouterChatSession {
+        let session = RouterChatSession(
+            transport: StubRouterTransport(
+                available: true,
+                result: .success(localReply(text: "Unused"))
+            ),
+            geometryCapture: capture
+        )
+        session.selectConversationTarget(
+            ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+        )
+        return session
+    }
+
+    private func makeRecorderCapture(
+        inputMonitoringAvailable: Bool,
+        monitorStarts: Bool,
+        probe: RecorderActivationProbe
+    ) -> NeutralGeometryCaptureSession {
+        let window = NeutralGeometryWindow(
+            id: 42,
+            ownerPID: 4242,
+            ownerName: "Synthetic Fixture",
+            bounds: CGRect(x: 20, y: 20, width: 800, height: 600)
+        )
+        let system = NeutralGeometryCaptureSession.SystemInterface(
+            preflightListenAccess: { inputMonitoringAvailable },
+            requestListenAccess: {
+                probe.requestPermissionCount += 1
+                return inputMonitoringAvailable
+            },
+            visibleWindows: { [window] },
+            currentWindow: { selected in
+                selected.id == window.id ? window : nil
+            },
+            isActive: { _ in true },
+            isTopmostAtPoint: { _, _ in true },
+            addGlobalMonitor: { _, _ in
+                probe.addMonitorCount += 1
+                return monitorStarts ? NSObject() : nil
+            },
+            removeMonitor: { _ in
+                probe.removeMonitorCount += 1
+            }
+        )
+        let capture = NeutralGeometryCaptureSession(system: system)
+        capture.select(windowID: window.id)
+        return capture
+    }
+}
+
+private final class SilentSpeechOutput: ConversationSpeechOutput,
+    @unchecked Sendable
+{
+    private(set) var isSpeaking = false
+    var completionHandler: (@Sendable () -> Void)?
+
+    func speak(_ text: String) {
+        isSpeaking = true
+    }
+
+    func stop() {
+        isSpeaking = false
     }
 }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -418,6 +418,47 @@ private final class RecorderActivationProbe: @unchecked Sendable {
     var requestPermissionCount = 0
 }
 
+private actor RecorderConversationModule: ConversationModuleTransport {
+    private let provenance = ConversationModuleProvenance(
+        sourceID: ConversationModuleAllowlist.relativeXYRecorderManifest
+            .provenanceSourceID,
+        buildDigest: String(repeating: "a", count: 64)
+    )
+
+    func health(
+        for manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleHealth {
+        ConversationModuleHealth(
+            contractVersion: manifest.contractVersion,
+            moduleID: manifest.moduleID,
+            state: .ready,
+            privacy: manifest.privacy,
+            provenance: provenance
+        )
+    }
+
+    func perform(
+        _ request: ConversationModuleRequest,
+        manifest: ConversationModuleManifest
+    ) async throws -> ConversationModuleResponse {
+        ConversationModuleResponse(
+            contractVersion: request.contractVersion,
+            moduleID: request.moduleID,
+            requestID: request.requestID,
+            turnID: request.turnID,
+            sequence: request.sequence,
+            floor: request.floor,
+            state: .idle,
+            reply: nil,
+            statuses: [],
+            checkpoints: [],
+            question: nil,
+            proposedActions: [],
+            provenance: provenance
+        )
+    }
+}
+
 private final class RecorderVoiceEngine: ConversationTranscriptionEngine,
     @unchecked Sendable
 {
@@ -841,16 +882,24 @@ struct RouterChatSessionTests {
     private func makeRecorderSession(
         capture: NeutralGeometryCaptureSession
     ) -> RouterChatSession {
+        let manifest = ConversationModuleAllowlist.relativeXYRecorderManifest
+        let modules = ConversationModuleHostSession(
+            registrations: [
+                ConversationModuleRegistration(
+                    manifest: manifest,
+                    transport: RecorderConversationModule()
+                ),
+            ]
+        )
         let session = RouterChatSession(
             transport: StubRouterTransport(
                 available: true,
                 result: .success(localReply(text: "Unused"))
             ),
+            modules: modules,
             geometryCapture: capture
         )
-        session.selectConversationTarget(
-            ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
-        )
+        session.selectConversationTarget(manifest.moduleID)
         return session
     }
 

--- a/prototypes/operations-floater/Tests/permission-identity-preflight.test.sh
+++ b/prototypes/operations-floater/Tests/permission-identity-preflight.test.sh
@@ -21,6 +21,10 @@ if [[ "$1 $2" == "--display -r" ]]; then
   cp "$4/DESIGNATED_REQUIREMENT" "$3"
   exit
 fi
+if [[ "$1 $2" == "--display --verbose=4" ]]; then
+  cat "$3/SIGNATURE_REPORT" >&2
+  exit
+fi
 if [[ "$1 $2 $3" == "--verify --strict -R" ]]; then
   cmp -s "$4" "$5/ACCEPTED_REQUIREMENT"
   exit
@@ -54,6 +58,7 @@ make_app() {
     "CFBundleIdentifier=$bundle_id" \
     "CFBundleExecutable=Operations Floater" \
     "CFBundleVersion=$build" \
+    "CFBundleIconName=AppIcon" \
     >"$path/Contents/Info.plist"
   printf '#!/bin/bash\nexit 0\n' >"$path/Contents/MacOS/Operations Floater"
   chmod +x "$path/Contents/MacOS/Operations Floater"
@@ -62,6 +67,8 @@ make_app() {
   : >"$path/GATEKEEPER_ACCEPTED"
   printf '%s\n' "$requirement" >"$path/DESIGNATED_REQUIREMENT"
   printf '%s\n' "$requirement" >"$path/ACCEPTED_REQUIREMENT"
+  printf '%s\n' "Authority=Developer ID Application" "TeamIdentifier=TEAMABC123" \
+    >"$path/SIGNATURE_REPORT"
 }
 
 run_preflight() {
@@ -72,30 +79,34 @@ run_preflight() {
 }
 
 bundle_id=com.owner.operationsfloater
+team_id=TEAMABC123
 installed="$fixture_root/Installed.app"
 candidate="$fixture_root/Candidate.app"
-make_app "$installed" "$bundle_id" 7 'identifier com.owner.operationsfloater and anchor owner'
-make_app "$candidate" "$bundle_id" 8 'identifier com.owner.operationsfloater and anchor owner'
+make_app "$installed" "$bundle_id" 7 'identifier "com.owner.operationsfloater" and anchor owner'
+make_app "$candidate" "$bundle_id" 8 'identifier "com.owner.operationsfloater" and anchor owner'
 
 run_preflight \
   --candidate "$candidate" \
   --installed "$installed" \
   --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
   | /usr/bin/grep -q 'mutually requirement-compatible'
 
 first_install="$fixture_root/FirstInstall.app"
-make_app "$first_install" "$bundle_id" 1 'identifier com.owner.operationsfloater and anchor owner'
+make_app "$first_install" "$bundle_id" 1 'identifier "com.owner.operationsfloater" and anchor owner'
 run_preflight \
   --candidate "$first_install" \
   --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
   | /usr/bin/grep -q 'user grants Input Monitoring once'
 
 incompatible="$fixture_root/Incompatible.app"
-make_app "$incompatible" "$bundle_id" 9 'identifier com.owner.operationsfloater and anchor different-owner'
+make_app "$incompatible" "$bundle_id" 9 'identifier "com.owner.operationsfloater" and anchor different-owner'
 if run_preflight \
   --candidate "$incompatible" \
   --installed "$installed" \
   --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
   >/dev/null 2>&1
 then
   printf 'expected incompatible designated requirement to fail\n' >&2
@@ -103,12 +114,13 @@ then
 fi
 
 helper_candidate="$fixture_root/HelperCandidate.app"
-make_app "$helper_candidate" "$bundle_id" 9 'identifier com.owner.operationsfloater and anchor owner'
-mkdir -p "$helper_candidate/Contents/Library/LaunchAgents"
-: >"$helper_candidate/Contents/Library/LaunchAgents/com.owner.unexpected.plist"
+make_app "$helper_candidate" "$bundle_id" 9 'identifier "com.owner.operationsfloater" and anchor owner'
+mkdir -p "$helper_candidate/Contents/XPCServices/Unexpected.xpc/Contents/MacOS"
+: >"$helper_candidate/Contents/XPCServices/Unexpected.xpc/Contents/MacOS/Unexpected"
 if run_preflight \
   --candidate "$helper_candidate" \
   --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
   >/dev/null 2>&1
 then
   printf 'expected unexpected helper to fail\n' >&2
@@ -118,10 +130,43 @@ fi
 if run_preflight \
   --candidate "$candidate" \
   --expected-bundle-id com.example.operationsfloater \
+  --expected-team-id "$team_id" \
   >/dev/null 2>&1
 then
   printf 'expected placeholder release identifier to fail\n' >&2
   exit 1
 fi
 
-printf 'permission-identity synthetic preflight: PASS (4 cases)\n'
+adhoc_candidate="$fixture_root/AdHocCandidate.app"
+make_app "$adhoc_candidate" "$bundle_id" 10 "designated => cdhash H\"synthetic\""
+printf '%s\n' "Signature=adhoc" "TeamIdentifier=not set" \
+  >"$adhoc_candidate/SIGNATURE_REPORT"
+if run_preflight \
+  --candidate "$adhoc_candidate" \
+  --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
+  >/dev/null 2>&1
+then
+  printf 'expected ad-hoc identity to fail\n' >&2
+  exit 1
+fi
+
+wrong_team_candidate="$fixture_root/WrongTeamCandidate.app"
+make_app \
+  "$wrong_team_candidate" \
+  "$bundle_id" \
+  10 \
+  'identifier "com.owner.operationsfloater" and anchor owner'
+printf '%s\n' "Authority=Developer ID Application" "TeamIdentifier=OTHERTEAM9" \
+  >"$wrong_team_candidate/SIGNATURE_REPORT"
+if run_preflight \
+  --candidate "$wrong_team_candidate" \
+  --expected-bundle-id "$bundle_id" \
+  --expected-team-id "$team_id" \
+  >/dev/null 2>&1
+then
+  printf 'expected wrong Team Identifier to fail\n' >&2
+  exit 1
+fi
+
+printf 'permission-identity synthetic preflight: PASS (7 cases)\n'

--- a/prototypes/operations-floater/Tests/permission-identity-preflight.test.sh
+++ b/prototypes/operations-floater/Tests/permission-identity-preflight.test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -euo pipefail
+
+prototype_root=$(cd "$(dirname "$0")/.." && pwd)
+preflight="$prototype_root/scripts/verify-permission-identity.sh"
+fixture_root=$(/usr/bin/mktemp -d)
+trap '/bin/rm -rf "$fixture_root"' EXIT
+
+fake_codesign="$fixture_root/codesign"
+fake_spctl="$fixture_root/spctl"
+fake_plist_buddy="$fixture_root/PlistBuddy"
+
+cat >"$fake_codesign" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$1 $2 $3" == "--verify --deep --strict" ]]; then
+  [[ -f "$4/SIGNATURE_VALID" ]]
+  exit
+fi
+if [[ "$1 $2" == "--display -r" ]]; then
+  cp "$4/DESIGNATED_REQUIREMENT" "$3"
+  exit
+fi
+if [[ "$1 $2 $3" == "--verify --strict -R" ]]; then
+  cmp -s "$4" "$5/ACCEPTED_REQUIREMENT"
+  exit
+fi
+exit 2
+EOF
+
+cat >"$fake_spctl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ "$1 $2 $3" == "--assess --type execute" ]]
+[[ -f "$4/GATEKEEPER_ACCEPTED" ]]
+EOF
+
+cat >"$fake_plist_buddy" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+key=${2#Print :}
+awk -F= -v key="$key" '$1 == key { print substr($0, length(key) + 2); found=1 } END { exit !found }' "$3"
+EOF
+
+chmod +x "$fake_codesign" "$fake_spctl" "$fake_plist_buddy"
+
+make_app() {
+  local path=$1
+  local bundle_id=$2
+  local build=$3
+  local requirement=$4
+  mkdir -p "$path/Contents/MacOS" "$path/Contents/Resources"
+  printf '%s\n' \
+    "CFBundleIdentifier=$bundle_id" \
+    "CFBundleExecutable=Operations Floater" \
+    "CFBundleVersion=$build" \
+    >"$path/Contents/Info.plist"
+  printf '#!/bin/bash\nexit 0\n' >"$path/Contents/MacOS/Operations Floater"
+  chmod +x "$path/Contents/MacOS/Operations Floater"
+  : >"$path/Contents/Resources/Assets.car"
+  : >"$path/SIGNATURE_VALID"
+  : >"$path/GATEKEEPER_ACCEPTED"
+  printf '%s\n' "$requirement" >"$path/DESIGNATED_REQUIREMENT"
+  printf '%s\n' "$requirement" >"$path/ACCEPTED_REQUIREMENT"
+}
+
+run_preflight() {
+  CODESIGN_BIN="$fake_codesign" \
+    SPCTL_BIN="$fake_spctl" \
+    PLIST_BUDDY_BIN="$fake_plist_buddy" \
+    "$preflight" "$@"
+}
+
+bundle_id=com.owner.operationsfloater
+installed="$fixture_root/Installed.app"
+candidate="$fixture_root/Candidate.app"
+make_app "$installed" "$bundle_id" 7 'identifier com.owner.operationsfloater and anchor owner'
+make_app "$candidate" "$bundle_id" 8 'identifier com.owner.operationsfloater and anchor owner'
+
+run_preflight \
+  --candidate "$candidate" \
+  --installed "$installed" \
+  --expected-bundle-id "$bundle_id" \
+  | /usr/bin/grep -q 'mutually requirement-compatible'
+
+first_install="$fixture_root/FirstInstall.app"
+make_app "$first_install" "$bundle_id" 1 'identifier com.owner.operationsfloater and anchor owner'
+run_preflight \
+  --candidate "$first_install" \
+  --expected-bundle-id "$bundle_id" \
+  | /usr/bin/grep -q 'user grants Input Monitoring once'
+
+incompatible="$fixture_root/Incompatible.app"
+make_app "$incompatible" "$bundle_id" 9 'identifier com.owner.operationsfloater and anchor different-owner'
+if run_preflight \
+  --candidate "$incompatible" \
+  --installed "$installed" \
+  --expected-bundle-id "$bundle_id" \
+  >/dev/null 2>&1
+then
+  printf 'expected incompatible designated requirement to fail\n' >&2
+  exit 1
+fi
+
+helper_candidate="$fixture_root/HelperCandidate.app"
+make_app "$helper_candidate" "$bundle_id" 9 'identifier com.owner.operationsfloater and anchor owner'
+mkdir -p "$helper_candidate/Contents/Library/LaunchAgents"
+: >"$helper_candidate/Contents/Library/LaunchAgents/com.owner.unexpected.plist"
+if run_preflight \
+  --candidate "$helper_candidate" \
+  --expected-bundle-id "$bundle_id" \
+  >/dev/null 2>&1
+then
+  printf 'expected unexpected helper to fail\n' >&2
+  exit 1
+fi
+
+if run_preflight \
+  --candidate "$candidate" \
+  --expected-bundle-id com.example.operationsfloater \
+  >/dev/null 2>&1
+then
+  printf 'expected placeholder release identifier to fail\n' >&2
+  exit 1
+fi
+
+printf 'permission-identity synthetic preflight: PASS (4 cases)\n'

--- a/prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md
+++ b/prototypes/operations-floater/docs/BACKGROUND_UI_TESTING.md
@@ -13,7 +13,7 @@ Mission Control step remains user-controlled.
    mode:
 
    ```bash
-   open -g -n "/path/to/Operations Floater.app" \
+   open -g "/path/to/Operations Floater.app" \
      --args --background-ui-test
    ```
 
@@ -38,8 +38,8 @@ candidate with a different bundle identifier needs its own one-time assignment.
 - snapshots, validation, privacy boundaries, chat defaults, and schema `1.0`
   remain unchanged.
 
-Normal launches intentionally retain the existing foreground, pinned, and
-all-Spaces behavior.
+Normal launches intentionally retain foreground activation. Every launch is
+unpinned by default and uses one Space.
 
 ```text
 User creates spare Desktop once
@@ -70,6 +70,8 @@ open -g ... --args --background-ui-test
 - This mode reduces interruption; it does not claim that every macOS release,
   window manager, or third-party utility will preserve focus identically.
 
-Before each run, verify that no old Operations Floater process remains. Start
-one instance, record its exact executable path and PID, and terminate that exact
-test instance during cleanup.
+Before each run, verify that no old Operations Floater process remains. Launch
+without `open -n`; a repeated LaunchServices open should route to the existing
+process, and the app also rejects a duplicate same-bundle process before
+creating a second dashboard window. Record the exact test executable path and
+PID, and terminate only that exact test instance during cleanup.

--- a/prototypes/operations-floater/docs/PERMISSION_AND_INSTALL_LIFECYCLE.md
+++ b/prototypes/operations-floater/docs/PERMISSION_AND_INSTALL_LIFECYCLE.md
@@ -1,0 +1,91 @@
+# Permission and install lifecycle
+
+## Why routine rebuilds lose Input Monitoring
+
+macOS grants privacy-protected resources to a code identity, not merely to an
+application name or icon. Apple documents that the designated requirement (DR)
+is the rule macOS uses to recognize later versions of signed code. An unsigned
+app has no DR, while an ad-hoc signature is tied to that specific version of the
+code. Replacing an installed ad-hoc build can therefore present a new identity
+to TCC.
+
+The checked-in `com.example.operationsfloater` identifier and unsigned or
+ad-hoc builds are disposable source-validation artifacts. They are never
+install candidates and must not be launched as the permission-bearing copy.
+
+## Stable release identity
+
+An installable candidate preserves all of these across releases:
+
+1. one owner-controlled, non-placeholder bundle identifier;
+2. one owner-controlled Apple signing team;
+3. an Xcode-produced Developer ID Application DR based on team and identifier,
+   not one executable CDHash;
+4. the canonical `/Applications/Operations Floater.app` path; and
+5. the main application executable as the sole Input Monitoring client.
+
+Developer ID Application plus notarization is the distribution target. Signing,
+notarization, installation, and the first owner-controlled TCC grant are
+separate owner gates. A future Mac App Store variant needs Apple's mutually
+compatible-DR procedure; do not hand-author a custom DR.
+
+## Build and install separation
+
+Routine validation on the active macOS account uses SwiftPM plus synthetic
+fixture tests. It does not create or launch an application bundle.
+
+Battle testing with Xcode 26.5 found that both `xcodebuild build` and
+`xcodebuild archive` invoke `lsregister` for the generated app. Supplying
+`REGISTER_WITH_LAUNCH_SERVICES=NO` did not suppress that phase. Do not treat
+that build setting as an isolation boundary. App-bundle compilation must run on
+a disposable macOS account or CI runner whose Launch Services database is not
+the owner's active application profile.
+
+Only an owner-gated release job may inject the bundle identifier and team,
+sign, notarize, pass the read-only identity gate, and produce an install
+candidate. Only a separately gated install may replace the canonical app.
+
+For first install, run the identity gate without `--installed`. For updates,
+provide both apps; the gate verifies the signatures and Team Identifier, rejects
+ad-hoc/CDHash-only identity and unexpected helpers, and proves the installed and
+candidate DRs mutually compatible.
+
+## Helper lifecycle
+
+Operations Floater currently embeds no LaunchAgent, Login Item, XPC service,
+daemon, privileged helper, or updater. Selected-window monitoring belongs to
+the main application process, so TCC has one client identity.
+
+A future helper requires a separate bundle identifier, stable signature, DR,
+`SMAppService` registration plan, rollback path, permission analysis, and owner
+gate. The identity preflight rejects helper payloads until that lifecycle is
+reviewed. Stale helper inspection/removal is also an owner-controlled
+maintenance action.
+
+## Runtime invariants
+
+- Launch Services routes a repeated open to the running app. A process-scoped
+  advisory lock prevents direct executable launches or `open -n` from starting
+  a second recorder host.
+- The retained controller owns one dashboard window per process.
+- The window is managed on one Space and never joins all Spaces.
+- **Give floor** grants the module floor, starts selected-window recording, and
+  then starts voice. Recording failure revokes recorder state and floor. Voice
+  failure stops voice, removes the event monitor, and revokes recorder state and
+  floor. Only complete activation remains live.
+- Returning to the dashboard, collapsing chat, or clearing the session stops
+  voice and clears ephemeral recorder state.
+
+## Safe validation
+
+Automated validation on the active account uses only synthetic window,
+event-monitor, voice, signing, Gatekeeper, plist, and DR fixtures. It must not
+call `CGRequestListenEventAccess`, create or register an app bundle, launch a
+candidate, mutate TCC or System Settings, install over the active app, sign,
+notarize, publish, or release.
+
+References:
+
+- [Apple TN3127: Inside Code Signing — Requirements](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements)
+- [Apple: Creating distribution-signed code for macOS](https://developer.apple.com/documentation/xcode/creating-distribution-signed-code-for-the-mac)
+- [Apple: CGPreflightListenEventAccess](https://developer.apple.com/documentation/coregraphics/cgpreflightlisteneventaccess%28%29)

--- a/prototypes/operations-floater/project.yml
+++ b/prototypes/operations-floater/project.yml
@@ -19,6 +19,8 @@ targets:
       properties:
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: public.app-category.productivity
+        CFBundleShortVersionString: "1.1.0"
+        CFBundleVersion: "2"
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         NSMicrophoneUsageDescription: Start Voice Conversation uses the microphone only while you explicitly listen.

--- a/prototypes/operations-floater/scripts/verify-permission-identity.sh
+++ b/prototypes/operations-floater/scripts/verify-permission-identity.sh
@@ -7,6 +7,7 @@ Usage:
   verify-permission-identity.sh \
     --candidate /absolute/path/Operations\ Floater.app \
     --expected-bundle-id com.example.owner.operationsfloater \
+    --expected-team-id ABCDE12345 \
     [--installed /absolute/path/Operations\ Floater.app]
 
 Read-only preflight for a first install or update. It never signs, copies,
@@ -22,6 +23,7 @@ fail() {
 candidate_app=
 installed_app=
 expected_bundle_id=
+expected_team_id=
 while (($#)); do
   case "$1" in
     --candidate)
@@ -39,6 +41,11 @@ while (($#)); do
       expected_bundle_id=$2
       shift 2
       ;;
+    --expected-team-id)
+      (($# >= 2)) || fail "--expected-team-id requires a value"
+      expected_team_id=$2
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -51,6 +58,7 @@ done
 
 [[ -n "$candidate_app" ]] || fail "--candidate is required"
 [[ -n "$expected_bundle_id" ]] || fail "--expected-bundle-id is required"
+[[ -n "$expected_team_id" ]] || fail "--expected-team-id is required"
 [[ "$candidate_app" == /* ]] || fail "candidate path must be absolute"
 if [[ -n "$installed_app" ]]; then
   [[ "$installed_app" == /* ]] || fail "installed path must be absolute"
@@ -58,6 +66,11 @@ fi
 case "$expected_bundle_id" in
   com.example.*|*.example|*'*'*|'')
     fail "expected bundle identifier must be the owner-controlled release identifier"
+    ;;
+esac
+case "$expected_team_id" in
+  *[!A-Za-z0-9]*|not-set|NOTSET|'')
+    fail "expected Team Identifier must be the owner-controlled release team"
     ;;
 esac
 
@@ -80,7 +93,8 @@ reject_embedded_helpers() {
     Contents/Library/LaunchAgents \
     Contents/Library/LaunchDaemons \
     Contents/Library/LaunchServices \
-    Contents/Library/PrivilegedHelperTools
+    Contents/Library/PrivilegedHelperTools \
+    Contents/XPCServices
   do
     [[ -d "$app/$relative" ]] || continue
     helper=$(/usr/bin/find "$app/$relative" -type f -print -quit)
@@ -93,6 +107,9 @@ verify_bundle_shape() {
   local label=$2
   local bundle_id
   local executable
+  local icon_name
+  local signature_report
+  local actual_team_id
   local ui_element
 
   [[ -d "$app" ]] || fail "$label app does not exist: $app"
@@ -114,11 +131,30 @@ verify_bundle_shape() {
         ;;
     esac
   fi
-  [[ -f "$app/Contents/Resources/Assets.car" ]] \
-    || fail "$label compiled application icon catalog is missing"
+  icon_name=$(plist_value "$app" CFBundleIconName) \
+    || fail "$label application icon declaration is missing"
+  [[ -n "$icon_name" ]] || fail "$label application icon name is empty"
+  [[ -f "$app/Contents/Resources/AppIcon.icns" \
+      || -f "$app/Contents/Resources/Assets.car" ]] \
+    || fail "$label compiled application icon resources are missing"
   reject_embedded_helpers "$app"
   "$codesign_bin" --verify --deep --strict "$app" >/dev/null 2>&1 \
     || fail "$label signature is invalid"
+  signature_report=$(
+    "$codesign_bin" --display --verbose=4 "$app" 2>&1
+  ) || fail "$label signature metadata is unreadable"
+  case "$signature_report" in
+    *"Signature=adhoc"*|*"TeamIdentifier=not set"*)
+      fail "$label uses an ad-hoc identity that changes across rebuilds"
+      ;;
+  esac
+  actual_team_id=$(
+    printf '%s\n' "$signature_report" \
+      | /usr/bin/sed -n 's/^TeamIdentifier=//p' \
+      | /usr/bin/head -n 1
+  )
+  [[ "$actual_team_id" == "$expected_team_id" ]] \
+    || fail "$label Team Identifier does not match the expected release team"
   "$spctl_bin" --assess --type execute "$app" >/dev/null 2>&1 \
     || fail "$label fails Gatekeeper assessment"
 }
@@ -133,6 +169,11 @@ candidate_requirement="$temporary_directory/candidate.requirement"
   || fail "candidate designated requirement is unavailable"
 [[ -s "$candidate_requirement" ]] \
   || fail "candidate designated requirement is empty"
+if /usr/bin/grep -Fq "cdhash H" "$candidate_requirement"; then
+  fail "candidate designated requirement is tied to one executable hash"
+fi
+/usr/bin/grep -Fq "identifier \"$expected_bundle_id\"" "$candidate_requirement" \
+  || fail "candidate designated requirement does not bind the expected identifier"
 
 if [[ -z "$installed_app" ]]; then
   printf '%s\n' \
@@ -147,6 +188,11 @@ installed_requirement="$temporary_directory/installed.requirement"
   || fail "installed designated requirement is unavailable"
 [[ -s "$installed_requirement" ]] \
   || fail "installed designated requirement is empty"
+if /usr/bin/grep -Fq "cdhash H" "$installed_requirement"; then
+  fail "installed designated requirement is tied to one executable hash"
+fi
+/usr/bin/grep -Fq "identifier \"$expected_bundle_id\"" "$installed_requirement" \
+  || fail "installed designated requirement does not bind the expected identifier"
 
 "$codesign_bin" --verify --strict -R "$installed_requirement" "$candidate_app" \
   >/dev/null 2>&1 \

--- a/prototypes/operations-floater/scripts/verify-permission-identity.sh
+++ b/prototypes/operations-floater/scripts/verify-permission-identity.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  verify-permission-identity.sh \
+    --candidate /absolute/path/Operations\ Floater.app \
+    --expected-bundle-id com.example.owner.operationsfloater \
+    [--installed /absolute/path/Operations\ Floater.app]
+
+Read-only preflight for a first install or update. It never signs, copies,
+launches, terminates, grants/resets TCC, or changes System Settings.
+EOF
+}
+
+fail() {
+  printf 'permission-identity preflight: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+candidate_app=
+installed_app=
+expected_bundle_id=
+while (($#)); do
+  case "$1" in
+    --candidate)
+      (($# >= 2)) || fail "--candidate requires a path"
+      candidate_app=$2
+      shift 2
+      ;;
+    --installed)
+      (($# >= 2)) || fail "--installed requires a path"
+      installed_app=$2
+      shift 2
+      ;;
+    --expected-bundle-id)
+      (($# >= 2)) || fail "--expected-bundle-id requires a value"
+      expected_bundle_id=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$candidate_app" ]] || fail "--candidate is required"
+[[ -n "$expected_bundle_id" ]] || fail "--expected-bundle-id is required"
+[[ "$candidate_app" == /* ]] || fail "candidate path must be absolute"
+if [[ -n "$installed_app" ]]; then
+  [[ "$installed_app" == /* ]] || fail "installed path must be absolute"
+fi
+case "$expected_bundle_id" in
+  com.example.*|*.example|*'*'*|'')
+    fail "expected bundle identifier must be the owner-controlled release identifier"
+    ;;
+esac
+
+codesign_bin=${CODESIGN_BIN:-/usr/bin/codesign}
+spctl_bin=${SPCTL_BIN:-/usr/sbin/spctl}
+plist_buddy_bin=${PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}
+
+plist_value() {
+  local app=$1
+  local key=$2
+  "$plist_buddy_bin" -c "Print :$key" "$app/Contents/Info.plist" 2>/dev/null
+}
+
+reject_embedded_helpers() {
+  local app=$1
+  local relative
+  local helper
+  for relative in \
+    Contents/Library/LoginItems \
+    Contents/Library/LaunchAgents \
+    Contents/Library/LaunchDaemons \
+    Contents/Library/LaunchServices \
+    Contents/Library/PrivilegedHelperTools
+  do
+    [[ -d "$app/$relative" ]] || continue
+    helper=$(/usr/bin/find "$app/$relative" -type f -print -quit)
+    [[ -z "$helper" ]] || fail "$app contains an unexpected helper at $helper"
+  done
+}
+
+verify_bundle_shape() {
+  local app=$1
+  local label=$2
+  local bundle_id
+  local executable
+  local ui_element
+
+  [[ -d "$app" ]] || fail "$label app does not exist: $app"
+  [[ -f "$app/Contents/Info.plist" ]] || fail "$label Info.plist is missing"
+  bundle_id=$(plist_value "$app" CFBundleIdentifier) \
+    || fail "$label bundle identifier is unreadable"
+  [[ "$bundle_id" == "$expected_bundle_id" ]] \
+    || fail "$label bundle identifier is $bundle_id, expected $expected_bundle_id"
+  executable=$(plist_value "$app" CFBundleExecutable) \
+    || fail "$label executable name is unreadable"
+  [[ "$executable" != */* && -n "$executable" ]] \
+    || fail "$label executable name is unsafe"
+  [[ -x "$app/Contents/MacOS/$executable" ]] \
+    || fail "$label executable is missing or not executable"
+  if ui_element=$(plist_value "$app" LSUIElement); then
+    case "$ui_element" in
+      true|TRUE|yes|YES|1)
+        fail "$label is an agent-only app and would not provide the audited Dock launcher"
+        ;;
+    esac
+  fi
+  [[ -f "$app/Contents/Resources/Assets.car" ]] \
+    || fail "$label compiled application icon catalog is missing"
+  reject_embedded_helpers "$app"
+  "$codesign_bin" --verify --deep --strict "$app" >/dev/null 2>&1 \
+    || fail "$label signature is invalid"
+  "$spctl_bin" --assess --type execute "$app" >/dev/null 2>&1 \
+    || fail "$label fails Gatekeeper assessment"
+}
+
+verify_bundle_shape "$candidate_app" "candidate"
+
+temporary_directory=$(/usr/bin/mktemp -d)
+trap '/bin/rm -rf "$temporary_directory"' EXIT
+candidate_requirement="$temporary_directory/candidate.requirement"
+"$codesign_bin" --display -r "$candidate_requirement" "$candidate_app" \
+  >/dev/null 2>&1 \
+  || fail "candidate designated requirement is unavailable"
+[[ -s "$candidate_requirement" ]] \
+  || fail "candidate designated requirement is empty"
+
+if [[ -z "$installed_app" ]]; then
+  printf '%s\n' \
+    "permission-identity preflight: PASS: signed first-install candidate; user grants Input Monitoring once after installation"
+  exit 0
+fi
+
+verify_bundle_shape "$installed_app" "installed"
+installed_requirement="$temporary_directory/installed.requirement"
+"$codesign_bin" --display -r "$installed_requirement" "$installed_app" \
+  >/dev/null 2>&1 \
+  || fail "installed designated requirement is unavailable"
+[[ -s "$installed_requirement" ]] \
+  || fail "installed designated requirement is empty"
+
+"$codesign_bin" --verify --strict -R "$installed_requirement" "$candidate_app" \
+  >/dev/null 2>&1 \
+  || fail "candidate does not satisfy the installed app designated requirement"
+"$codesign_bin" --verify --strict -R "$candidate_requirement" "$installed_app" \
+  >/dev/null 2>&1 \
+  || fail "installed app does not satisfy the candidate designated requirement"
+
+candidate_build=$(plist_value "$candidate_app" CFBundleVersion) \
+  || fail "candidate build version is unreadable"
+installed_build=$(plist_value "$installed_app" CFBundleVersion) \
+  || fail "installed build version is unreadable"
+[[ "$candidate_build" =~ ^[0-9]+$ && "$installed_build" =~ ^[0-9]+$ ]] \
+  || fail "build versions must be monotonic integers"
+((candidate_build > installed_build)) \
+  || fail "candidate build $candidate_build must be newer than installed build $installed_build"
+
+printf '%s\n' \
+  "permission-identity preflight: PASS: update is mutually requirement-compatible; existing TCC grants are eligible to persist"


### PR DESCRIPTION
## Outcome

Make Operations Floater 1.1.0 (build 2) preserve a stable permission-bearing identity across signed updates and make **Give floor** transactional across selected-window recording and voice startup.

## What changed

- add a read-only release preflight that rejects placeholder bundle IDs, wrong Team IDs, ad-hoc/CDHash requirements, incompatible installed/candidate designated requirements, non-monotonic builds, missing icon metadata, and unexpected helpers/XPC services
- enforce one recorder host with a process-scoped application lease while retaining one-window/one-Space behavior
- roll back floor ownership, selected-window monitoring, event monitor state, and voice on either startup failure
- isolate Input Monitoring and voice lifecycle tests behind synthetic interfaces; no test calls the permission request API
- bump the prototype to 1.1.0 build 2 and update both changelogs plus install/update/rollback documentation
- document the tested Xcode 26.5 limitation: both `build` and `archive` invoke `lsregister` despite `REGISTER_WITH_LAUNCH_SERVICES=NO`; routine validation on the active macOS profile is therefore SwiftPM + synthetic only, and app-bundle compilation requires a disposable macOS account or CI runner

## Validation

- `swift test` — 97 tests pass
- repeated `swift test --skip-build` — 10/10 passes (970 test executions)
- synthetic identity preflight — 25/25 passes, 7 scenarios per run (175 scenario executions)
- shell parse and `git diff --check` — pass
- Firestarter all-stack Docker stamp/token/workflow/shell gate — pass on the first candidate commit; follow-up changes are confined to the prototype, tests, and documentation

One full-suite race was found during battle testing: the new lifecycle tests were accidentally using the live loopback module health transport. The tests now inject a deterministic synthetic module and passed all repeat runs.

## Safety boundary

No TCC/System Settings mutation or prompt, active app replacement, app launch, signing, notarization, credential/keychain access, release, or deployment was performed. Xcode did register task-owned placeholder build paths during the bounded validation attempt; that side effect is documented, no task app is running or installed, and the selected disposition is to leave stale task-path registrations alone rather than mutate Launch Services. The pre-existing `/Applications/Operations Floater.app` remains untouched.
