### PR TITLE
fix(template): close failed SQLite connections

### DIFF
--- a/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
+++ b/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
@@ -1124,33 +1124,35 @@ class Plane:
         previous_umask = os.umask(0o077)
         try:
             connection = sqlite3.connect(self.db_path, timeout=5, isolation_level=None)
-            connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA foreign_keys = ON")
-            connection.execute("PRAGMA journal_mode = WAL")
-            connection.execute("PRAGMA synchronous = FULL")
-            connection.execute("PRAGMA busy_timeout = 5000")
-            for suffix in ("", "-wal", "-shm"):
-                state_file = Path(str(self.db_path) + suffix)
-                if not state_file.exists():
-                    continue
-                if state_file.is_symlink():
-                    connection.close()
-                    fail(
-                        "STATE_UNSAFE",
-                        "SQLite authority files cannot be symlinks",
-                        exit_status=EXIT_STATE,
-                    )
-                if (
-                    hasattr(os, "getuid")
-                    and state_file.stat().st_uid != os.getuid()
-                ):
-                    connection.close()
-                    fail(
-                        "STATE_OWNERSHIP",
-                        "SQLite authority must be owned by the current user",
-                        exit_status=EXIT_STATE,
-                    )
-                os.chmod(state_file, 0o600)
+            try:
+                connection.row_factory = sqlite3.Row
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.execute("PRAGMA journal_mode = WAL")
+                connection.execute("PRAGMA synchronous = FULL")
+                connection.execute("PRAGMA busy_timeout = 5000")
+                for suffix in ("", "-wal", "-shm"):
+                    state_file = Path(str(self.db_path) + suffix)
+                    if not state_file.exists():
+                        continue
+                    if state_file.is_symlink():
+                        fail(
+                            "STATE_UNSAFE",
+                            "SQLite authority files cannot be symlinks",
+                            exit_status=EXIT_STATE,
+                        )
+                    if (
+                        hasattr(os, "getuid")
+                        and state_file.stat().st_uid != os.getuid()
+                    ):
+                        fail(
+                            "STATE_OWNERSHIP",
+                            "SQLite authority must be owned by the current user",
+                            exit_status=EXIT_STATE,
+                        )
+                    os.chmod(state_file, 0o600)
+            except BaseException:
+                connection.close()
+                raise
         finally:
             os.umask(previous_umask)
         return connection

--- a/tests/test_orchestrator_control.py
+++ b/tests/test_orchestrator_control.py
@@ -60,6 +60,7 @@ class ControlPlaneTests(unittest.TestCase):
         now: str | None = None,
         expected: int = 0,
         state: Path | None = None,
+        env: dict[str, str] | None = None,
     ) -> dict[str, object]:
         arguments = [
             sys.executable,
@@ -84,6 +85,7 @@ class ControlPlaneTests(unittest.TestCase):
             text=True,
             capture_output=True,
             check=False,
+            env=env,
         )
         self.assertEqual(
             expected,
@@ -1710,7 +1712,14 @@ class ControlPlaneTests(unittest.TestCase):
         corrupt.mkdir(mode=0o700)
         (corrupt / "orchestrator.sqlite3").write_bytes(b"not sqlite")
         os.chmod(corrupt / "orchestrator.sqlite3", 0o600)
-        error = self.run_cli("status", expected=4, state=corrupt)
+        warning_strict_env = dict(os.environ)
+        warning_strict_env["PYTHONWARNINGS"] = "error::ResourceWarning"
+        error = self.run_cli(
+            "status",
+            expected=4,
+            state=corrupt,
+            env=warning_strict_env,
+        )
         self.assertEqual("STATE_FAIL_CLOSED", error["error"]["code"])
 
     def test_blocked_queue_recycles_before_new_lower_value_work(self) -> None:


### PR DESCRIPTION
## Summary

Close the SQLite connection if `Plane.connect()` fails while applying startup
PRAGMAs or validating authority files. Add a warning-strict corrupt-state
regression to keep the fail-closed JSON response single and parseable.

Intended subject: `fix(template): close failed SQLite connections`

## Why

On a corrupt SQLite file, `sqlite3.connect()` succeeds and the first PRAGMA
fails. The connection was left open, so `ResourceWarning` at interpreter
shutdown could append a second stderr record and break machine-readable error
parsing when warnings are promoted to errors.

## Generated-project impact

Only the `orchestrator_session` add-on control plane changes. Newly stamped
projects close partially initialized SQLite connections on every setup failure;
successful connections and policy behavior are unchanged.

## Test plan

- `PYTHONWARNINGS=error::ResourceWarning python3 -B -m unittest -v tests.test_orchestrator_control.ControlPlaneTests.test_killed_sqlite_writer_releases_lock_without_partial_revision`
- `PYTHONWARNINGS=error::ResourceWarning python3 -B -m unittest -v tests.test_orchestrator_control tests.test_duration_control tests.test_root_role_guard tests.test_receipt_feed tests.test_orchestrator_session_contract` (80/80)
- Plugin suite against this exact checkout with `FIRESTARTER_CURRENT_CLI` and `FIRESTARTER_CURRENT_REPO` set (25/25 applicable; historical pinned compatibility fixture skipped)
- `python3 -B scripts/privacy_scan.py .` from the plugin root

Dockerized all-stack stamps were not rerun because this validation lane was
explicitly isolated from host-service actions. The 80-test suite includes the
declared-stack orchestrator session contract.

## Feature handoff evidence

Non-visual change; storyboard, state map, video, release cut, and media are N/A.
Acceptance is the warning-strict corrupt-state regression plus the full 80-test
suite. Failure/recovery evidence is the corrupt database returning the existing
`STATE_FAIL_CLOSED` response without a leaked-connection warning. Rollback is
reverting this one commit.

## Checklist

- [ ] Every declared stack example stamps cleanly in Docker — not rerun; see test plan
- [x] No unintended `{{ token }}` leaks; GitHub/JS brace syntax is preserved
- [ ] `docs/ANATOMY.md` and `docs/LIFT-LOG.md` updated for a lifted precept/component — N/A, no lift
- [x] Conventional-commit subject (`type(scope): subject`, ≤100 chars)
- [x] Acceptance, failure/recovery, rollback, and exact verification evidence is attached (N/A explained)
- [x] UI changes refresh the real-app storyboard and state map, or N/A is explained
- [x] The generated project's full E2E/release rehearsal passes, or N/A is explained
- [x] Narrated E2E evidence is post-processed from normal-speed assertions, without `slowMo` or fixed presentation waits, or N/A is explained
- [x] Material multi-step UI work links the supported release cut, or video N/A is explained
- [x] Compact polished media is committed under `docs/media/`; raw recordings remain artifacts, or N/A is explained
