### PR TITLE
fix(build): retain Operations Floater launcher icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to the firestarter template. See
   synthetic tests that never sign, install, launch, or request TCC access.
   Routine validation is bundle-free on the active macOS profile because Xcode
   26.5 still invokes `lsregister` despite
-  `REGISTER_WITH_LAUNCH_SERVICES=NO`.
+  `REGISTER_WITH_LAUNCH_SERVICES=NO`; XcodeGen source now retains both the
+  `AppIcon` plist and asset-compiler declarations.
 - Unified operations-dashboard reference sources under `prototypes/`: a strict
   privacy-neutral contract, native macOS floater with validated local snapshot
   import/rollback, sanitized static web renderer, and offline content-addressed

--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -13,6 +13,8 @@
   `REGISTER_WITH_LAUNCH_SERVICES=NO` is supplied.
 - Enforce one recorder host with a process-scoped application lease while
   retaining the existing single-Space window policy and Dock launcher.
+- Keep the `AppIcon` plist and asset-compiler declarations in the XcodeGen
+  source of truth so regenerating the project cannot drop the Dock icon.
 - Roll back floor ownership, selected-window recording, the global event
   monitor, and voice state when either half of **Give floor** fails to start.
 - Reject unexpected embedded login items, agents, daemons, privileged helpers,

--- a/prototypes/operations-floater/Info.plist
+++ b/prototypes/operations-floater/Info.plist
@@ -8,6 +8,8 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -208,6 +208,28 @@ struct GuidePresentationTests {
         #expect(transport["NSAllowsArbitraryLoads"] == nil)
     }
 
+    @Test("Application metadata keeps the launcher icon and release version")
+    func applicationMetadataRemainsRegeneratable() throws {
+        let root = packageRoot()
+        let data = try Data(contentsOf: root.appendingPathComponent("Info.plist"))
+        let value = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        )
+        let info = try #require(value as? [String: Any])
+        let project = try String(
+            contentsOf: root.appendingPathComponent("project.yml"),
+            encoding: .utf8
+        )
+
+        #expect(info["CFBundleIconName"] as? String == "AppIcon")
+        #expect(info["CFBundleShortVersionString"] as? String == "1.1.0")
+        #expect(info["CFBundleVersion"] as? String == "2")
+        #expect(project.contains("CFBundleIconName: AppIcon"))
+        #expect(project.contains("ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon"))
+    }
+
     private func makeSnapshot(
         queue: [QueueRecord] = [],
         tests: [TestRecord] = [],

--- a/prototypes/operations-floater/project.yml
+++ b/prototypes/operations-floater/project.yml
@@ -17,6 +17,7 @@ targets:
     info:
       path: Info.plist
       properties:
+        CFBundleIconName: AppIcon
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: public.app-category.productivity
         CFBundleShortVersionString: "1.1.0"
@@ -27,6 +28,7 @@ targets:
         NSSpeechRecognitionUsageDescription: Voice Conversation requires on-device speech recognition and keeps transcripts ephemeral.
     settings:
       base:
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_ENTITLEMENTS: OperationsFloater.entitlements
         ENABLE_APP_SANDBOX: YES
         ENABLE_HARDENED_RUNTIME: YES


### PR DESCRIPTION
## Outcome

Retain the Operations Floater Dock/launcher icon when the checked-in Xcode project is regenerated from `project.yml`.

## Root cause and fix

Exact-default validation after #48 found that `OperationsFloater.xcodeproj` had `ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon`, but the XcodeGen source of truth did not. Regenerating the project could therefore silently remove the icon setting.

- declare `CFBundleIconName: AppIcon` in both the plist and XcodeGen metadata
- declare `ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon` in `project.yml`
- add a regression test for the icon declarations and 1.1.0 build 2 metadata
- update prototype and root changelogs

## Validation

- `swift test` — 98 tests pass
- repeated `swift test --skip-build` — 5/5 pass
- synthetic identity preflight — 10/10 pass (70 scenario executions)
- disposable `xcodegen generate` project audit — AppIcon compiler setting retained
- `git diff --check` — pass

No app bundle was compiled, registered, launched, installed, signed, notarized, or released. TCC, System Settings, Launch Services, and the pre-existing `/Applications/Operations Floater.app` were untouched.
