### PR TITLE
feat(operations-floater): Developer ID signing/notarization kit

### DIFF
--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.2.0 (build 3) — unreleased
 
+- Resolve the sandbox-vs-Input-Monitoring conflict: adopt Developer ID (direct)
+  distribution with the Hardened Runtime and **without** the App Sandbox, so the
+  Relative XY recorder's cross-process Input Monitoring works. Correct
+  `OperationsFloater.entitlements` to the minimal set (Hardened Runtime
+  microphone exception only) and set `ENABLE_APP_SANDBOX: NO` in `project.yml`.
+- Add `scripts/sign-and-notarize.sh` (owner-run, credential-free, parameterized):
+  codesign `--options runtime` + entitlements + secure timestamp -> notarytool
+  submit `--wait` -> stapler staple -> verify (`spctl`, `codesign --verify
+  --deep --strict`, `stapler validate`).
+- Add `docs/SIGNING.md` with the sandbox-vs-Input-Monitoring analysis, the
+  sandboxed-alternative tradeoff, and the owner checklist (Developer ID cert,
+  notary profile, build, sign, first-launch TCC grants).
 - Add **Ember**, a dismissible, vector-drawn corner companion that mirrors the
   canonical snapshot: it naps when the queue is empty, focuses while lanes run,
   briefly celebrates when work reaches the finished lane, and shows concern on a

--- a/prototypes/operations-floater/OperationsFloater.entitlements
+++ b/prototypes/operations-floater/OperationsFloater.entitlements
@@ -2,13 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<!--
+	  Distribution posture: Developer ID (direct) + Hardened Runtime, NOT sandboxed.
+
+	  Operations Floater's Relative XY recorder calls CGRequestListenEventAccess()
+	  to observe another application's mouse/scroll/key-code stream (Input
+	  Monitoring). The App Sandbox structurally blocks cross-process event
+	  monitoring, so com.apple.security.app-sandbox is intentionally ABSENT here.
+	  See docs/SIGNING.md for the sandbox-vs-Input-Monitoring analysis and the
+	  alternative (drop Input Monitoring to stay sandboxed).
+
+	  The only entitlement required for the recommended path is the Hardened
+	  Runtime microphone resource-access exception. Speech Recognition and Input
+	  Monitoring carry no entitlement; they are gated purely by TCC at runtime
+	  (NSSpeechRecognitionUsageDescription / Privacy & Security -> Input
+	  Monitoring). Network and user-selected file access are unrestricted once the
+	  sandbox is removed, so the former sandbox-only keys are dropped as no-ops.
+	-->
 	<key>com.apple.security.device.audio-input</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>
 </plist>

--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -21,8 +21,8 @@ The native app first polls only the fixed loopback Router metrics endpoint at
 when it is a verified canonical `local` snapshot. It sends no credentials,
 cookies, dashboard state, or private file content, and follows no redirect.
 
-An optional runtime snapshot may also be placed in the app's sandboxed
-Application Support container as `OperationsFloater/dashboard-state.json`.
+An optional runtime snapshot may also be placed in the app's
+Application Support directory as `OperationsFloater/dashboard-state.json`.
 That local path is resolved by the app at runtime and is never committed or
 transmitted. The native adapter rejects unknown contract fields and rejects
 every `local-only` record unless it is marked `verified`. Invalid or missing
@@ -69,7 +69,7 @@ snapshot remains schema version `1.0`.
 - An explicit user launch opens visibly in front but defaults **Keep in front**
   to off and stays on one macOS Desktop. Pinning and showing the same window on
   every Desktop are never implicit.
-- The app holds one process-scoped lease in its sandboxed Application Support
+- The app holds one process-scoped lease in its Application Support
   directory. A direct second launch activates the existing bundle instance and
   exits before starting another recorder host.
 - A deliberate `--background-ui-test` launch mode leaves **Keep in front** off,
@@ -179,8 +179,12 @@ snapshot remains schema version `1.0`.
   remains the authoritative egress guard.
 - The default 620-by-640 window shows a dense two-column operational grid and
   remains usable down to a 380-by-480 compact single-column layout.
