### PR TITLE
fix(recorder): make activation transactional

### DIFF
--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -2,6 +2,42 @@ import Combine
 import Foundation
 import SwiftUI
 
+enum RecorderActivationResult: Equatable {
+    case activated
+    case failed(reason: String, changedConversationControl: Bool)
+}
+
+@MainActor
+enum RecorderActivationTransaction {
+    static func run(
+        grantFloor: () async -> String?,
+        startRecording: () -> String?,
+        startVoice: () async -> String?,
+        stopVoice: () -> Void,
+        revokeRecording: (String) -> Void,
+        revokeFloor: () async -> Void
+    ) async -> RecorderActivationResult {
+        if let reason = await grantFloor() {
+            return .failed(reason: reason, changedConversationControl: false)
+        }
+
+        if let reason = startRecording() {
+            revokeRecording(reason)
+            await revokeFloor()
+            return .failed(reason: reason, changedConversationControl: true)
+        }
+
+        if let reason = await startVoice() {
+            stopVoice()
+            revokeRecording(reason)
+            await revokeFloor()
+            return .failed(reason: reason, changedConversationControl: true)
+        }
+
+        return .activated
+    }
+}
+
 enum RouterAvailability: Equatable, Sendable {
     case disabled
     case checking
@@ -1096,33 +1132,45 @@ final class RouterChatSession: ObservableObject {
             return
         }
 
-        await modules.grantSelectedFloor()
-        guard modules.activeFloor != nil else {
-            lastError = modules.lastError
-                ?? "The selected recorder could not receive the floor."
-            return
-        }
-
-        geometryCapture.start()
-        guard geometryCapture.mode == .recording else {
-            let reason = geometryCapture.lastError
-                ?? "Input monitoring is required before recording can start."
-            geometryCapture.revoke(reason: reason)
-            await modules.revokeFloor()
+        let result = await RecorderActivationTransaction.run(
+            grantFloor: {
+                await self.modules.grantSelectedFloor()
+                return self.modules.activeFloor == nil
+                    ? self.modules.lastError
+                        ?? "The selected recorder could not receive the floor."
+                    : nil
+            },
+            startRecording: {
+                self.geometryCapture.start()
+                return self.geometryCapture.mode == .recording
+                    ? nil
+                    : self.geometryCapture.lastError
+                        ?? "Input monitoring is required before recording can start."
+            },
+            startVoice: {
+                await voice.start()
+                return voice.state == .listening
+                    ? nil
+                    : voice.lastError ?? "Voice could not start."
+            },
+            stopVoice: {
+                voice.stop()
+            },
+            revokeRecording: { reason in
+                self.geometryCapture.revoke(reason: reason)
+            },
+            revokeFloor: {
+                await self.modules.revokeFloor()
+            }
+        )
+        switch result {
+        case .activated:
+            lastError = nil
+        case .failed(let reason, let changedConversationControl):
             lastError = reason
-            onConversationControlChanged?()
-            return
-        }
-
-        await voice.start()
-        guard voice.state == .listening else {
-            let reason = voice.lastError ?? "Voice could not start."
-            voice.stop()
-            geometryCapture.revoke(reason: reason)
-            await modules.revokeFloor()
-            lastError = reason
-            onConversationControlChanged?()
-            return
+            if changedConversationControl {
+                onConversationControlChanged?()
+            }
         }
     }
 

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -832,6 +832,132 @@ struct RouterChatSessionTests {
         #expect(probe.removeMonitorCount == 1)
     }
 
+    @Test("Recorder startup revokes floor when recording cannot start")
+    func recorderStartupRollsBackRecordingFailure() async {
+        var calls: [String] = []
+
+        let result = await RecorderActivationTransaction.run(
+            grantFloor: {
+                calls.append("grant floor")
+                return nil
+            },
+            startRecording: {
+                calls.append("start recording")
+                return "Input Monitoring is unavailable."
+            },
+            startVoice: {
+                calls.append("start voice")
+                return nil
+            },
+            stopVoice: {
+                calls.append("stop voice")
+            },
+            revokeRecording: { _ in
+                calls.append("revoke recording")
+            },
+            revokeFloor: {
+                calls.append("revoke floor")
+            }
+        )
+
+        #expect(
+            result
+                == .failed(
+                    reason: "Input Monitoring is unavailable.",
+                    changedConversationControl: true
+                )
+        )
+        #expect(
+            calls
+                == [
+                    "grant floor",
+                    "start recording",
+                    "revoke recording",
+                    "revoke floor"
+                ]
+        )
+    }
+
+    @Test("Recorder startup stops voice and revokes recording on voice failure")
+    func recorderStartupRollsBackVoiceFailure() async {
+        var calls: [String] = []
+
+        let result = await RecorderActivationTransaction.run(
+            grantFloor: {
+                calls.append("grant floor")
+                return nil
+            },
+            startRecording: {
+                calls.append("start recording")
+                return nil
+            },
+            startVoice: {
+                calls.append("start voice")
+                return "Voice is unavailable."
+            },
+            stopVoice: {
+                calls.append("stop voice")
+            },
+            revokeRecording: { _ in
+                calls.append("revoke recording")
+            },
+            revokeFloor: {
+                calls.append("revoke floor")
+            }
+        )
+
+        #expect(
+            result
+                == .failed(
+                    reason: "Voice is unavailable.",
+                    changedConversationControl: true
+                )
+        )
+        #expect(
+            calls
+                == [
+                    "grant floor",
+                    "start recording",
+                    "start voice",
+                    "stop voice",
+                    "revoke recording",
+                    "revoke floor"
+                ]
+        )
+    }
+
+    @Test("Recorder startup keeps all resources after complete activation")
+    func recorderStartupCommitsOnlyAfterEveryStepSucceeds() async {
+        var calls: [String] = []
+
+        let result = await RecorderActivationTransaction.run(
+            grantFloor: {
+                calls.append("grant floor")
+                return nil
+            },
+            startRecording: {
+                calls.append("start recording")
+                return nil
+            },
+            startVoice: {
+                calls.append("start voice")
+                return nil
+            },
+            stopVoice: {
+                calls.append("stop voice")
+            },
+            revokeRecording: { _ in
+                calls.append("revoke recording")
+            },
+            revokeFloor: {
+                calls.append("revoke floor")
+            }
+        )
+
+        #expect(result == .activated)
+        #expect(calls == ["grant floor", "start recording", "start voice"])
+    }
+
     @Test("Collapsing chat suspends and clears its ephemeral lifecycle")
     func collapsedChatIsInactive() async {
         let session = RouterChatSession(


### PR DESCRIPTION
## What changed

- extract recorder activation into a testable floor → recording → voice transaction
- preserve exact reverse-order rollback for recording and voice startup failures
- clear stale activation errors only after complete activation
- add exact call-order coverage for recording failure, voice failure, and success

## Why

The UI-level activation path already attempted coordinated startup, but its ordering and rollback behavior were coupled to concrete sessions. A small transaction seam makes the atomic contract explicit and independently testable while preserving the higher-level injected capture/voice coverage on `master`.

## Impact

Relative XY **Give floor** now has direct deterministic evidence that partial startup cannot leave floor, recording, voice, or the event monitor active. No production endpoint, permission, signing, install, deployment, or release behavior changes.

## Validation

- `swift test` — 101 tests passed
- `bash Tests/permission-identity-preflight.test.sh` — 7 synthetic cases passed
- Dockerized orchestrator control and stamping contracts — 18 tests passed
- Dockerized dashboard/privacy suites — 19 Node tests and 9 Python tests passed
- Dockerized full generator gate — all four declared examples, token/privacy leak checks, generated shell/workflow YAML, k8s-on/off, generator compile, and root workflow YAML passed
- bounded synthetic first-time Relative XY acceptance — one activation, no TCC request, recording + stub voice listening, canonical fixture ECHO/NEXT, then floor/voice/capture/listener/process/port cleanup

## Evidence and boundaries

- source diff matches the retained recovery patch exactly
- synthetic fixtures only; no browser, Citrix, EHR, private data, real microphone/input permission, signing, installation, deployment, or release
- Operations Floater remains `1.1.0` build `2` unreleased; its changelog and lifecycle docs already describe this atomic rollback contract
