### PR TITLE
feat(template): add native receipt-backed task view

### DIFF
--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Operations Floater changelog
 
+## 1.2.0 (build 3) — unreleased
+
+- Add a local-only, read-only receipt-feed 1.1 source with strict shape,
+  duplicate-key, provenance, file-type, size, and SHA-256 validation.
+- Read content-addressed `current` first and use LKG only when current fails
+  pointer, digest, JSON, schema, or provenance validation. A valid stale
+  current feed remains visible with degraded freshness.
+- Add native **NOW**, **DECISIONS**, and **RECENTLY DONE** mappings plus
+  current/stale/LKG/offline provenance badges. Missing or invalid feed data
+  degrades only this panel and never disables existing dashboard features.
+- Pin the reviewed dashboard snapshot, LKG, feed schema, manifest schema, and
+  sanitized manifest hashes. No raw prompt, private path, or private content
+  enters the source or tests.
+- Preserve Router chat/review, voice and floor control, Relative XY recording,
+  race/resource/privacy panels, collapse persistence, keyboard behavior,
+  nonactivating background tests, and truthful empty dashboard behavior.
+
 ## 1.1.0 (build 2) — unreleased
 
 - Add a read-only signed-code identity preflight for first install and update.

--- a/prototypes/operations-floater/Info.plist
+++ b/prototypes/operations-floater/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
+++ b/prototypes/operations-floater/OperationsFloater.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2200D085E7B69957855949ED /* LocalSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */; };
 		4A46BD1BBBED0C66FA4E0AD7 /* RecorderNarrationNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6418B6AF4C7BABB9A54C0761 /* RecorderNarrationNormalizer.swift */; };
+		888F9EE175FB265A1569D5CA /* ReceiptFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD924D96814A8B31F9CE0A61 /* ReceiptFeed.swift */; };
 		9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */; };
 		A705BC6F0D3A543F75D84535 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D7388421B1A4219EF55A7B2 /* Assets.xcassets */; };
 		A8C223AF7E4BCD86BEDCAF80 /* LoopbackOperationsSnapshotClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28190247462D6C55127EABE8 /* LoopbackOperationsSnapshotClient.swift */; };
@@ -34,6 +35,7 @@
 		6D7388421B1A4219EF55A7B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeutralGeometryCapture.swift; sourceTree = "<group>"; };
 		A37B6D58036BC8B9F8A47688 /* ConversationVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationVoice.swift; sourceTree = "<group>"; };
+		AD924D96814A8B31F9CE0A61 /* ReceiptFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFeed.swift; sourceTree = "<group>"; };
 		CEED0760241BADE47AB545B7 /* LocalSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -59,6 +61,7 @@
 				98029EC2964C84D24843E9F4 /* NeutralGeometryCapture.swift */,
 				62EC0288576AB159180BAA8B /* OperationsFloaterApp.swift */,
 				4A9DF97AD77E17679BD52803 /* QueueRace.swift */,
+				AD924D96814A8B31F9CE0A61 /* ReceiptFeed.swift */,
 				6418B6AF4C7BABB9A54C0761 /* RecorderNarrationNormalizer.swift */,
 				42AF18361984088F8616CB04 /* RouterChat.swift */,
 			);
@@ -153,6 +156,7 @@
 				9B233F7676FC120A1BC3C6EB /* NeutralGeometryCapture.swift in Sources */,
 				B62C2C7DCF69BD92439B2DAF /* OperationsFloaterApp.swift in Sources */,
 				C5CF829831A8C373615B6D78 /* QueueRace.swift in Sources */,
+				888F9EE175FB265A1569D5CA /* ReceiptFeed.swift in Sources */,
 				4A46BD1BBBED0C66FA4E0AD7 /* RecorderNarrationNormalizer.swift in Sources */,
 				C8B57BCE1270FE6351B6218A /* RouterChat.swift in Sources */,
 			);

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -30,6 +30,16 @@ live and saved input fails closed to an empty dashboard; the committed generic
 sample remains storyboard/test data only. Imports must be regular files no
 larger than one megabyte.
 
+The additive receipt-backed task view reads only content-addressed
+receipt-feed 1.1 files from the app's local
+`OperationsFloater/receipts` Application Support directory. It verifies the
+current pointer and snapshot SHA-256, rejects duplicate keys and unknown
+contract fields, requires allowlisted root-excluded provenance, and falls back
+to an independently verified LKG only when current input is invalid. A valid
+stale current feed remains selected and is visibly marked stale. Feed absence
+or failure makes only this panel unavailable; it never disables the established
+dashboard, Router, voice, recorder, or window behavior.
+
 Choose **Import Local Snapshot…** to select and install a canonical local file.
 The app does not retain the selected source path. Installation validates before
 writing, uses private file permissions, and retains the previous valid snapshot.
@@ -46,7 +56,8 @@ sharing runtime code or creating a device bridge:
 
 1. resource-budget evidence;
 2. sortable queue race lanes for running, queued, waiting, and ready work; and
-3. compact tests-and-quality and signals panels.
+3. a receipt-backed NOW, DECISIONS, and RECENTLY DONE view; and
+4. compact tests-and-quality and signals panels.
 
 The native surface adds a local queue guide and window controls. At widths of
 560 points or more, operational panels use a dense two-column grid; below that
@@ -71,6 +82,9 @@ snapshot remains schema version `1.0`.
   refresh work when all of them are collapsed; collapsing Assistant Chat stops
   voice, cancels pending work, revokes the module floor, and clears its
   ephemeral session instead of merely hiding it.
+- The receipt view has independent persisted collapse state and never performs
+  a control-plane action. It displays only bounded allowlisted labels and
+  status fields plus a current, stale, LKG, or offline provenance indicator.
 - Closing the window, including with Command-W, retains the app; use **Show
   Dashboard** or click the Dock icon to reopen the same window.
 - A procedural animated guide summarizes only canonical state. Verified
@@ -178,6 +192,8 @@ lifecycle, privacy posture, and failure behavior.
 See [docs/RECORDER_LIVE_TRACE.md](docs/RECORDER_LIVE_TRACE.md) for the visible
 voice-to-command architecture, event-echo boundary, collapse lifecycle, and
 single-Space behavior.