-- The application target is sandboxed, uses hardened runtime, and includes a
-  macOS app icon, encryption declaration, and productivity category.
+- The application target uses the Hardened Runtime and is distributed directly
+  with a Developer ID (not sandboxed), and includes a macOS app icon, encryption
+  declaration, and productivity category. The App Sandbox is deliberately off
+  because the Relative XY recorder needs cross-process Input Monitoring, which
+  the sandbox blocks. See [docs/SIGNING.md](docs/SIGNING.md) for the
+  sandbox-vs-Input-Monitoring analysis, entitlements, and owner signing steps.
 - The supported release shape is one signed main app with no login item,
   launch agent, daemon, privileged helper, or updater. Input Monitoring belongs
   to that app's stable code identity; unsigned and ad-hoc routine builds are

--- a/prototypes/operations-floater/docs/SIGNING.md
+++ b/prototypes/operations-floater/docs/SIGNING.md
@@ -1,0 +1,198 @@
+# Signing and notarization
+
+Operations Floater ships as a Developer ID (direct) macOS app with the Hardened
+Runtime and **without** the App Sandbox. This document explains why, what the
+entitlements are, and exactly what the owner must do. It contains no
+credentials, team identifiers, Apple IDs, or owner-specific values; every such
+value is supplied at run time and never committed (firestarter's origin is
+public).
+
+## The sandbox vs. Input Monitoring conflict
+
+The app needs three privacy-protected resources:
+
+| Resource | Trigger in the app | Gate |
+| --- | --- | --- |
+| Microphone | Voice Conversation (`AVAudioEngine` / on-device speech) | Hardened Runtime entitlement + TCC (`NSMicrophoneUsageDescription`) |
+| Speech Recognition | On-device transcription of voice turns | TCC (`NSSpeechRecognitionUsageDescription`) |
+| Input Monitoring | Relative XY recorder — `CGRequestListenEventAccess()` / `CGPreflightListenEventAccess()` in `NeutralGeometryCapture.swift` | TCC (Privacy & Security -> Input Monitoring) |
+
+The Relative XY recorder observes the **complete mouse, scroll, and key-code
+stream of another application's selected window**. That is cross-process global
+input monitoring. macOS deliberately does not allow a sandboxed process to
+monitor input directed at other applications: the App Sandbox confines a process
+to its own event stream, and `CGRequestListenEventAccess()` cannot grant a
+sandboxed app system-wide Input Monitoring. So the two requirements are mutually
+exclusive:
+
+- **App Sandbox on** -> Input Monitoring of other apps' windows does not work,
+  and the recorder — a headline feature — is dead.
+- **Input Monitoring required** -> the app cannot be sandboxed.
+
+The previously committed `OperationsFloater.entitlements` declared
+`com.apple.security.app-sandbox = true` (and `project.yml` set
+`ENABLE_APP_SANDBOX: YES`). That directly contradicts the recorder and the app's
+own docs, which describe the main process as the sole Input Monitoring client.
+The microphone sandbox entitlement (`com.apple.security.device.audio-input`) was
+already present, but the sandbox itself was the blocker. This is the conflict
+this change resolves.
+
+> Note: because the App Store requires the App Sandbox, an app that keeps Input
+> Monitoring **cannot** ship on the Mac App Store. Direct Developer ID
+> distribution is the only channel that supports this feature.
+
+## Recommendation: Developer ID direct + Hardened Runtime, no sandbox
+
+**Adopted.** Distribute the app directly (Developer ID Application certificate +
+notarization), enable the Hardened Runtime, and **do not** enable the App
+Sandbox. This preserves the microphone, Speech Recognition, and Input Monitoring
+features intact. The Hardened Runtime satisfies the notarization requirement and
+still constrains the process (code-injection, unsigned-memory-execution, and
+library-validation protections all remain on).
+
+### Corrected entitlements
+
+`OperationsFloater.entitlements` is now:
+
+```xml
+<key>com.apple.security.device.audio-input</key>
+<true/>
+```
+
+That single key is the Hardened Runtime's microphone resource-access exception,
+required before the mic can be used at all; TCC then prompts the user with the
+`NSMicrophoneUsageDescription` string. Everything else needs no entitlement:
+
+- **Speech Recognition** is TCC-gated by `NSSpeechRecognitionUsageDescription`;
+  there is no Hardened Runtime entitlement for it.
+- **Input Monitoring** is TCC-gated by `CGRequestListenEventAccess()`; it needs
+  no entitlement and now works because the sandbox is gone.
+- **Network** (`127.0.0.1:11500` loopback Router) and **user-selected files**
+  (the Import Local Snapshot picker) are unrestricted without the sandbox, so
+  the former `com.apple.security.network.client` and
+  `com.apple.security.files.user-selected.read-write` keys were dropped as
+  no-ops.
+
+`project.yml` now sets `ENABLE_APP_SANDBOX: NO` and keeps
+`ENABLE_HARDENED_RUNTIME: YES` so a regenerated Xcode project matches these
+entitlements.
+
+### One side effect: Application Support location
+
+Leaving the sandbox moves the app's storage from the per-app container
+(`~/Library/Containers/<bundle-id>/Data/Library/Application Support/`) to the
+standard `~/Library/Application Support/`. The code resolves this with
+`FileManager.default.urls(for: .applicationSupportDirectory, ...)`
+(`OperationsFloaterApp.swift`, `LocalSnapshotStore.swift`), so no code change is
+needed; the process-scoped lease, saved snapshot, and receipts simply live at
+the standard path. A migration is only relevant if a previously sandboxed build
+was already installed with real data — not the case for a first release.
+
+## Tradeoff: the sandboxed alternative
+
+If Mac App Store distribution or the stronger sandbox confinement were ever
+required, the only way to stay sandboxed is to **drop Input Monitoring** —
+remove the Relative XY recorder's cross-process event capture entirely (or
+reduce it to events inside the app's own windows, which needs no special
+permission). The sandboxed entitlements would then be:
+
+```xml
+<key>com.apple.security.app-sandbox</key><true/>
+<key>com.apple.security.device.audio-input</key><true/>
+<key>com.apple.security.network.client</key><true/>
+<key>com.apple.security.files.user-selected.read-write</key><true/>
+```
+
+Microphone and Speech Recognition survive under the sandbox; only the recorder
+is lost. Because the recorder is a defining capability of this app, the
+non-sandboxed Developer ID path is recommended. Revisit only if the product
+direction changes (e.g. an App Store build that deliberately omits the
+recorder).
+
+## OWNER checklist
+
+These steps need the owner's Apple credentials and are **not** run by CI or by
+any automation in this repo. Do them on the owner's signing machine.
+
+1. **Obtain a Developer ID Application certificate.**
+   In Xcode: Settings -> Accounts -> your Apple Developer team -> Manage
+   Certificates -> "+" -> **Developer ID Application** (or create it in the
+   Apple Developer portal and download it). Confirm it is installed in the login
+   keychain:
+
+   ```bash
+   security find-identity -v -p codesigning | grep "Developer ID Application"
+   ```
+
+   Note the identity string, e.g. `Developer ID Application: Example Owner (TEAMID1234)`.
+
+2. **Create the notary keychain profile** (store credentials once; the values
+   never enter this repo). Preferred — an App Store Connect API key:
+
+   ```bash
+   xcrun notarytool store-credentials operations-floater-notary \
+     --key "AuthKey_XXXXXXXXXX.p8" \
+     --key-id "XXXXXXXXXX" \
+     --issuer "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+   ```
+
+   Alternative — Apple ID + app-specific password (create the password at
+   appleid.apple.com -> Sign-In and Security -> App-Specific Passwords):
+
+   ```bash
+   xcrun notarytool store-credentials operations-floater-notary \
+     --apple-id "you@example.com" \
+     --team-id "TEAMID1234" \
+     --password "abcd-efgh-ijkl-mnop"
+   ```
+
+3. **Build the .app on a disposable account / CI runner**, not the active
+   profile (Xcode 26.5 runs `lsregister` during build/archive — see
+   `docs/PERMISSION_AND_INSTALL_LIFECYCLE.md`). Set the owner's real bundle
+   identifier and team at this stage; the checked-in `com.example.operationsfloater`
+   is a disposable placeholder and must be overridden.
+
+4. **Run the signing kit** against the built bundle:
+
+   ```bash
+   scripts/sign-and-notarize.sh \
+     --app "/path/to/Operations Floater.app" \
+     --identity "Developer ID Application: Example Owner (TEAMID1234)" \
+     --notary-profile operations-floater-notary
+   ```
+
+   The script signs with the Hardened Runtime + these entitlements + a secure
+   timestamp, submits to the notary service and waits, staples the ticket, and
+   verifies with `spctl --assess`, `codesign --verify --deep --strict`, and
+   `stapler validate`.
+
+5. **(Optional) Run the identity preflight** before installing/updating the
+   canonical copy:
+
+   ```bash
+   scripts/verify-permission-identity.sh \
+     --candidate "/path/to/Operations Floater.app" \
+     --expected-bundle-id "<owner-bundle-id>" \
+     --expected-team-id "TEAMID1234"
+   ```
+
+6. **Grant TCC on first launch.** Launch the installed app and approve, when the
+   app explicitly asks:
+   - **Microphone** and **Speech Recognition** — prompted the first time Voice
+     Conversation starts.
+   - **Input Monitoring** — the app calls `CGRequestListenEventAccess()`, which
+     opens Privacy & Security -> Input Monitoring; enable Operations Floater
+     there, then retry recording. macOS cannot revoke this from inside the app;
+     removal is done in System Settings.
+
+   Grant these only to the signed, notarized, installed copy — never to a
+   DerivedData product, SwiftPM executable, or other disposable build (each has
+   a different code identity and would strand the grant on the next release).
+
+## References
+
+- [Apple: Hardened Runtime — Resource Access entitlements](https://developer.apple.com/documentation/security/hardened_runtime)
+- [Apple: Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Apple: Customizing the notarization workflow (notarytool)](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- [Apple: App Sandbox](https://developer.apple.com/documentation/security/app-sandbox)
+- [Apple: CGRequestListenEventAccess()](https://developer.apple.com/documentation/coregraphics/cgrequestlisteneventaccess%28%29)

--- a/prototypes/operations-floater/project.yml
+++ b/prototypes/operations-floater/project.yml
@@ -30,7 +30,9 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_ENTITLEMENTS: OperationsFloater.entitlements
-        ENABLE_APP_SANDBOX: YES
+        # Developer ID (direct) distribution keeps Input Monitoring working, which
+        # the App Sandbox would block. Hardened Runtime stays on. See docs/SIGNING.md.
+        ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         PRODUCT_BUNDLE_IDENTIFIER: com.example.operationsfloater
         PRODUCT_NAME: Operations Floater

--- a/prototypes/operations-floater/scripts/sign-and-notarize.sh
+++ b/prototypes/operations-floater/scripts/sign-and-notarize.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Sign, notarize, staple, and verify a built Operations Floater.app for
+# Developer ID (direct) distribution with the Hardened Runtime.
+#
+# This script is OWNER-RUN. It is intentionally free of credentials, team
+# identifiers, Apple IDs, and bundle identifiers: the signing identity and the
+# notary keychain profile are supplied by the owner as flags or environment
+# variables. It never embeds, prints, or persists any secret.
+#
+# It does NOT build the app. Compile the .app on a disposable macOS account or
+# CI runner first (Xcode 26.5 runs lsregister during build/archive; see
+# docs/PERMISSION_AND_INSTALL_LIFECYCLE.md), then point this script at the
+# resulting bundle.
+#
+# Chain:
+#   1. codesign --options runtime (Hardened Runtime) + entitlements + secure timestamp
+#   2. xcrun notarytool submit --wait
+#   3. xcrun stapler staple
+#   4. verify: spctl -a -vv, codesign --verify --deep --strict, stapler validate
+#
+# Usage:
+#   scripts/sign-and-notarize.sh \
+#     --app "/path/to/Operations Floater.app" \
+#     --identity "Developer ID Application: Example Owner (TEAMID1234)" \
+#     --notary-profile operations-floater-notary \
+#     [--entitlements /path/to/OperationsFloater.entitlements] \
+#     [--bundle-id com.owner.operationsfloater]
+#
+# Equivalent environment variables (flags win):
+#   DEVELOPER_ID_APP   -> --identity
+#   NOTARY_PROFILE     -> --notary-profile
+#   ENTITLEMENTS       -> --entitlements
+#   BUNDLE_ID          -> --bundle-id   (optional; validated, never required)
+#
+# The notary profile is created once by the owner (values never touch this repo):
+#   xcrun notarytool store-credentials operations-floater-notary \
+#     --apple-id "<apple-id>" --team-id "<TEAMID>" --password "<app-specific-password>"
+#   # or, preferred, an App Store Connect API key:
+#   xcrun notarytool store-credentials operations-floater-notary \
+#     --key "<AuthKey_XXXX.p8>" --key-id "<KEY_ID>" --issuer "<ISSUER_UUID>"
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+default_entitlements="$script_dir/../OperationsFloater.entitlements"
+
+usage() {
+  sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+fail() {
+  printf 'sign-and-notarize: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+info() {
+  printf 'sign-and-notarize: %s\n' "$*"
+}
+
+app=
+identity=${DEVELOPER_ID_APP:-}
+notary_profile=${NOTARY_PROFILE:-}
+entitlements=${ENTITLEMENTS:-$default_entitlements}
+bundle_id=${BUNDLE_ID:-}
+
+while (($#)); do
+  case "$1" in
+    --app)
+      (($# >= 2)) || fail "--app requires a path"
+      app=$2
+      shift 2
+      ;;
+    --identity)
+      (($# >= 2)) || fail "--identity requires a value"
+      identity=$2
+      shift 2
+      ;;
+    --notary-profile)
+      (($# >= 2)) || fail "--notary-profile requires a value"
+      notary_profile=$2
+      shift 2
+      ;;
+    --entitlements)
+      (($# >= 2)) || fail "--entitlements requires a path"
+      entitlements=$2
+      shift 2
+      ;;
+    --bundle-id)
+      (($# >= 2)) || fail "--bundle-id requires a value"
+      bundle_id=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+# --- Preconditions ---------------------------------------------------------
+
+[[ -n "$app" ]] || fail "--app is required (path to the built .app bundle)"
+[[ -d "$app" ]] || fail "app bundle does not exist: $app"
+[[ "$app" == *.app ]] || fail "app must be a .app bundle: $app"
+[[ -n "$identity" ]] \
+  || fail "signing identity is required (--identity or DEVELOPER_ID_APP); \
+must be a 'Developer ID Application: ...' certificate in the login keychain"
+[[ -n "$notary_profile" ]] \
+  || fail "notary profile is required (--notary-profile or NOTARY_PROFILE); \
+create it once with 'xcrun notarytool store-credentials'"
+[[ -f "$entitlements" ]] || fail "entitlements file not found: $entitlements"
+
+# Public-repo safety: refuse the disposable placeholder identifier as a release
+# identity, mirroring scripts/verify-permission-identity.sh.
+if [[ -n "$bundle_id" ]]; then
+  case "$bundle_id" in
+    com.example.*|*.example|*'*'*)
+      fail "--bundle-id must be the owner-controlled release identifier, not a placeholder"
+      ;;
+  esac
+fi
+
+for tool in codesign ditto xcrun spctl; do
+  command -v "$tool" >/dev/null 2>&1 || fail "required tool not found on PATH: $tool"
+done
+xcrun --find notarytool >/dev/null 2>&1 || fail "xcrun notarytool is unavailable (install Xcode command line tools)"
+xcrun --find stapler >/dev/null 2>&1 || fail "xcrun stapler is unavailable (install Xcode command line tools)"
+
+info "app:            $app"
+info "identity:       $identity"
+info "notary profile: $notary_profile"
+info "entitlements:   $entitlements"
+[[ -n "$bundle_id" ]] && info "bundle id:      $bundle_id"
+
+# --- 1. Sign with Hardened Runtime + entitlements + secure timestamp -------
+#
+# This bundle embeds no frameworks, XPC services, or helper tools, so a single
+# signing pass is correct. If nested code is ever added, sign it inside-out
+# (deepest first) BEFORE signing the outer bundle; do not rely on --deep to sign.
+info "signing (Hardened Runtime + entitlements + secure timestamp)..."
+codesign \
+  --force \
+  --timestamp \
+  --options runtime \
+  --entitlements "$entitlements" \
+  --sign "$identity" \
+  "$app"
+
+info "verifying local signature before notarization..."
+codesign --verify --strict --verbose=2 "$app" \
+  || fail "post-sign signature verification failed"
+
+# --- 2. Notarize (submit a zip, wait for the verdict) ----------------------
+#
+# notarytool accepts a .zip/.pkg/.dmg, not a bare .app. Zip for submission only;
+# the ticket is stapled to the .app itself in step 3.
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+zip_path="$workdir/$(basename "$app" .app).zip"
+
+info "zipping bundle for submission..."
+ditto -c -k --keepParent "$app" "$zip_path"
+
+info "submitting to Apple notary service (this blocks until a verdict)..."
+if ! xcrun notarytool submit "$zip_path" \
+  --keychain-profile "$notary_profile" \
+  --wait; then
+  fail "notarization was not accepted; re-run 'xcrun notarytool log <submission-id> \
+--keychain-profile $notary_profile' for the detailed issue list"
+fi
+
+# --- 3. Staple the ticket to the bundle ------------------------------------
+info "stapling notarization ticket..."
+xcrun stapler staple "$app" || fail "stapler could not attach the ticket"
+
+# --- 4. Verify the shipped artifact ----------------------------------------
+info "verifying Gatekeeper assessment (spctl)..."
+spctl --assess --type execute -vv "$app" \
+  || fail "Gatekeeper rejected the stapled bundle (spctl --assess)"
+
+info "verifying signature (codesign --verify --deep --strict)..."
+codesign --verify --deep --strict --verbose=2 "$app" \
+  || fail "codesign deep/strict verification failed"
+
+info "validating stapled ticket (stapler validate)..."
+xcrun stapler validate "$app" || fail "stapled ticket did not validate"
+
+info "effective entitlements on the signed bundle:"
+codesign --display --entitlements - --xml "$app" 2>/dev/null || true
+
+info "PASS: signed, notarized, stapled, and verified: $app"


### PR DESCRIPTION
## Summary

Prepares a complete, **owner-run** code-signing kit for the `operations-floater`
macOS prototype and resolves the sandbox-vs-Input-Monitoring conflict in its
entitlements. Nothing is executed here — the owner runs it with their Apple
credentials. **Public-safe:** no credentials, team IDs, Apple IDs, or owner
specifics; every such value is supplied at run time.

## The conflict resolved

The Relative XY recorder calls `CGRequestListenEventAccess()` to observe another
application's mouse/scroll/key-code stream (**Input Monitoring**), and the app
also uses the microphone + Speech Recognition. The committed entitlements
declared `com.apple.security.app-sandbox`, but the App Sandbox structurally
**blocks cross-process Input Monitoring** — the two are mutually exclusive.

**Recommendation (implemented): Developer ID (direct) + Hardened Runtime,
WITHOUT the App Sandbox.** This keeps Input Monitoring, the microphone, and
Speech Recognition all working. The alternative — stay sandboxed by dropping the
recorder's Input Monitoring — is documented as the tradeoff. (Keeping Input
Monitoring also means the app cannot ship on the Mac App Store, which requires
the sandbox.)

## Deliverables

- **`scripts/sign-and-notarize.sh`** — parameterized (`--identity` /
  `DEVELOPER_ID_APP`, `--notary-profile` / `NOTARY_PROFILE`, nothing hardcoded):
  `codesign --options runtime` + entitlements + secure timestamp →
  `xcrun notarytool submit --wait` → `xcrun stapler staple` → verify
  (`spctl --assess`, `codesign --verify --deep --strict`, `stapler validate`).
- **`OperationsFloater.entitlements`** — corrected to the minimal set (Hardened
  Runtime microphone exception only; sandbox + sandbox-only keys removed).
- **`project.yml`** — `ENABLE_APP_SANDBOX: NO`, Hardened Runtime stays on.
- **`docs/SIGNING.md`** — the sandbox-vs-Input-Monitoring analysis, the
  sandboxed-alternative tradeoff, corrected entitlements rationale, and the
  OWNER checklist (obtain Developer ID Application cert → create notary profile
  via ASC API key or app-specific password → build on a disposable account →
  run the script → grant TCC for mic / Speech Recognition / Input Monitoring on
  first launch).
- **`README.md` / `CHANGELOG.md`** — updated to the non-sandboxed Developer ID
  posture.

## Verification

- `swift build` passes on this branch.
- `bash -n` clean on the script; `--help` and precondition guards exercised.
- Public-safety grep: no credentials / PII / owner specifics; only generic
  placeholders (`Example Owner`, `TEAMID1234`, `com.example.*`).

## The one thing the owner must do first

Obtain a **Developer ID Application** certificate in the login keychain (Xcode →
Settings → Accounts → Manage Certificates, or the Apple Developer portal).
Everything else in the script depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)