### PR TITLE
fix(template): allow distinct repeat-acquire permits

### DIFF
--- a/addons/service_supervisor/common/tools/service_supervisor/CHANGELOG.md
+++ b/addons/service_supervisor/common/tools/service_supervisor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fixed repeat acquisition for independently signed permit IDs/nonces targeting
+  the same deterministic plan and authority generation. State schema 2 retains
+  atomic nonce replay protection, durably binds each permit ID to one exact
+  signed payload, and migrates schema 1 ledgers without losing prior
+  consumption or revocations.
+
 ## 0.2.0 - 2026-07-28
 
 - Added strict typed validation for the local-ai adapter plan/result v1 seam,

--- a/addons/service_supervisor/common/tools/service_supervisor/compatibility/firestarter/execution-handoff-receipt-1.untrusted.synthetic.json
+++ b/addons/service_supervisor/common/tools/service_supervisor/compatibility/firestarter/execution-handoff-receipt-1.untrusted.synthetic.json
@@ -30,8 +30,8 @@
   "catalog_digest": "6d0b7a440c2f6758b0b01482a5a508dba12b8c191938949854ad1189718fa5f1",
   "executor_generation": 1,
   "state_generation": 1,
-  "verifier_artifact_digest": "c02b7bb559240a6a9be86db078eb15b8186b2e7a72234f93d40fda147de49fee",
+  "verifier_artifact_digest": "c90e0f28545735e03a6ef5805be2ed5a060c3870c42c6c5808940439ab64a838",
   "contract_pin_digest": "39c206b35119cf1c1d42ae361735025c366f5c5da01ef0c66f82c39bed89e826",
   "rollback_authorized": false,
-  "signature": "ad8ffec6e79ff8810549b5ecdae55b01908c8d9a2fe364d88221f599d0754928"
+  "signature": "7020de8dff18ecb866f236aec033d7829b8ccc6c40bdfeb4f5341e808ad81583"
 }

--- a/addons/service_supervisor/common/tools/service_supervisor/docs/PERMIT_MIGRATION_ROLLBACK.md
+++ b/addons/service_supervisor/common/tools/service_supervisor/docs/PERMIT_MIGRATION_ROLLBACK.md
@@ -29,8 +29,12 @@ Before using the new API:
    nonce in its own durable ledger. No executor or broker is supplied by this
    release.
 
-The PM permit state schema starts at SQLite `user_version=1`. Unknown future versions
-fail closed; there is no automatic downgrade or lossy migration.
+New PM permit ledgers use SQLite `user_version=2`. Opening a version 1 ledger
+atomically preserves its consumed nonce fingerprints and revocations while
+removing the obsolete generation-wide uniqueness constraint; legacy rows have
+no recoverable permit ID, so their nonce replay protection remains the durable
+authority. Unknown future versions fail closed. There is no automatic
+downgrade or lossy migration.
 
 ## Rollback
 

--- a/addons/service_supervisor/common/tools/service_supervisor/docs/PERMIT_VERIFIER.md
+++ b/addons/service_supervisor/common/tools/service_supervisor/docs/PERMIT_VERIFIER.md
@@ -128,12 +128,20 @@ revocations. Symlinks, non-regular files, oversized state, unsupported schema
 versions, and failed integrity checks refuse.
 
 The authorization record commits before the signed handoff receipt is returned.
-Concurrent copies therefore produce one winner and replay refusals. If the
-process fails before commit, SQLite rolls the insertion back and a fresh
-verifier can retry. Restarting does not make a consumed nonce reusable.
-The exact plan/phase/catalog/executor/state generation is also single-use:
-issuing a second nonce for an already consumed generation is a conflicting
-permit, not a retry. A retry requires a newly reviewed state generation.
+Concurrent copies of the same signed permit therefore produce one winner and
+replay refusals. If the process fails before commit, SQLite rolls back both the
+nonce consumption and permit-ID binding so a fresh verifier can retry.
+Restarting does not make a consumed nonce reusable.
+
+Distinct correctly signed permits may authorize the same deterministic
+plan/phase/catalog/executor/state generation. Each must have its own permit ID
+and nonce, and each produces its own independently consumable handoff receipt.
+This permits genuine multi-client singleflight at the broker without weakening
+the verifier boundary. A permit ID is durably bound to its exact signed permit
+fingerprint; reusing a permit ID for a different payload is conflicting.
+State schema 1 ledgers migrate atomically to schema 2, preserving prior nonce
+consumption and revocations while removing the obsolete generation-wide
+uniqueness constraint.
 
 The deterministic snapshot is an audit/testing surface, not an executor input.
 It excludes raw nonces, signatures, keys, commands, paths, URLs, models, and