+See [docs/RECEIPT_FEED_NATIVE.md](docs/RECEIPT_FEED_NATIVE.md) for the pinned
+native receipt contract, selection semantics, privacy boundary, and rollback.
 
 ## Validation
 

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -414,6 +414,7 @@ final class DashboardWindowController {
 final class DashboardState: ObservableObject {
     @Published var pinned: Bool { didSet { onPinnedChange?(pinned) } }
     @Published private(set) var snapshot: DashboardSnapshot
+    @Published private(set) var receiptFeed: ReceiptFeedPresentation
     @Published private(set) var sourceDescription: String
     @Published private(set) var canRestorePreviousSnapshot: Bool
     var onPinnedChange: ((Bool) -> Void)?
@@ -427,25 +428,41 @@ final class DashboardState: ObservableObject {
             .appendingPathComponent("OperationsFloater", isDirectory: true)
             .appendingPathComponent("dashboard-state.json")
     }()
+    private static let defaultReceiptDirectoryURL: URL = {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        return applicationSupport
+            .appendingPathComponent("OperationsFloater", isDirectory: true)
+            .appendingPathComponent("receipts", isDirectory: true)
+    }()
     private let store: LocalSnapshotStore
+    private let receiptStore: ReceiptFeedStore
     private let liveClient: LoopbackOperationsSnapshotClient?
     private var isRefreshing = false
 
     init(
         snapshotURL: URL? = nil,
+        receiptDirectoryURL: URL? = nil,
         initialPinned: Bool = false,
         liveClient: LoopbackOperationsSnapshotClient? = LoopbackOperationsSnapshotClient()
     ) {
         pinned = initialPinned
         store = LocalSnapshotStore(snapshotURL: snapshotURL ?? Self.defaultSnapshotURL)
+        receiptStore = ReceiptFeedStore(
+            directoryURL: receiptDirectoryURL ?? Self.defaultReceiptDirectoryURL
+        )
         self.liveClient = liveClient
         snapshot = .emptyLocal
+        receiptFeed = .unavailable
         sourceDescription = "No live or saved operations — lanes empty"
         canRestorePreviousSnapshot = false
         reload()
     }
 
     func reload() {
+        receiptFeed = receiptStore.load()
         guard let decoded = store.load() else {
             snapshot = .emptyLocal
             sourceDescription = "No live or saved operations — lanes empty"
@@ -459,6 +476,7 @@ final class DashboardState: ObservableObject {
         guard !isRefreshing else { return }
         isRefreshing = true
         defer { isRefreshing = false }
+        receiptFeed = receiptStore.load()
 
         if let liveClient, let liveSnapshot = try? await liveClient.fetch() {
             use(
@@ -507,6 +525,8 @@ private struct DashboardView: View {
     private var assistantCollapsed = false
     @AppStorage("OperationsFloater.ResourcesCollapsedV1")
     private var resourcesCollapsed = false
+    @AppStorage("OperationsFloater.ReceiptsCollapsedV1")
+    private var receiptsCollapsed = false
     @AppStorage("OperationsFloater.RacesCollapsedV1")
     private var racesCollapsed = false
     @AppStorage("OperationsFloater.TestsCollapsedV1")
@@ -542,6 +562,7 @@ private struct DashboardView: View {
                             metrics: metrics,
                             isCollapsed: $assistantCollapsed
                         )
+                        receiptFeedPanel(metrics: metrics)
                         resourceBudgetPanel(metrics: metrics)
                         QueueRaceBoard(
                             records: state.snapshot.queue,
@@ -696,6 +717,126 @@ private struct DashboardView: View {
         }
     }
 
+    private func receiptFeedPanel(metrics: DashboardLayoutMetrics) -> some View {
+        dashboardPanel(
+            title: "Receipt-backed task view",
+            subtitle: state.receiptFeed.sourceBadge,
+            isCollapsed: $receiptsCollapsed,
+            metrics: metrics
+        ) {
+            VStack(alignment: .leading, spacing: 0) {
+                receiptProvenance
+                Divider()
+                receiptGroup(
+                    title: "NOW",
+                    empty: state.receiptFeed.isAvailable
+                        ? "No active receipt-backed tasks."
+                        : "Current task receipts are unavailable.",
+                    receipts: state.receiptFeed.now,
+                    metrics: metrics
+                )
+                Divider()
+                receiptDecisionGroup(metrics: metrics)
+                Divider()
+                receiptGroup(
+                    title: "RECENTLY DONE",
+                    empty: state.receiptFeed.isAvailable
+                        ? "No accepted completion receipts."
+                        : "Completion receipts are unavailable.",
+                    receipts: state.receiptFeed.recentlyDone,
+                    metrics: metrics
+                )
+            }
+        }
+    }
+
+    private var receiptProvenance: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                compactBadge(state.receiptFeed.sourceBadge)
+                if let age = state.receiptFeed.ageSeconds,
+                   let threshold = state.receiptFeed.thresholdSeconds {
+                    Text("age \(age)s · limit \(threshold)s")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text(state.receiptFeed.provenance)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            if let reason = state.receiptFeed.reason {
+                Text(reason)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(10)
+    }
+
+    private func receiptGroup(
+        title: String,
+        empty: String,
+        receipts: [ReceiptFeedReceipt],
+        metrics: DashboardLayoutMetrics
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, metrics.recordPadding)
+                .padding(.top, 8)
+            if receipts.isEmpty {
+                Text(empty)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(metrics.recordPadding)
+            } else {
+                ForEach(receipts) { receipt in
+                    recordRow(
+                        title: receipt.publicLabel,
+                        detail: receipt.nextSafeMove.replacingOccurrences(
+                            of: "-",
+                            with: " "
+                        ),
+                        status: receipt.laneClass,
+                        verification: receipt.ownerClass,
+                        metrics: metrics
+                    )
+                }
+            }
+        }
+    }
+
+    private func receiptDecisionGroup(metrics: DashboardLayoutMetrics) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("DECISIONS")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, metrics.recordPadding)
+                .padding(.top, 8)
+            if state.receiptFeed.decisions.isEmpty {
+                Text(
+                    state.receiptFeed.isAvailable
+                        ? "No owner decision receipts."
+                        : "Decision receipts are unavailable."
+                )
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(metrics.recordPadding)
+            } else {
+                ForEach(state.receiptFeed.decisions) { receipt in
+                    recordRow(
+                        title: receipt.publicLabel,
+                        detail: "Owner review required",
+                        status: receipt.gateKind,
+                        verification: receipt.ownerClass,
+                        metrics: metrics
+                    )
+                }
+            }
+        }
+    }
+
     private func supportingGrid(metrics: DashboardLayoutMetrics) -> some View {
         LazyVGrid(
             columns: gridColumns(metrics: metrics),
@@ -840,6 +981,7 @@ private struct DashboardView: View {
     private var hasActiveSnapshotConsumers: Bool {
         DashboardPanelActivity.shouldRefreshSnapshot(
             guideCollapsed: guideCollapsed,
+            receiptsCollapsed: receiptsCollapsed,
             resourcesCollapsed: resourcesCollapsed,
             racesCollapsed: racesCollapsed,
             testsCollapsed: testsCollapsed,
@@ -871,12 +1013,14 @@ private struct DashboardView: View {
 enum DashboardPanelActivity {
     static func shouldRefreshSnapshot(
         guideCollapsed: Bool,
+        receiptsCollapsed: Bool,
         resourcesCollapsed: Bool,
         racesCollapsed: Bool,
         testsCollapsed: Bool,
         signalsCollapsed: Bool
     ) -> Bool {
         !guideCollapsed
+            || !receiptsCollapsed
             || !resourcesCollapsed
             || !racesCollapsed
             || !testsCollapsed

--- a/prototypes/operations-floater/Sources/OperationsFloater/ReceiptFeed.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ReceiptFeed.swift
@@ -1,0 +1,832 @@
+import CryptoKit
+import Foundation
+
+enum ReceiptFeedContractPins {
+    static let reviewedSnapshotSHA256 =
+        "e0c598cdcc29ba39f509ccdb553f8d2c65709896827229e3aff1ada07c1bd1f2"
+    static let reviewedLKGSnapshotSHA256 =
+        "ae4948b1c6396caca73a372a90474626d82d94291f36cb8bbc973799c6bebea8"
+    static let feedSchemaSHA256 =
+        "26cfc2cddac67831c6470f32dd54537762be95138661850d70e49a734db3ccc4"
+    static let manifestSchemaSHA256 =
+        "6b2649aef97774a00ed8323f91ce84c951220243ed4fd8b6d036b715d17a581f"
+    static let reviewedManifestSHA256 =
+        "a94a8331b303189a99334b8c2f5940418a510326ceabbc1e58c34ee2460af1f8"
+    static let canonicalManifestStateSHA256 =
+        "0a815cbd060d698b39badc715c16933436b7abec6588ca226bd1ffee4d73cc6a"
+}
+
+enum ReceiptFeedPointerKind: String, Hashable {
+    case current
+    case lkg = "last known good"
+}
+
+enum ReceiptFeedFreshness: String, Hashable {
+    case current
+    case stale
+    case unknown
+}
+
+struct ReceiptFeedEvidence: Decodable, Hashable {
+    let kind: String
+    let ref: String
+    let label: String?
+}
+
+struct ReceiptFeedReceipt: Identifiable, Decodable, Hashable {
+    struct Metric: Decodable, Hashable {
+        let value: Int?
+        let availability: String
+    }
+
+    struct Duration: Decodable, Hashable {
+        let estimateSeconds: Metric
+        let elapsedActiveSeconds: Metric
+        let externalWaitSeconds: Metric
+        let firstUsefulEvidenceSeconds: Metric
+    }
+
+    struct EvidenceAge: Decodable, Hashable {
+        let latestEvidenceAt: String?
+        let ageSeconds: Int?
+        let availability: String
+    }
+
+    let fingerprint: String
+    let revision: Int
+    let publicLabel: String
+    let ownerClass: String
+    let laneClass: String
+    let metadataSource: String
+    let lifecycle: String
+    let gateKind: String
+    let dependsOn: [String]
+    let acceptanceReceipts: [String]
+    let successorReceipts: [String]
+    let mirrorOf: String?
+    let runnable: Bool?
+    let duration: Duration
+    let nextSafeMove: String
+    let evidenceAge: EvidenceAge
+    let fieldAvailability: [String: String]
+    let evidenceRefs: [ReceiptFeedEvidence]
+
+    var id: String { fingerprint }
+}
+
+struct ReceiptFeedOwnerGate: Identifiable, Decodable, Hashable {
+    let fingerprint: String
+    let revision: Int
+    let decisionCode: String
+    let recordedAt: String
+    let nextSafeMove: String
+    let evidenceRefs: [ReceiptFeedEvidence]
+
+    var id: String { fingerprint }
+}
+
+struct ReceiptFeedSource: Decodable, Hashable {
+    struct Freshness: Decodable, Hashable {
+        let state: String
+        let ageSeconds: Int?
+        let thresholdSeconds: Int
+    }
+
+    struct Provenance: Decodable, Hashable {
+        let sourceClass: String
+        let sanitization: String
+        let rootExcluded: Bool
+    }
+
+    let generatedAt: String?
+    let servedAt: String
+    let sourceStatus: String
+    let freshness: Freshness
+    let sourceRevision: String?
+    let discrepancies: [String]
+    let provenance: Provenance
+}
+
+struct ReceiptFeedSnapshot: Decodable, Hashable {
+    struct Capacity: Decodable, Hashable {
+        let configuredWorkers: Int?
+        let rootExcluded: Bool
+        let availability: String
+    }
+
+    struct Counts: Decodable, Hashable {
+        let availability: String
+        let setupReserved: Int?
+        let active: Int?
+        let waiting: Int?
+        let ownerGated: Int?
+        let failed: Int?
+        let done: Int?
+        let acknowledged: Int?
+        let runnable: Int?
+        let quarantined: Int?
+    }
+
+    struct Quarantine: Decodable, Hashable {
+        let fingerprint: String
+        let reason: String
+        let mirrorOf: String?
+        let excludedFromCounts: Bool
+    }
+
+    let schemaVersion: String
+    let source: ReceiptFeedSource
+    let capacity: Capacity
+    let counts: Counts
+    let receipts: [ReceiptFeedReceipt]
+    let ownerGates: [ReceiptFeedOwnerGate]
+    let quarantine: [Quarantine]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case source
+        case capacity
+        case counts
+        case receipts
+        case ownerGates
+        case quarantine
+    }
+}
+
+struct ReceiptFeedPresentation: Hashable {
+    let pointerKind: ReceiptFeedPointerKind?
+    let freshness: ReceiptFeedFreshness
+    let ageSeconds: Int?
+    let thresholdSeconds: Int?
+    let provenance: String
+    let now: [ReceiptFeedReceipt]
+    let decisions: [ReceiptFeedReceipt]
+    let recentlyDone: [ReceiptFeedReceipt]
+    let reason: String?
+
+    static let unavailable = ReceiptFeedPresentation(
+        pointerKind: nil,
+        freshness: .unknown,
+        ageSeconds: nil,
+        thresholdSeconds: nil,
+        provenance: "Receipt feed unavailable",
+        now: [],
+        decisions: [],
+        recentlyDone: [],
+        reason: "No valid current or last-known-good receipt feed is available."
+    )
+
+    var isAvailable: Bool { pointerKind != nil }
+
+    var sourceBadge: String {
+        guard let pointerKind else { return "OFFLINE" }
+        if pointerKind == .lkg { return "LKG" }
+        return freshness == .current ? "CURRENT" : "STALE"
+    }
+}
+
+struct ReceiptFeedStore {
+    enum StoreError: Error, Equatable {
+        case invalidFile
+        case oversized
+        case invalidJSON
+        case invalidPointer
+        case hashMismatch
+        case invalidContract
+    }
+
+    static let maximumPointerBytes = 4_096
+    static let maximumSnapshotBytes = 1_048_576
+
+    let directoryURL: URL
+
+    init(directoryURL: URL) {
+        self.directoryURL = directoryURL
+    }
+
+    func load(now: Date = Date()) -> ReceiptFeedPresentation {
+        if let current = try? loadPointer(
+            named: "receipt-feed-current.json",
+            kind: .current,
+            now: now
+        ) {
+            return current
+        }
+        if let lkg = try? loadPointer(
+            named: "receipt-feed-lkg.json",
+            kind: .lkg,
+            now: now
+        ) {
+            return lkg
+        }
+        return .unavailable
+    }
+
+    private func loadPointer(
+        named pointerName: String,
+        kind: ReceiptFeedPointerKind,
+        now: Date
+    ) throws -> ReceiptFeedPresentation {
+        let pointerData = try readRegularFile(
+            directoryURL.appendingPathComponent(pointerName),
+            maximumBytes: Self.maximumPointerBytes
+        )
+        try StrictReceiptFeedJSON.rejectDuplicateObjectKeys(in: pointerData)
+        let pointerObject = try jsonObject(pointerData)
+        try requireExactKeys(
+            pointerObject,
+            required: ["schemaVersion", "sha256", "snapshot", "generatedAt"]
+        )
+        guard pointerObject["schemaVersion"] as? String == "1.1",
+              let digest = pointerObject["sha256"] as? String,
+              digest.range(of: #"^[a-f0-9]{64}$"#, options: .regularExpression) != nil,
+              let snapshotName = pointerObject["snapshot"] as? String,
+              snapshotName == "receipt-feed-1.1.\(digest).json",
+              let pointerGeneratedAt = pointerObject["generatedAt"] as? String,
+              Self.parseDate(pointerGeneratedAt) != nil else {
+            throw StoreError.invalidPointer
+        }
+
+        let snapshotData = try readRegularFile(
+            directoryURL.appendingPathComponent(snapshotName),
+            maximumBytes: Self.maximumSnapshotBytes
+        )
+        let actualDigest = SHA256.hash(data: snapshotData)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        guard actualDigest == digest else {
+            throw StoreError.hashMismatch
+        }
+
+        try StrictReceiptFeedJSON.validateSnapshot(snapshotData)
+        let snapshot: ReceiptFeedSnapshot
+        do {
+            snapshot = try JSONDecoder().decode(ReceiptFeedSnapshot.self, from: snapshotData)
+        } catch {
+            throw StoreError.invalidContract
+        }
+        try validate(snapshot)
+
+        let freshness = Self.freshness(snapshot: snapshot, now: now)
+        return ReceiptFeedPresentation(
+            pointerKind: kind,
+            freshness: freshness.state,
+            ageSeconds: freshness.ageSeconds,
+            thresholdSeconds: snapshot.source.freshness.thresholdSeconds,
+            provenance:
+                "\(snapshot.source.provenance.sourceClass) · "
+                + "\(snapshot.source.provenance.sanitization)",
+            now: snapshot.receipts.filter {
+                ["active", "setup-reserved"].contains($0.lifecycle)
+            },
+            decisions: snapshot.receipts.filter {
+                $0.lifecycle == "owner-gated" && $0.gateKind == "owner"
+            },
+            recentlyDone: snapshot.receipts.filter {
+                ["done", "acknowledged"].contains($0.lifecycle)
+            },
+            reason: kind == .lkg
+                ? "Current receipt feed was unavailable or invalid; showing last known good."
+                : nil
+        )
+    }
+
+    private func readRegularFile(_ url: URL, maximumBytes: Int) throws -> Data {
+        let values: URLResourceValues
+        do {
+            values = try url.resourceValues(
+                forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+            )
+        } catch {
+            throw StoreError.invalidFile
+        }
+        guard values.isRegularFile == true, values.isSymbolicLink != true else {
+            throw StoreError.invalidFile
+        }
+        if let fileSize = values.fileSize, fileSize > maximumBytes {
+            throw StoreError.oversized
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        } catch {
+            throw StoreError.invalidFile
+        }
+        guard data.count <= maximumBytes else { throw StoreError.oversized }
+        return data
+    }
+
+    private func jsonObject(_ data: Data) throws -> [String: Any] {
+        let value: Any
+        do {
+            value = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw StoreError.invalidJSON
+        }
+        guard let object = value as? [String: Any] else {
+            throw StoreError.invalidJSON
+        }
+        return object
+    }
+
+    private func requireExactKeys(
+        _ object: [String: Any],
+        required: Set<String>,
+        optional: Set<String> = []
+    ) throws {
+        guard Set(object.keys).isSuperset(of: required),
+              Set(object.keys).subtracting(required).isSubset(of: optional) else {
+            throw StoreError.invalidContract
+        }
+    }
+
+    private func validate(_ snapshot: ReceiptFeedSnapshot) throws {
+        guard snapshot.schemaVersion == "1.1",
+              snapshot.capacity.rootExcluded,
+              snapshot.source.provenance.rootExcluded,
+              [
+                "orchestrator-status", "orchestrator-ledger", "pm-proxy-manifest",
+                "legacy-receipt-feed",
+              ].contains(snapshot.source.provenance.sourceClass),
+              [
+                "projection-enforced", "caller-allowlisted+projection-validated",
+                "migration-placeholder",
+              ].contains(snapshot.source.provenance.sanitization),
+              ["live", "degraded"].contains(
+                snapshot.source.sourceStatus
+              ),
+              ["current", "stale", "unknown"].contains(snapshot.source.freshness.state),
+              snapshot.source.freshness.thresholdSeconds > 0,
+              snapshot.receipts.count <= 2_000,
+              snapshot.ownerGates.count <= 2_000,
+              snapshot.quarantine.count <= 2_000,
+              Self.validOptionalNonnegative(snapshot.capacity.configuredWorkers),
+              ["supplied", "derived", "unavailable"].contains(
+                snapshot.capacity.availability
+              ),
+              Self.validCounts(snapshot.counts),
+              Self.validDiscrepancies(snapshot.source.discrepancies),
+              Self.parseDate(snapshot.source.servedAt) != nil,
+              (
+                  snapshot.source.generatedAt == nil
+                      || snapshot.source.generatedAt.flatMap(Self.parseDate) != nil
+              ) else {
+            throw StoreError.invalidContract
+        }
+        if let revision = snapshot.source.sourceRevision {
+            guard revision.range(
+                of: #"^[A-Za-z0-9._:-]{1,128}$"#,
+                options: .regularExpression
+            ) != nil else {
+                throw StoreError.invalidContract
+            }
+        }
+        guard snapshot.receipts.allSatisfy(Self.validReceipt),
+              snapshot.ownerGates.allSatisfy(Self.validOwnerGate),
+              snapshot.quarantine.allSatisfy(Self.validQuarantine) else {
+            throw StoreError.invalidContract
+        }
+    }
+
+    private static func validOptionalNonnegative(_ value: Int?) -> Bool {
+        value.map { $0 >= 0 } ?? true
+    }
+
+    private static func validDiscrepancies(_ values: [String]) -> Bool {
+        values.count <= 16
+            && Set(values).count == values.count
+            && values.allSatisfy {
+                [
+                    "CAPACITY_INVARIANT_FAILED", "MIRROR_QUARANTINED",
+                    "RECEIPT_REVISION_CONFLICT", "STALE_SOURCE",
+                    "SUPPLIED_DERIVED_MISMATCH",
+                ].contains($0)
+            }
+    }
+
+    private static func validCounts(_ counts: ReceiptFeedSnapshot.Counts) -> Bool {
+        ["derived", "unavailable"].contains(counts.availability)
+            && [
+                counts.setupReserved, counts.active, counts.waiting,
+                counts.ownerGated, counts.failed, counts.done,
+                counts.acknowledged, counts.runnable, counts.quarantined,
+            ].allSatisfy(validOptionalNonnegative)
+    }
+
+    private static func validReceipt(_ receipt: ReceiptFeedReceipt) -> Bool {
+        receipt.fingerprint.range(
+            of: #"^rcpt_[a-f0-9]{64}$"#,
+            options: .regularExpression
+        ) != nil
+            && receipt.revision > 0
+            && receipt.publicLabel.range(
+                of: #"^[A-Za-z0-9][A-Za-z0-9 .,&()'’+-]{0,79}$"#,
+                options: .regularExpression
+            ) != nil
+            && ["pm-proxy", "worker", "owner", "external", "unknown"].contains(
+                receipt.ownerClass
+            )
+            && ["running", "next", "waiting", "owner-gated", "complete", "unknown"]
+                .contains(receipt.laneClass)
+            && ["launch", "handback", "migration", "unavailable"].contains(
+                receipt.metadataSource
+            )
+            && [
+                "setup-reserved", "active", "waiting", "owner-gated", "failed",
+                "done", "acknowledged",
+            ].contains(receipt.lifecycle)
+            && ["none", "dependency", "owner", "external", "capacity", "failure"]
+                .contains(receipt.gateKind)
+            && validFingerprintArray(receipt.dependsOn)
+            && validFingerprintArray(receipt.acceptanceReceipts)
+            && validFingerprintArray(receipt.successorReceipts)
+            && (receipt.mirrorOf.map(validFingerprint) ?? true)
+            && validDuration(receipt.duration)
+            && [
+                "await-launch-receipt", "continue-active-work",
+                "resolve-dependency", "review-owner-gate",
+                "retry-or-reconcile-failure", "verify-and-archive",
+                "none-terminal",
+            ].contains(receipt.nextSafeMove)
+            && validEvidenceAge(receipt.evidenceAge)
+            && !receipt.fieldAvailability.isEmpty
+            && receipt.fieldAvailability.values.allSatisfy {
+                ["supplied", "derived", "unavailable"].contains($0)
+            }
+            && receipt.evidenceRefs.count <= 24
+            && receipt.evidenceRefs.allSatisfy(validEvidence)
+    }
+
+    private static func validFingerprint(_ value: String) -> Bool {
+        value.range(of: #"^rcpt_[a-f0-9]{64}$"#, options: .regularExpression) != nil
+    }
+
+    private static func validFingerprintArray(_ values: [String]) -> Bool {
+        Set(values).count == values.count && values.allSatisfy(validFingerprint)
+    }
+
+    private static func validDuration(_ duration: ReceiptFeedReceipt.Duration) -> Bool {
+        [
+            duration.estimateSeconds, duration.elapsedActiveSeconds,
+            duration.externalWaitSeconds, duration.firstUsefulEvidenceSeconds,
+        ].allSatisfy {
+            validOptionalNonnegative($0.value)
+                && ["supplied", "derived", "unavailable"].contains($0.availability)
+        }
+    }
+
+    private static func validEvidenceAge(_ age: ReceiptFeedReceipt.EvidenceAge) -> Bool {
+        (
+            age.latestEvidenceAt == nil
+                || age.latestEvidenceAt.flatMap(parseDate) != nil
+        )
+            && validOptionalNonnegative(age.ageSeconds)
+            && ["derived", "unavailable"].contains(age.availability)
+    }
+
+    private static func validOwnerGate(_ gate: ReceiptFeedOwnerGate) -> Bool {
+        gate.fingerprint.range(
+            of: #"^rcpt_[a-f0-9]{64}$"#,
+            options: .regularExpression
+        ) != nil
+            && gate.revision > 0
+            && gate.decisionCode.range(
+                of: #"^[A-Z][A-Z0-9_]{0,127}$"#,
+                options: .regularExpression
+            ) != nil
+            && parseDate(gate.recordedAt) != nil
+            && gate.nextSafeMove == "review-owner-gate"
+            && !gate.evidenceRefs.isEmpty
+            && gate.evidenceRefs.count <= 24
+            && gate.evidenceRefs.allSatisfy(validEvidence)
+    }
+
+    private static func validQuarantine(
+        _ item: ReceiptFeedSnapshot.Quarantine
+    ) -> Bool {
+        validFingerprint(item.fingerprint)
+            && [
+                "duplicate-without-mirrorOf", "mirror", "revision-conflict",
+                "invalid", "privacy-rejected",
+            ].contains(item.reason)
+            && (item.mirrorOf.map(validFingerprint) ?? true)
+            && item.excludedFromCounts
+    }
+
+    private static func validEvidence(_ evidence: ReceiptFeedEvidence) -> Bool {
+        ["receipt", "test", "commit", "pullRequest", "deployment", "decision", "artifact"]
+            .contains(evidence.kind)
+            && evidence.ref.range(
+                of: #"^[A-Za-z0-9][A-Za-z0-9._:/#@+-]{0,159}$"#,
+                options: .regularExpression
+            ) != nil
+            && !evidence.ref.contains("/Users/")
+            && !evidence.ref.contains("/private/")
+            && !evidence.ref.lowercased().hasPrefix("file:")
+            && (evidence.label.map {
+                !$0.contains("\n") && !$0.contains("\r") && !$0.contains("<")
+                    && !$0.contains(">") && $0.count <= 120
+            } ?? true)
+    }
+
+    private static func freshness(
+        snapshot: ReceiptFeedSnapshot,
+        now: Date
+    ) -> (state: ReceiptFeedFreshness, ageSeconds: Int?) {
+        guard let generatedAt = snapshot.source.generatedAt,
+              let generated = parseDate(generatedAt) else {
+            return (.unknown, nil)
+        }
+        let age = max(0, now.timeIntervalSince(generated))
+        let roundedUp = Int(ceil(age))
+        return (
+            roundedUp > snapshot.source.freshness.thresholdSeconds ? .stale : .current,
+            roundedUp
+        )
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = formatter.date(from: value) { return parsed }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+}
+
+private enum StrictReceiptFeedJSON {
+    static func validateSnapshot(_ data: Data) throws {
+        try rejectDuplicateObjectKeys(in: data)
+        let value: Any
+        do {
+            value = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw ReceiptFeedStore.StoreError.invalidJSON
+        }
+        guard let root = value as? [String: Any] else {
+            throw ReceiptFeedStore.StoreError.invalidContract
+        }
+        try exact(root, ["schemaVersion", "source", "capacity", "counts", "receipts",
+                         "ownerGates", "quarantine"])
+        try exactObject(
+            root["source"],
+            ["generatedAt", "servedAt", "sourceStatus", "freshness", "sourceRevision",
+             "discrepancies", "provenance"]
+        )
+        let source = try object(root["source"])
+        try exactObject(source["freshness"], ["state", "ageSeconds", "thresholdSeconds"])
+        try exactObject(
+            source["provenance"],
+            ["sourceClass", "sanitization", "rootExcluded"]
+        )
+        try exactObject(
+            root["capacity"],
+            ["configuredWorkers", "rootExcluded", "availability"]
+        )
+        try exactObject(
+            root["counts"],
+            ["availability", "setupReserved", "active", "waiting", "ownerGated",
+             "failed", "done", "acknowledged", "runnable", "quarantined"]
+        )
+        for receipt in try array(root["receipts"]) {
+            let item = try object(receipt)
+            try exact(
+                item,
+                ["fingerprint", "revision", "publicLabel", "ownerClass", "laneClass",
+                 "metadataSource", "lifecycle", "gateKind", "dependsOn",
+                 "acceptanceReceipts", "successorReceipts", "runnable", "duration",
+                 "nextSafeMove", "evidenceAge", "fieldAvailability", "evidenceRefs"],
+                optional: ["mirrorOf"]
+            )
+            let duration = try object(item["duration"])
+            try exact(
+                duration,
+                ["estimateSeconds", "elapsedActiveSeconds", "externalWaitSeconds",
+                 "firstUsefulEvidenceSeconds"]
+            )
+            for metric in duration.values {
+                try exactObject(metric, ["value", "availability"])
+            }
+            try exactObject(
+                item["evidenceAge"],
+                ["latestEvidenceAt", "ageSeconds", "availability"]
+            )
+            guard let availability = item["fieldAvailability"] as? [String: Any],
+                  !availability.isEmpty,
+                  availability.values.allSatisfy({
+                      guard let value = $0 as? String else { return false }
+                      return ["supplied", "derived", "unavailable"].contains(value)
+                  }) else {
+                throw ReceiptFeedStore.StoreError.invalidContract
+            }
+            try validateEvidence(item["evidenceRefs"])
+        }
+        for gate in try array(root["ownerGates"]) {
+            let item = try object(gate)
+            try exact(
+                item,
+                ["fingerprint", "revision", "decisionCode", "recordedAt",
+                 "nextSafeMove", "evidenceRefs"]
+            )
+            try validateEvidence(item["evidenceRefs"])
+        }
+        for quarantine in try array(root["quarantine"]) {
+            try exact(
+                try object(quarantine),
+                ["fingerprint", "reason", "excludedFromCounts"],
+                optional: ["mirrorOf"]
+            )
+        }
+    }
+
+    static func rejectDuplicateObjectKeys(in data: Data) throws {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw ReceiptFeedStore.StoreError.invalidJSON
+        }
+        var parser = JSONKeyParser(text)
+        try parser.parse()
+    }
+
+    private static func validateEvidence(_ value: Any?) throws {
+        for evidence in try array(value) {
+            try exact(
+                try object(evidence),
+                ["kind", "ref"],
+                optional: ["label"]
+            )
+        }
+    }
+
+    private static func exactObject(_ value: Any?, _ keys: Set<String>) throws {
+        try exact(try object(value), keys)
+    }
+
+    private static func exact(
+        _ object: [String: Any],
+        _ required: Set<String>,
+        optional: Set<String> = []
+    ) throws {
+        let keys = Set(object.keys)
+        guard keys.isSuperset(of: required),
+              keys.subtracting(required).isSubset(of: optional) else {
+            throw ReceiptFeedStore.StoreError.invalidContract
+        }
+    }
+
+    private static func object(_ value: Any?) throws -> [String: Any] {
+        guard let object = value as? [String: Any] else {
+            throw ReceiptFeedStore.StoreError.invalidContract
+        }
+        return object
+    }
+
+    private static func array(_ value: Any?) throws -> [Any] {
+        guard let array = value as? [Any], array.count <= 2_000 else {
+            throw ReceiptFeedStore.StoreError.invalidContract
+        }
+        return array
+    }
+}
+
+private struct JSONKeyParser {
+    private let scalars: [UnicodeScalar]
+    private var index = 0
+
+    init(_ text: String) {
+        scalars = Array(text.unicodeScalars)
+    }
+
+    mutating func parse() throws {
+        skipWhitespace()
+        try value()
+        skipWhitespace()
+        guard index == scalars.count else { throw ReceiptFeedStore.StoreError.invalidJSON }
+    }
+
+    private mutating func value() throws {
+        skipWhitespace()
+        guard let scalar = peek() else { throw ReceiptFeedStore.StoreError.invalidJSON }
+        switch scalar {
+        case "{": try object()
+        case "[": try array()
+        case "\"": _ = try string()
+        case "t": try literal("true")
+        case "f": try literal("false")
+        case "n": try literal("null")
+        default: try number()
+        }
+    }
+
+    private mutating func object() throws {
+        try consume("{")
+        skipWhitespace()
+        if consumeIf("}") { return }
+        var keys = Set<String>()
+        while true {
+            skipWhitespace()
+            let key = try string()
+            guard keys.insert(key).inserted else {
+                throw ReceiptFeedStore.StoreError.invalidJSON
+            }
+            skipWhitespace()
+            try consume(":")
+            try value()
+            skipWhitespace()
+            if consumeIf("}") { return }
+            try consume(",")
+        }
+    }
+
+    private mutating func array() throws {
+        try consume("[")
+        skipWhitespace()
+        if consumeIf("]") { return }
+        while true {
+            try value()
+            skipWhitespace()
+            if consumeIf("]") { return }
+            try consume(",")
+        }
+    }
+
+    private mutating func string() throws -> String {
+        try consume("\"")
+        var result = ""
+        while let scalar = peek() {
+            index += 1
+            if scalar == "\"" { return result }
+            if scalar == "\\" {
+                guard let escaped = peek() else {
+                    throw ReceiptFeedStore.StoreError.invalidJSON
+                }
+                index += 1
+                if escaped == "u" {
+                    guard index + 4 <= scalars.count else {
+                        throw ReceiptFeedStore.StoreError.invalidJSON
+                    }
+                    let digits = String(String.UnicodeScalarView(scalars[index..<(index + 4)]))
+                    guard let value = UInt32(digits, radix: 16),
+                          let decoded = UnicodeScalar(value) else {
+                        throw ReceiptFeedStore.StoreError.invalidJSON
+                    }
+                    result.unicodeScalars.append(decoded)
+                    index += 4
+                } else {
+                    let mapped: UnicodeScalar
+                    switch escaped {
+                    case "\"", "\\", "/": mapped = escaped
+                    case "b": mapped = "\u{8}"
+                    case "f": mapped = "\u{c}"
+                    case "n": mapped = "\n"
+                    case "r": mapped = "\r"
+                    case "t": mapped = "\t"
+                    default: throw ReceiptFeedStore.StoreError.invalidJSON
+                    }
+                    result.unicodeScalars.append(mapped)
+                }
+            } else {
+                guard scalar.value >= 0x20 else {
+                    throw ReceiptFeedStore.StoreError.invalidJSON
+                }
+                result.unicodeScalars.append(scalar)
+            }
+        }
+        throw ReceiptFeedStore.StoreError.invalidJSON
+    }
+
+    private mutating func number() throws {
+        let start = index
+        while let scalar = peek(),
+              "-+0123456789.eE".unicodeScalars.contains(scalar) {
+            index += 1
+        }
+        guard index > start else { throw ReceiptFeedStore.StoreError.invalidJSON }
+    }
+
+    private mutating func literal(_ expected: String) throws {
+        for scalar in expected.unicodeScalars {
+            try consume(scalar)
+        }
+    }
+
+    private mutating func consume(_ expected: UnicodeScalar) throws {
+        guard peek() == expected else { throw ReceiptFeedStore.StoreError.invalidJSON }
+        index += 1
+    }
+
+    private mutating func consumeIf(_ expected: UnicodeScalar) -> Bool {
+        guard peek() == expected else { return false }
+        index += 1
+        return true
+    }
+
+    private mutating func skipWhitespace() {
+        while let scalar = peek(), " \n\r\t".unicodeScalars.contains(scalar) {
+            index += 1
+        }
+    }
+
+    private func peek() -> UnicodeScalar? {
+        index < scalars.count ? scalars[index] : nil
+    }
+}

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/DashboardStateTests.swift
@@ -333,6 +333,7 @@ struct DashboardStateTests {
         #expect(
             !DashboardPanelActivity.shouldRefreshSnapshot(
                 guideCollapsed: true,
+                receiptsCollapsed: true,
                 resourcesCollapsed: true,
                 racesCollapsed: true,
                 testsCollapsed: true,
@@ -342,6 +343,7 @@ struct DashboardStateTests {
         #expect(
             DashboardPanelActivity.shouldRefreshSnapshot(
                 guideCollapsed: true,
+                receiptsCollapsed: true,
                 resourcesCollapsed: true,
                 racesCollapsed: false,
                 testsCollapsed: true,

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -224,8 +224,8 @@ struct GuidePresentationTests {
         )
 
         #expect(info["CFBundleIconName"] as? String == "AppIcon")
-        #expect(info["CFBundleShortVersionString"] as? String == "1.1.0")
-        #expect(info["CFBundleVersion"] as? String == "2")
+        #expect(info["CFBundleShortVersionString"] as? String == "1.2.0")
+        #expect(info["CFBundleVersion"] as? String == "3")
         #expect(project.contains("CFBundleIconName: AppIcon"))
         #expect(project.contains("ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon"))
     }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ReceiptFeedTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ReceiptFeedTests.swift
@@ -1,0 +1,476 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Receipt feed")
+struct ReceiptFeedTests {
+    @Test("Reviewed dashboard handoff and canonical schemas remain pinned")
+    func reviewedContractPins() throws {
+        #expect(
+            ReceiptFeedContractPins.reviewedSnapshotSHA256
+                == "e0c598cdcc29ba39f509ccdb553f8d2c65709896827229e3aff1ada07c1bd1f2"
+        )
+        #expect(
+            ReceiptFeedContractPins.reviewedLKGSnapshotSHA256
+                == "ae4948b1c6396caca73a372a90474626d82d94291f36cb8bbc973799c6bebea8"
+        )
+        #expect(
+            ReceiptFeedContractPins.reviewedManifestSHA256
+                == "a94a8331b303189a99334b8c2f5940418a510326ceabbc1e58c34ee2460af1f8"
+        )
+        #expect(
+            ReceiptFeedContractPins.canonicalManifestStateSHA256
+                == "0a815cbd060d698b39badc715c16933436b7abec6588ca226bd1ffee4d73cc6a"
+        )
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let schemaRoot = packageRoot
+            .appendingPathComponent("../../addons/orchestrator_session/common/")
+            .appendingPathComponent("orchestrator-control/schemas")
+            .standardizedFileURL
+        #expect(
+            try sha256(
+                Data(contentsOf: schemaRoot.appendingPathComponent(
+                    "receipt-feed-1.1.schema.json"
+                ))
+            ) == ReceiptFeedContractPins.feedSchemaSHA256
+        )
+        #expect(
+            try sha256(
+                Data(contentsOf: schemaRoot.appendingPathComponent(
+                    "current-task-manifest-1.0.schema.json"
+                ))
+            ) == ReceiptFeedContractPins.manifestSchemaSHA256
+        )
+    }
+
+    @Test("A valid current snapshot maps NOW, DECISIONS, and RECENTLY DONE")
+    func validCurrentSnapshot() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let data = try snapshotData(
+            generatedAt: "2026-07-29T22:00:00Z",
+            receipts: [
+                receipt(label: "Current task", lifecycle: "active", lane: "running"),
+                receipt(
+                    label: "Owner decision",
+                    lifecycle: "owner-gated",
+                    lane: "owner-gated",
+                    gate: "owner"
+                ),
+                receipt(label: "Accepted completion", lifecycle: "done", lane: "complete"),
+            ]
+        )
+        try install(data, pointer: "receipt-feed-current.json", in: directory)
+
+        let view = ReceiptFeedStore(directoryURL: directory).load(
+            now: try #require(date("2026-07-29T22:00:30Z"))
+        )
+
+        #expect(view.pointerKind == .current)
+        #expect(view.freshness == .current)
+        #expect(view.now.map(\.publicLabel) == ["Current task"])
+        #expect(view.decisions.map(\.publicLabel) == ["Owner decision"])
+        #expect(view.recentlyDone.map(\.publicLabel) == ["Accepted completion"])
+        #expect(view.sourceBadge == "CURRENT")
+    }
+
+    @Test("A fractional overrun is stale without hiding accepted receipts")
+    func fractionalStaleBoundary() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let data = try snapshotData(
+            generatedAt: "2026-07-29T22:00:00.100Z",
+            receipts: [
+                receipt(label: "Still visible", lifecycle: "active", lane: "running")
+            ],
+            threshold: 60
+        )
+        try install(data, pointer: "receipt-feed-current.json", in: directory)
+
+        let view = ReceiptFeedStore(directoryURL: directory).load(
+            now: try #require(date("2026-07-29T22:01:01Z"))
+        )
+
+        #expect(view.freshness == .stale)
+        #expect(view.ageSeconds == 61)
+        #expect(view.now.map(\.publicLabel) == ["Still visible"])
+        #expect(view.sourceBadge == "STALE")
+    }
+
+    @Test("Tampered current falls back to independently hashed LKG")
+    func tamperedCurrentUsesLKG() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let current = try snapshotData(
+            generatedAt: "2026-07-29T22:00:00Z",
+            receipts: [receipt(label: "Current", lifecycle: "active", lane: "running")]
+        )
+        let lkg = try snapshotData(
+            generatedAt: "2026-07-29T21:00:00Z",
+            receipts: [receipt(label: "Fallback", lifecycle: "done", lane: "complete")]
+        )
+        let currentSnapshot = try install(
+            current,
+            pointer: "receipt-feed-current.json",
+            in: directory
+        )
+        try install(lkg, pointer: "receipt-feed-lkg.json", in: directory)
+        try Data("tampered".utf8).write(to: currentSnapshot, options: .atomic)
+
+        let view = ReceiptFeedStore(directoryURL: directory).load(
+            now: try #require(date("2026-07-29T22:00:30Z"))
+        )
+
+        #expect(view.pointerKind == .lkg)
+        #expect(view.recentlyDone.map(\.publicLabel) == ["Fallback"])
+        #expect(view.sourceBadge == "LKG")
+        #expect(view.reason?.contains("last known good") == true)
+    }
+
+    @Test("Unavailable current source status falls back to LKG")
+    func unavailableCurrentUsesLKG() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var current = try #require(
+            JSONSerialization.jsonObject(
+                with: snapshotData(
+                    generatedAt: "2026-07-29T22:00:00Z",
+                    receipts: []
+                )
+            ) as? [String: Any]
+        )
+        var source = try #require(current["source"] as? [String: Any])
+        source["sourceStatus"] = "unavailable"
+        current["source"] = source
+        try install(
+            JSONSerialization.data(withJSONObject: current, options: [.sortedKeys]),
+            pointer: "receipt-feed-current.json",
+            in: directory
+        )
+        let lkg = try snapshotData(
+            generatedAt: "2026-07-29T21:00:00Z",
+            receipts: [receipt(label: "Fallback", lifecycle: "done", lane: "complete")]
+        )
+        try install(lkg, pointer: "receipt-feed-lkg.json", in: directory)
+
+        let view = ReceiptFeedStore(directoryURL: directory).load(
+            now: try #require(date("2026-07-29T22:00:30Z"))
+        )
+
+        #expect(view.pointerKind == .lkg)
+        #expect(view.recentlyDone.map(\.publicLabel) == ["Fallback"])
+    }
+
+    @Test("Unknown fields and duplicate keys fail closed")
+    func unknownAndDuplicateFieldsFailClosed() throws {
+        let unknownDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: unknownDirectory) }
+        var unknown = try #require(
+            JSONSerialization.jsonObject(
+                with: snapshotData(generatedAt: "2026-07-29T22:00:00Z", receipts: [])
+            ) as? [String: Any]
+        )
+        unknown["rawPrompt"] = "must not be accepted"
+        try install(
+            JSONSerialization.data(withJSONObject: unknown, options: [.sortedKeys]),
+            pointer: "receipt-feed-current.json",
+            in: unknownDirectory
+        )
+        #expect(
+            ReceiptFeedStore(directoryURL: unknownDirectory).load().pointerKind == nil
+        )
+
+        let duplicateDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: duplicateDirectory) }
+        let valid = try snapshotData(
+            generatedAt: "2026-07-29T22:00:00Z",
+            receipts: []
+        )
+        let duplicate = Data(
+            String(decoding: valid, as: UTF8.self)
+                .replacingOccurrences(
+                    of: #""schemaVersion":"1.1""#,
+                    with: #""schemaVersion":"1.1","schemaVersion":"1.1""#
+                )
+                .utf8
+        )
+        try install(
+            duplicate,
+            pointer: "receipt-feed-current.json",
+            in: duplicateDirectory
+        )
+        #expect(
+            ReceiptFeedStore(directoryURL: duplicateDirectory).load().pointerKind == nil
+        )
+    }
+
+    @Test("Schema mismatch, invalid hash, empty directory, and symlinks are unavailable")
+    func failClosedSources() throws {
+        let empty = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: empty) }
+        #expect(ReceiptFeedStore(directoryURL: empty).load() == .unavailable)
+
+        let schemaDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: schemaDirectory) }
+        var schema = try #require(
+            JSONSerialization.jsonObject(
+                with: snapshotData(generatedAt: "2026-07-29T22:00:00Z", receipts: [])
+            ) as? [String: Any]
+        )
+        schema["schemaVersion"] = "2.0"
+        try install(
+            JSONSerialization.data(withJSONObject: schema, options: [.sortedKeys]),
+            pointer: "receipt-feed-current.json",
+            in: schemaDirectory
+        )
+        #expect(ReceiptFeedStore(directoryURL: schemaDirectory).load().pointerKind == nil)
+
+        let linkedDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: linkedDirectory) }
+        let outside = linkedDirectory.appendingPathComponent("outside.json")
+        try Data("{}".utf8).write(to: outside)
+        try FileManager.default.createSymbolicLink(
+            at: linkedDirectory.appendingPathComponent("receipt-feed-current.json"),
+            withDestinationURL: outside
+        )
+        #expect(ReceiptFeedStore(directoryURL: linkedDirectory).load().pointerKind == nil)
+    }
+
+    @Test("Nested receipt schema violations fail closed before projection")
+    func nestedSchemaViolationFailsClosed() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var object = try #require(
+            JSONSerialization.jsonObject(
+                with: snapshotData(
+                    generatedAt: "2026-07-29T22:00:00Z",
+                    receipts: [
+                        receipt(label: "Invalid metric", lifecycle: "active", lane: "running")
+                    ]
+                )
+            ) as? [String: Any]
+        )
+        var receipts = try #require(object["receipts"] as? [[String: Any]])
+        var duration = try #require(receipts[0]["duration"] as? [String: Any])
+        duration["elapsedActiveSeconds"] = [
+            "value": -1,
+            "availability": "derived",
+        ]
+        receipts[0]["duration"] = duration
+        object["receipts"] = receipts
+        try install(
+            JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+            pointer: "receipt-feed-current.json",
+            in: directory
+        )
+
+        #expect(ReceiptFeedStore(directoryURL: directory).load().pointerKind == nil)
+    }
+
+    @Test("Feed absence never disables the established dashboard snapshot")
+    @MainActor
+    func feedAbsenceIsAdditive() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let snapshotURL = directory.appendingPathComponent("dashboard-state.json")
+        try Data(localDashboardFixture.utf8).write(to: snapshotURL)
+
+        let state = DashboardState(
+            snapshotURL: snapshotURL,
+            receiptDirectoryURL: directory.appendingPathComponent("missing-receipts"),
+            liveClient: nil
+        )
+
+        #expect(state.snapshot.queue.first?.title == "Existing race lane")
+        #expect(state.snapshot.resourceBudget.first?.title == "Existing resource panel")
+        #expect(state.receiptFeed == .unavailable)
+        #expect(
+            DashboardPanelActivity.shouldRefreshSnapshot(
+                guideCollapsed: true,
+                receiptsCollapsed: true,
+                resourcesCollapsed: false,
+                racesCollapsed: true,
+                testsCollapsed: true,
+                signalsCollapsed: true
+            )
+        )
+    }
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ReceiptFeedTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    @discardableResult
+    private func install(
+        _ snapshot: Data,
+        pointer: String,
+        in directory: URL
+    ) throws -> URL {
+        let digest = SHA256.hash(data: snapshot)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let snapshotName = "receipt-feed-1.1.\(digest).json"
+        let snapshotURL = directory.appendingPathComponent(snapshotName)
+        try snapshot.write(to: snapshotURL, options: .atomic)
+        let pointerObject: [String: Any] = [
+            "schemaVersion": "1.1",
+            "sha256": digest,
+            "snapshot": snapshotName,
+            "generatedAt": "2026-07-29T22:00:00Z",
+        ]
+        try JSONSerialization.data(withJSONObject: pointerObject, options: [.sortedKeys])
+            .write(
+                to: directory.appendingPathComponent(pointer),
+                options: .atomic
+            )
+        return snapshotURL
+    }
+
+    private func snapshotData(
+        generatedAt: String,
+        receipts: [[String: Any]],
+        threshold: Int = 300
+    ) throws -> Data {
+        let done = receipts.filter { ["done", "acknowledged"].contains($0["lifecycle"] as? String) }
+        let active = receipts.filter {
+            ["active", "setup-reserved"].contains($0["lifecycle"] as? String)
+        }
+        let ownerGated = receipts.filter { $0["lifecycle"] as? String == "owner-gated" }
+        let object: [String: Any] = [
+            "schemaVersion": "1.1",
+            "source": [
+                "generatedAt": generatedAt,
+                "servedAt": generatedAt,
+                "sourceStatus": "live",
+                "freshness": [
+                    "state": "current",
+                    "ageSeconds": 0,
+                    "thresholdSeconds": threshold,
+                ],
+                "sourceRevision": "native-consumer-fixture-1",
+                "discrepancies": [],
+                "provenance": [
+                    "sourceClass": "pm-proxy-manifest",
+                    "sanitization": "caller-allowlisted+projection-validated",
+                    "rootExcluded": true,
+                ],
+            ],
+            "capacity": [
+                "configuredWorkers": 4,
+                "rootExcluded": true,
+                "availability": "derived",
+            ],
+            "counts": [
+                "availability": "derived",
+                "setupReserved": 0,
+                "active": active.count,
+                "waiting": 0,
+                "ownerGated": ownerGated.count,
+                "failed": 0,
+                "done": done.count,
+                "acknowledged": 0,
+                "runnable": 0,
+                "quarantined": 0,
+            ],
+            "receipts": receipts,
+            "ownerGates": [],
+            "quarantine": [],
+        ]
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    private func receipt(
+        label: String,
+        lifecycle: String,
+        lane: String,
+        gate: String = "none"
+    ) -> [String: Any] {
+        let checksum = label.utf8.reduce(0) { $0 + Int($1) } % 255
+        let hex = String(
+            repeating: String(format: "%02x", checksum),
+            count: 32
+        )
+        return [
+            "fingerprint": "rcpt_\(hex)",
+            "revision": 1,
+            "publicLabel": label,
+            "ownerClass": gate == "owner" ? "owner" : "worker",
+            "laneClass": lane,
+            "metadataSource": lifecycle == "active" ? "launch" : "handback",
+            "lifecycle": lifecycle,
+            "gateKind": gate,
+            "dependsOn": [],
+            "acceptanceReceipts": [],
+            "successorReceipts": [],
+            "runnable": false,
+            "duration": [
+                "estimateSeconds": ["value": NSNull(), "availability": "unavailable"],
+                "elapsedActiveSeconds": ["value": NSNull(), "availability": "unavailable"],
+                "externalWaitSeconds": ["value": NSNull(), "availability": "unavailable"],
+                "firstUsefulEvidenceSeconds": [
+                    "value": NSNull(), "availability": "unavailable",
+                ],
+            ],
+            "nextSafeMove": gate == "owner"
+                ? "review-owner-gate"
+                : (lifecycle == "active" ? "continue-active-work" : "verify-and-archive"),
+            "evidenceAge": [
+                "latestEvidenceAt": "2026-07-29T22:00:00Z",
+                "ageSeconds": 0,
+                "availability": "derived",
+            ],
+            "fieldAvailability": ["publicLabel": "supplied"],
+            "evidenceRefs": [
+                ["kind": "receipt", "ref": "fixture:receipt", "label": "Synthetic fixture"]
+            ],
+        ]
+    }
+
+    private func date(_ value: String) -> Date? {
+        ISO8601DateFormatter().date(from: value)
+    }
+
+    private func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private var localDashboardFixture: String {
+        """
+        {
+          "schemaVersion": "1.0",
+          "mode": "local",
+          "queue": [{
+            "id": "Q1",
+            "title": "Existing race lane",
+            "detail": "Existing feature remains available.",
+            "state": "running",
+            "exposure": "local-only",
+            "verification": "verified"
+          }],
+          "tests": [],
+          "resourceBudget": [{
+            "id": "R1",
+            "title": "Existing resource panel",
+            "detail": "Existing feature remains available.",
+            "displayValue": "Available",
+            "exposure": "local-only",
+            "verification": "verified"
+          }],
+          "signals": []
+        }
+        """
+    }
+}