--- a/addons/service_supervisor/common/tools/service_supervisor/permits.py
+++ b/addons/service_supervisor/common/tools/service_supervisor/permits.py
@@ -25,6 +25,7 @@ from pathlib import Path, PurePosixPath
 from urllib.parse import unquote, urlsplit
 
 SCHEMA_VERSION = 1
+STATE_SCHEMA_VERSION = 2
 SUPERVISOR_CONTRACT_VERSION = "0.1.0"
 PERMIT_POLICY_VERSION = "pm-execution-permit/1"
 HANDOFF_RECEIPT_VERSION = "execution-handoff-receipt/1"
@@ -1478,13 +1479,18 @@ class PermitVerifier:
             if check is None or check[0] != "ok":
                 raise PermitStateError("STATE_INTEGRITY_FAILED")
             version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-            if version not in {0, 1}:
+            if version not in {0, 1, STATE_SCHEMA_VERSION}:
                 raise PermitStateError("UNSUPPORTED_STATE_VERSION")
             connection.execute("BEGIN IMMEDIATE")
+            if version == 1:
+                connection.execute(
+                    "ALTER TABLE permit_uses RENAME TO permit_uses_v1"
+                )
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS permit_uses (
                     nonce_hash TEXT PRIMARY KEY,
+                    permit_id TEXT UNIQUE,
                     permit_digest TEXT NOT NULL,
                     plan_digest TEXT NOT NULL,
                     target_service_id TEXT NOT NULL,
@@ -1496,17 +1502,30 @@ class PermitVerifier:
                     executor_generation INTEGER NOT NULL,
                     state_generation INTEGER NOT NULL,
                     policy_version TEXT NOT NULL,
-                    consumed_at INTEGER NOT NULL,
-                    UNIQUE (
-                        plan_digest,
-                        authorization_phase,
-                        catalog_digest,
-                        executor_generation,
-                        state_generation
-                    )
+                    consumed_at INTEGER NOT NULL
                 ) STRICT
                 """
             )
+            if version == 1:
+                connection.execute(
+                    """
+                    INSERT INTO permit_uses (
+                        nonce_hash, permit_id, permit_digest, plan_digest,
+                        target_service_id, intent, authorization_phase,
+                        adapter_set_json, producer_schema_digest,
+                        catalog_digest, executor_generation, state_generation,
+                        policy_version, consumed_at
+                    )
+                    SELECT
+                        nonce_hash, NULL, permit_digest, plan_digest,
+                        target_service_id, intent, authorization_phase,
+                        adapter_set_json, producer_schema_digest,
+                        catalog_digest, executor_generation, state_generation,
+                        policy_version, consumed_at
+                    FROM permit_uses_v1
+                    """
+                )
+                connection.execute("DROP TABLE permit_uses_v1")
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS revocations (
@@ -1516,7 +1535,7 @@ class PermitVerifier:
                 ) STRICT
                 """
             )
-            connection.execute("PRAGMA user_version = 1")
+            connection.execute(f"PRAGMA user_version = {STATE_SCHEMA_VERSION}")
             connection.execute("COMMIT")
         except PermitStateError:
             if connection.in_transaction:
@@ -1648,38 +1667,31 @@ class PermitVerifier:
                     if existing["permit_digest"] != permit_digest:
                         raise PermitRefusal("CONFLICTING_PERMIT")
                     raise PermitRefusal("REPLAYED_PERMIT")
-                conflicting = connection.execute(
+                permit_id_binding = connection.execute(
                     """
-                    SELECT 1
+                    SELECT permit_digest
                     FROM permit_uses
-                    WHERE plan_digest = ?
-                      AND authorization_phase = ?
-                      AND catalog_digest = ?
-                      AND executor_generation = ?
-                      AND state_generation = ?
+                    WHERE permit_id = ?
                     """,
-                    (
-                        plan["plan_digest"],
-                        authorization_phase,
-                        self.expected_catalog_digest,
-                        self.expected_executor_generation,
-                        self.expected_state_generation,
-                    ),
+                    (permit["permit_id"],),
                 ).fetchone()
-                if conflicting is not None:
-                    raise PermitRefusal("CONFLICTING_PERMIT")
+                if permit_id_binding is not None:
+                    if permit_id_binding["permit_digest"] != permit_digest:
+                        raise PermitRefusal("CONFLICTING_PERMIT")
+                    raise PermitRefusal("REPLAYED_PERMIT")
                 connection.execute(
                     """
                     INSERT INTO permit_uses (
-                        nonce_hash, permit_digest, plan_digest,
+                        nonce_hash, permit_id, permit_digest, plan_digest,
                         target_service_id, intent, authorization_phase,
                         adapter_set_json, producer_schema_digest,
                         catalog_digest, executor_generation, state_generation,
                         policy_version, consumed_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         nonce_hash,
+                        permit["permit_id"],
                         permit_digest,
                         plan["plan_digest"],
                         plan["target_service_id"],
@@ -1762,7 +1774,7 @@ class PermitVerifier:
                 dict(row)
                 for row in connection.execute(
                     """
-                    SELECT nonce_hash, permit_digest, plan_digest,
+                    SELECT nonce_hash, permit_id, permit_digest, plan_digest,
                            target_service_id, intent, authorization_phase,
                            adapter_set_json, producer_schema_digest,
                            catalog_digest, executor_generation,

--- a/addons/service_supervisor/common/tools/service_supervisor/tests/test_permits.py
+++ b/addons/service_supervisor/common/tools/service_supervisor/tests/test_permits.py
@@ -8,6 +8,7 @@ import hmac
 import json
 import multiprocessing
 import os
+import sqlite3
 import tempfile
 import threading
 import unittest
@@ -852,7 +853,7 @@ class PermitVerificationTests(unittest.TestCase):
             with self.assertRaisesRegex(PermitRefusal, "CONFLICTING_PERMIT"):
                 check.verify_and_consume(value, conflict)
 
-    def test_second_nonce_cannot_reauthorize_same_plan_generation(self) -> None:
+    def test_distinct_permits_can_reauthorize_same_plan_generation(self) -> None:
         value = plan()
         first = signed_permit(value)
         second = signed_permit(
@@ -862,9 +863,72 @@ class PermitVerificationTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as directory:
             check = verifier(Path(directory) / "state.sqlite3")
+            first_receipt = check.verify_and_consume(value, first)
+            second_receipt = check.verify_and_consume(value, second)
+        self.assertEqual(first["permit_id"], first_receipt["permit_id"])
+        self.assertEqual(second["permit_id"], second_receipt["permit_id"])
+        self.assertNotEqual(
+            first_receipt["permit_fingerprint"],
+            second_receipt["permit_fingerprint"],
+        )
+        self.assertNotEqual(
+            first_receipt["receipt_nonce"], second_receipt["receipt_nonce"]
+        )
+        self.assertEqual(first_receipt, validate_receipt(first_receipt, value))
+        self.assertEqual(second_receipt, validate_receipt(second_receipt, value))
+
+    def test_same_permit_id_with_different_payload_is_conflict(self) -> None:
+        value = plan()
+        first = signed_permit(value, permit_id="permit-stable-id")
+        conflict = signed_permit(
+            value,
+            permit_id="permit-stable-id",
+            nonce="abcdefghijklmnopqrstuz",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            check = verifier(Path(directory) / "state.sqlite3")
             check.verify_and_consume(value, first)
             with self.assertRaisesRegex(PermitRefusal, "CONFLICTING_PERMIT"):
-                check.verify_and_consume(value, second)
+                check.verify_and_consume(value, conflict)
+
+    def test_concurrent_distinct_permits_for_same_scope_all_succeed(self) -> None:
+        value = plan()
+        permits = [
+            signed_permit(
+                value,
+                permit_id=f"permit-client-{number}",
+                nonce=f"client_nonce_{number:08d}abcdef",
+            )
+            for number in range(24)
+        ]
+        receipts: list[dict] = []
+        refusals: list[str] = []
+        barrier = threading.Barrier(len(permits) + 1)
+        with tempfile.TemporaryDirectory() as directory:
+            check = verifier(Path(directory) / "state.sqlite3")
+
+            def worker(permit: dict) -> None:
+                barrier.wait(timeout=5)
+                try:
+                    receipts.append(check.verify_and_consume(value, permit))
+                except PermitRefusal as exc:
+                    refusals.append(exc.code)
+
+            threads = [
+                threading.Thread(target=worker, args=(permit,))
+                for permit in permits
+            ]
+            for thread in threads:
+                thread.start()
+            barrier.wait(timeout=5)
+            for thread in threads:
+                thread.join(timeout=10)
+            self.assertTrue(all(not thread.is_alive() for thread in threads))
+        self.assertEqual([], refusals)
+        self.assertEqual(len(permits), len(receipts))
+        self.assertEqual(
+            len(permits), len({receipt["receipt_nonce"] for receipt in receipts})
+        )
 
     def test_concurrent_single_use_race_has_exactly_one_winner(self) -> None:
         value = plan()
@@ -937,6 +1001,131 @@ class PermitVerificationTests(unittest.TestCase):
                 check.verify_and_consume(value, permit)
             decision = verifier(state).verify_and_consume(value, permit)
         self.assertEqual("AUTHORIZED_FOR_EXECUTOR_HANDOFF", decision["decision"])
+
+    def test_transaction_failure_rolls_back_permit_id_binding(self) -> None:
+        value = plan()
+        first = signed_permit(value, permit_id="permit-crash-binding")
+        retry = signed_permit(
+            value,
+            permit_id="permit-crash-binding",
+            nonce="abcdefghijklmnopqrstuz",
+        )
+
+        def crash() -> None:
+            raise RuntimeError("synthetic crash")
+
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.sqlite3"
+            check = verifier(state)
+            check._after_nonce_recorded = crash
+            with self.assertRaisesRegex(
+                PermitStateError, "NONCE_CONSUMPTION_FAILED"
+            ):
+                check.verify_and_consume(value, first)
+            decision = verifier(state).verify_and_consume(value, retry)
+        self.assertEqual("permit-crash-binding", decision["permit_id"])
+
+    def test_v1_state_migrates_without_losing_nonce_replay_protection(self) -> None:
+        value = plan()
+        legacy = signed_permit(value)
+        legacy_digest = hashlib.sha256(
+            canonical_json_bytes(legacy)
+        ).hexdigest()
+        legacy_nonce_hash = hashlib.sha256(
+            legacy["nonce"].encode("ascii")
+        ).hexdigest()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.sqlite3"
+            connection = sqlite3.connect(state)
+            connection.execute(
+                """
+                CREATE TABLE permit_uses (
+                    nonce_hash TEXT PRIMARY KEY,
+                    permit_digest TEXT NOT NULL,
+                    plan_digest TEXT NOT NULL,
+                    target_service_id TEXT NOT NULL,
+                    intent TEXT NOT NULL,
+                    authorization_phase TEXT NOT NULL,
+                    adapter_set_json TEXT NOT NULL,
+                    producer_schema_digest TEXT NOT NULL,
+                    catalog_digest TEXT NOT NULL,
+                    executor_generation INTEGER NOT NULL,
+                    state_generation INTEGER NOT NULL,
+                    policy_version TEXT NOT NULL,
+                    consumed_at INTEGER NOT NULL,
+                    UNIQUE (
+                        plan_digest,
+                        authorization_phase,
+                        catalog_digest,
+                        executor_generation,
+                        state_generation
+                    )
+                ) STRICT
+                """
+            )
+            actions, adapters = scope(value, "apply")
+            self.assertTrue(actions)
+            connection.execute(
+                """
+                INSERT INTO permit_uses (
+                    nonce_hash, permit_digest, plan_digest,
+                    target_service_id, intent, authorization_phase,
+                    adapter_set_json, producer_schema_digest,
+                    catalog_digest, executor_generation, state_generation,
+                    policy_version, consumed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    legacy_nonce_hash,
+                    legacy_digest,
+                    value["plan_digest"],
+                    value["target_service_id"],
+                    value["intent"],
+                    "apply",
+                    canonical_json_bytes(adapters).decode("ascii"),
+                    SCHEMA_DIGEST,
+                    CATALOG_DIGEST,
+                    7,
+                    9,
+                    PERMIT_POLICY_VERSION,
+                    NOW,
+                ),
+            )
+            connection.execute(
+                """
+                CREATE TABLE revocations (
+                    nonce_hash TEXT PRIMARY KEY,
+                    revoked_at INTEGER NOT NULL,
+                    reason_code TEXT NOT NULL
+                ) STRICT
+                """
+            )
+            connection.execute("PRAGMA user_version = 1")
+            connection.commit()
+            connection.close()
+            state.chmod(0o600)
+
+            check = verifier(state)
+            with self.assertRaisesRegex(PermitRefusal, "REPLAYED_PERMIT"):
+                check.verify_and_consume(value, legacy)
+            receipt = check.verify_and_consume(
+                value,
+                signed_permit(
+                    value,
+                    permit_id="permit-after-migration",
+                    nonce="migration_nonce_abcdefgh",
+                ),
+            )
+            connection = sqlite3.connect(state)
+            version = connection.execute("PRAGMA user_version").fetchone()[0]
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(permit_uses)")
+            }
+            connection.close()
+        self.assertEqual(2, version)
+        self.assertIn("permit_id", columns)
+        self.assertEqual("permit-after-migration", receipt["permit_id"])
 
     def test_revocation_is_durable_and_idempotent(self) -> None:
         value = plan()


### PR DESCRIPTION
## What changed

- migrate the durable permit ledger from state schema 1 to schema 2
- allow independently signed, distinct permit IDs/nonces to authorize the same deterministic plan/phase/generation
- retain atomic nonce replay rejection and bind each permit ID to one exact signed permit fingerprint
- preserve expiry, revocation, exact scope/generation checks, and separate apply/rollback authority
- refresh the synthetic handoff fixture to pin the new verifier artifact

## Root cause

State schema 1 used a uniqueness constraint on `(plan_digest, authorization_phase, catalog_digest, executor_generation, state_generation)`. That made the first valid client globally exclusive and incorrectly rejected a second independently authorized client as `CONFLICTING_PERMIT`.

## Impact

Multiple genuine clients can now acquire independently authorized handoff receipts for one deterministic lifecycle plan. Their broker requests can participate in singleflight while retaining separate receipt nonce consumption and leases.

## Validation

- focused permit suite: 42 passed
- full service-supervisor discovery: 119 passed
- stamped supervisor suite: 119 passed
- exact all-stack addon gate: 77 passed; addon present in all four stacks and absent by default
- root orchestrator/receipt contracts: 51 passed after redirecting read-only bytecode cache to `/tmp`
- all declared examples stamped; no template-token leaks; GitHub expressions preserved
- 50 generated/root workflow YAML files parsed; generated shell and generator compile gates passed
- cross-repo synthetic rehearsal with immutable local-ai candidate `71b3298`: 2 genuine receipts → 2 READY responses, 1 synthetic wake, 2 consumed receipts, 2 leases

No executor, broker, deployment, listener, host-service mutation, or live call is added.