--- a/prototypes/operations-floater/docs/RECEIPT_FEED_NATIVE.md
+++ b/prototypes/operations-floater/docs/RECEIPT_FEED_NATIVE.md
@@ -1,0 +1,56 @@
+# Native receipt-feed contract
+
+Operations Floater consumes the dashboard lane's sanitized receipt-feed 1.1
+projection as local, read-only input. The reviewed handoff came from dashboard
+candidate commit `0e340073708684d8530f0769780e705d9e8c5990`.
+
+## Cryptographic pins
+
+- reviewed current snapshot:
+  `e0c598cdcc29ba39f509ccdb553f8d2c65709896827229e3aff1ada07c1bd1f2`
+- reviewed LKG snapshot:
+  `ae4948b1c6396caca73a372a90474626d82d94291f36cb8bbc973799c6bebea8`
+- receipt-feed 1.1 schema:
+  `26cfc2cddac67831c6470f32dd54537762be95138661850d70e49a734db3ccc4`
+- current-task manifest schema:
+  `6b2649aef97774a00ed8323f91ce84c951220243ed4fd8b6d036b715d17a581f`
+- reviewed manifest file:
+  `a94a8331b303189a99334b8c2f5940418a510326ceabbc1e58c34ee2460af1f8`
+- canonical manifest state:
+  `0a815cbd060d698b39badc715c16933436b7abec6588ca226bd1ffee4d73cc6a`
+
+The app also carries these pins in source and verifies content-addressed
+snapshot bytes against their pointer at every read. Runtime snapshots need not
+equal the reviewed fixture hash, but they must satisfy the pinned schema
+contract, exact provenance allowlists, and their own pointer digest.
+
+## Selection and freshness
+
+The app reads `receipt-feed-current.json` first. It uses
+`receipt-feed-lkg.json` only if the current pointer, digest, JSON, schema, or
+provenance is invalid. A valid stale current snapshot stays selected.
+
+Freshness is recomputed at read time as
+`max(0, ceil(readAt - generatedAt))`. It is stale only when that conservative
+integer age is greater than `thresholdSeconds`; therefore an actual age of
+60.9 seconds is 61 seconds and stale at a 60-second threshold.
+
+Missing, invalid, or unavailable sources make only the receipt panel offline.
+The existing local snapshot, Router chat and review, voice/floor controls,
+Relative XY recorder, race/resource/privacy panels, keyboard behavior, and
+window lifecycle remain independent.
+
+## Privacy and mutation boundary
+
+Only the dashboard contract's bounded public labels and status projections are
+rendered. The consumer rejects duplicate JSON keys, unknown object fields,
+symlinks, oversized input, mismatched hashes, and non-allowlisted provenance.
+It never displays raw prompts, source paths, manifest internals, or arbitrary
+unknown content. It has no write, network, task-action, or control-plane path.
+
+## Rollback
+
+Revert the focused receipt-view commit and regenerate the Xcode project from
+`project.yml`. Removing the local `OperationsFloater/receipts` directory is
+optional: old builds do not read it. No Router, service, configuration,
+permission, signing, installation, or task state needs to be changed.

--- a/prototypes/operations-floater/docs/receipt-feed-native-consumer-contract.json
+++ b/prototypes/operations-floater/docs/receipt-feed-native-consumer-contract.json
@@ -1,0 +1,55 @@
+{
+  "contractVersion": "1.0",
+  "feedSchemaVersion": "1.1",
+  "fixtureFile": "receipt-feed-native-current.json",
+  "fixtureSha256": "e0c598cdcc29ba39f509ccdb553f8d2c65709896827229e3aff1ada07c1bd1f2",
+  "feedSchemaSha256": "26cfc2cddac67831c6470f32dd54537762be95138661850d70e49a734db3ccc4",
+  "manifestSchemaSha256": "6b2649aef97774a00ed8323f91ce84c951220243ed4fd8b6d036b715d17a581f",
+  "manifestFileSha256": "a94a8331b303189a99334b8c2f5940418a510326ceabbc1e58c34ee2460af1f8",
+  "canonicalManifestStateSha256": "0a815cbd060d698b39badc715c16933436b7abec6588ca226bd1ffee4d73cc6a",
+  "lkgSnapshotSha256": "ae4948b1c6396caca73a372a90474626d82d94291f36cb8bbc973799c6bebea8",
+  "expectedProjection": {
+    "active": 8,
+    "ownerGated": 1,
+    "done": 6,
+    "quarantined": 0
+  },
+  "requiredProvenance": {
+    "sourceClass": "pm-proxy-manifest",
+    "sanitization": "caller-allowlisted+projection-validated",
+    "rootExcluded": true
+  },
+  "displayAllowlist": [
+    "publicLabel",
+    "ownerClass",
+    "laneClass",
+    "lifecycle",
+    "gateKind",
+    "nextSafeMove",
+    "evidenceAge",
+    "evidenceRefs"
+  ],
+  "freshness": {
+    "ageSeconds": "max(0, ceil((readAt-generatedAt)/1000))",
+    "currentWhen": "ageSeconds <= thresholdSeconds",
+    "staleWhen": "ageSeconds > thresholdSeconds",
+    "staleSourceStatus": "degraded",
+    "missingOrInvalidSourceStatus": "unavailable"
+  },
+  "selection": {
+    "primary": "receipt-feed-current.json",
+    "fallback": "receipt-feed-lkg.json",
+    "useFallbackWhen": "primary pointer, digest, JSON, schema, or provenance validation fails",
+    "doNotFallbackWhen": "primary is valid but stale",
+    "mutation": "none"
+  },
+  "failClosed": [
+    "reject duplicate JSON object keys",
+    "reject a pointer whose digest does not match its snapshot bytes",
+    "reject unsupported schema versions",
+    "reject missing or non-allowlisted provenance",
+    "never render unknown fields as task content",
+    "never infer zero from unavailable counts",
+    "never write task state or send an action"
+  ]
+}

--- a/prototypes/operations-floater/project.yml
+++ b/prototypes/operations-floater/project.yml
@@ -20,8 +20,8 @@ targets:
         CFBundleIconName: AppIcon
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: public.app-category.productivity
-        CFBundleShortVersionString: "1.1.0"
-        CFBundleVersion: "2"
+        CFBundleShortVersionString: "1.2.0"
+        CFBundleVersion: "3"
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         NSMicrophoneUsageDescription: Start Voice Conversation uses the microphone only while you explicitly listen.


### PR DESCRIPTION
## Summary
- add a fail-closed local-only receipt-feed 1.1 consumer to Operations Floater
- display sanitized NOW, DECISIONS, and RECENTLY DONE projections with current/stale/LKG/offline provenance
- pin the reviewed dashboard handoff hashes and preserve all existing native panels and behavior

## Validation
- ReceiptFeedTests: 9/9
- full Swift suite: 110/110
- permission identity preflight: 7/7
- full repository Python suite: 99/99
- browser/shared suites: 9/9 Python, 4/4 web, 15/15 publisher
- every-stack generator gate: 4/4 stacks; no token leaks; scripts parse

No app launch, installation, signing, TCC/mic/input request, Router/service/config mutation, deployment, or release was performed.