### PR TITLE
feat(operations-floater): Screen Trainer — visual EHR-layout trainer (slice 1)

### DIFF
--- a/prototypes/operations-floater/README.md
+++ b/prototypes/operations-floater/README.md
@@ -162,6 +162,16 @@ snapshot remains schema version `1.0`.
   The selected-window input panel separately echoes the latest mouse, scroll,
   and key-code events with elapsed time and relative coordinates. Printable
   character strings are not reconstructed and replay remains disabled.
+- The **Screen Trainer** overlay draws the local vision model's read of an
+  EHR-like screen as labeled, normalized boxes in a transparent, always-on-top,
+  click-through window, and lets the clinician correct it — click to confirm,
+  relabel, or drag a box, or type a free-text note. A live "what I'm learning"
+  panel narrates each correction and states what it now believes. Pointer and
+  typed input feed one PHI-free on-device store (the same
+  signature+label memory `watchful_memory.py` uses); a voice modality is
+  architected for the next slice. Development and tests use synthetic frames
+  only; no real screen is ever captured or read, and nothing leaves the device.
+  See [docs/SCREEN_TRAINER.md](docs/SCREEN_TRAINER.md).
 - Voice conversation is separately explicit and default-off. Production speech
   recognition requires an on-device provider and fails closed when permission,
   provider metadata, or on-device support is unavailable. Start, pause, resume,
@@ -224,6 +234,16 @@ and writes a PNG without opening or foregrounding a dashboard window:
 
 ```bash
 swift run OperationsFloater --render-companion-preview /tmp/ember-gallery.png
+```
+
+Render the Screen Trainer review still over a synthetic (PHI-free) EHR frame.
+This also rasterizes offscreen without opening a window:
+
+```bash
+swift run OperationsFloater \
+  --render-trainer-demo /tmp/screen-trainer-demo.png \
+  --trainer-demo-frame /tmp/synthetic-frame.png \
+  --trainer-demo-label results-review
 ```
 
 Routine validation stops at SwiftPM and synthetic fixture tests on the active

--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -123,6 +123,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             launchConfiguration.usesRecorderNormalizerFixture
     )
 
+    private lazy var screenTrainerController = ScreenTrainerOverlayWindowController(
+        session: ScreenTrainerSession(
+            readout: SyntheticScreenTrainerModel.readout(for: .resultsReview),
+            store: ScreenTrainerCorrectionStore.defaultStore()
+        )
+    )
+
     private override init() {
         let launchConfiguration = DashboardLaunchConfiguration()
         self.launchConfiguration = launchConfiguration
@@ -151,6 +158,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApplication.shared.terminate(nil)
             return
         }
+        if let trainerDemoPath = ScreenTrainerDemoRenderer.requestedOutputPath() {
+            NSApplication.shared.setActivationPolicy(.accessory)
+            _ = ScreenTrainerDemoRenderer.render(
+                to: trainerDemoPath,
+                framePath: ScreenTrainerDemoRenderer.requestedFramePath(),
+                label: ScreenTrainerDemoRenderer.requestedLabel()
+            )
+            NSApplication.shared.terminate(nil)
+            return
+        }
         guard claimSingleInstance() else { return }
         configureMainMenu()
         showDashboard(nil)
@@ -166,6 +183,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func showDashboard(_ sender: Any?) {
         windowController.show(sender)
+    }
+
+    /// Opens the Screen Trainer overlay: a transparent, always-on-top window that
+    /// draws the local model's candidate EHR regions for visual correction. It is
+    /// seeded with a synthetic readout; real capture is a separate runtime step
+    /// that only ever feeds the local model.
+    @objc private func showScreenTrainer(_ sender: Any?) {
+        screenTrainerController.show()
     }
 
     @objc private func closeDashboard(_ sender: Any?) {
@@ -280,6 +305,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: "0"
         )
         showItem.target = self
+
+        let trainerItem = applicationMenu.addItem(
+            withTitle: "Screen Trainer Overlay",
+            action: #selector(showScreenTrainer(_:)),
+            keyEquivalent: "t"
+        )
+        trainerItem.target = self
         applicationMenu.addItem(.separator())
 
         let importItem = applicationMenu.addItem(

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainer.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainer.swift
@@ -1,0 +1,623 @@
+import CoreGraphics
+import Foundation
+
+// MARK: - Screen Trainer model (content-free by construction)
+//
+// The Screen Trainer is the visual face of the local "watch me work" learning
+// loop. A local vision model (qwen2.5vl over localhost Ollama) reads a screen's
+// GEOMETRY and returns candidate regions marking where it thinks the EHR
+// elements / workflow areas sit. The overlay draws those boxes; the clinician
+// corrects them (confirm / relabel / drag); each correction is appended to the
+// same PHI-free signature+label memory the Python `watchful_memory.py` loop uses.
+//
+// PHI BOUNDARY (absolute): nothing in this file is or can become PHI. Regions
+// are normalized rectangles (0...1) plus a structure-only element tag and a
+// workflow tag — never pixels, never screen text, never a patient value, never
+// an absolute screen position. Real frames are seen only by the local model at
+// runtime on the clinician's machine and deleted after inference; they never
+// enter this process's model or persistence. The synthetic model below drives
+// every demo and test so no real capture is ever required to exercise the loop.
+
+/// The macro-layout signature the local vision model assigns to a screen. This
+/// one clean, content-free token — never the verbose read — is the learning
+/// substrate the memory embeds. Mirrors `watchful_train.py` `LAYOUT_TAGS`.
+enum ScreenLayoutSignature: String, Codable, CaseIterable, Sendable {
+    case stackedForm = "stacked-form"
+    case fullWidthGrid = "full-width-grid"
+    case leftListRightDetail = "left-list-right-detail"
+    case twoParallelColumns = "two-parallel-columns"
+
+    var displayName: String {
+        rawValue.replacingOccurrences(of: "-", with: " ")
+    }
+}
+
+/// The clinical workflow step a screen depicts — the closed vocabulary the
+/// clinician confirms or relabels. Mirrors `synthetic_ehr.py` `LABELS`. A tag is
+/// a workflow name, never patient content, so it is never PHI.
+enum WorkflowTag: String, Codable, CaseIterable, Sendable {
+    case orderEntry = "order-entry"
+    case resultsReview = "results-review"
+    case problemList = "problem-list"
+    case medReconciliation = "med-reconciliation"
+
+    var displayName: String {
+        rawValue.replacingOccurrences(of: "-", with: " ")
+    }
+
+    /// The macro layout each synthetic workflow presents. This is the same
+    /// mapping `synthetic_ehr.py` renders and `watchful_train.py` tags.
+    var defaultSignature: ScreenLayoutSignature {
+        switch self {
+        case .orderEntry: return .stackedForm
+        case .resultsReview: return .fullWidthGrid
+        case .problemList: return .leftListRightDetail
+        case .medReconciliation: return .twoParallelColumns
+        }
+    }
+}
+
+/// The kind of UI element a detected region marks. Structure only — the label
+/// describes what a region *is* (a grid, a button), never what it *contains*.
+enum ScreenElementKind: String, Codable, CaseIterable, Sendable {
+    case titleBar = "title-bar"
+    case sectionHeader = "section-header"
+    case dataGrid = "data-grid"
+    case inputFieldStack = "input-field-stack"
+    case listColumn = "list-column"
+    case detailCard = "detail-card"
+    case comparisonColumn = "comparison-column"
+    case primaryButton = "primary-button"
+
+    var displayName: String {
+        rawValue.replacingOccurrences(of: "-", with: " ")
+    }
+
+    /// A stable ordering used to cycle the element tag during a relabel.
+    static var cycle: [ScreenElementKind] { allCases }
+
+    /// The next tag when the clinician relabels an element region.
+    var next: ScreenElementKind {
+        let all = Self.cycle
+        let index = all.firstIndex(of: self) ?? 0
+        return all[(index + 1) % all.count]
+    }
+}
+
+/// A rectangle normalized to the captured window: origin at the top-left,
+/// each axis in `0...1`. Carries no pixels and no absolute screen coordinate, so
+/// it cannot localize a real screen or leak PHI. Values are always clamped.
+struct NormalizedRect: Equatable, Codable, Sendable {
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+
+    init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = NormalizedRect.clampOrigin(x)
+        self.y = NormalizedRect.clampOrigin(y)
+        self.width = NormalizedRect.clampExtent(width, origin: self.x)
+        self.height = NormalizedRect.clampExtent(height, origin: self.y)
+    }
+
+    private static func clampOrigin(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(1, max(0, value))
+    }
+
+    private static func clampExtent(_ value: Double, origin: Double) -> Double {
+        guard value.isFinite, value > 0 else { return 0 }
+        return min(1 - origin, value)
+    }
+
+    var maxX: Double { x + width }
+    var maxY: Double { y + height }
+
+    func contains(_ point: CGPoint) -> Bool {
+        Double(point.x) >= x && Double(point.x) <= maxX
+            && Double(point.y) >= y && Double(point.y) <= maxY
+    }
+
+    /// The pixel rectangle this normalized rect maps to inside a view of `size`.
+    func cgRect(in size: CGSize) -> CGRect {
+        CGRect(
+            x: x * Double(size.width),
+            y: y * Double(size.height),
+            width: width * Double(size.width),
+            height: height * Double(size.height)
+        )
+    }
+}
+
+/// One candidate region the model believes marks an EHR element / workflow area.
+struct ScreenRegion: Identifiable, Equatable, Codable, Sendable {
+    let id: String
+    var element: ScreenElementKind
+    var normalizedRect: NormalizedRect
+    /// The model's confidence in this region, `0...1`.
+    var confidence: Double
+    /// True once the clinician has confirmed or relabeled this region.
+    var corrected: Bool
+
+    init(
+        id: String,
+        element: ScreenElementKind,
+        normalizedRect: NormalizedRect,
+        confidence: Double,
+        corrected: Bool = false
+    ) {
+        self.id = id
+        self.element = element
+        self.normalizedRect = normalizedRect
+        self.confidence = min(1, max(0, confidence))
+        self.corrected = corrected
+    }
+}
+
+/// The local vision model's full read of one frame: window dimensions, the macro
+/// layout signature, a best-guess workflow, and the element regions. Everything
+/// is content-free structure — the payload the overlay draws and the clinician
+/// corrects.
+struct ScreenReadout: Equatable, Codable, Sendable {
+    var windowWidth: Int
+    var windowHeight: Int
+    var signature: ScreenLayoutSignature
+    var workflow: WorkflowTag
+    var regions: [ScreenRegion]
+
+    /// The aspect ratio of the captured window, used to size the overlay canvas.
+    var aspectRatio: CGFloat {
+        guard windowHeight > 0 else { return 16.0 / 10.0 }
+        return CGFloat(windowWidth) / CGFloat(windowHeight)
+    }
+}
+
+// MARK: - Synthetic vision model (offline demo + tests)
+
+/// Produces a deterministic, content-free readout for a synthetic EHR frame with
+/// a KNOWN layout. This stands in for the local vision model so the whole loop —
+/// overlay draw, correct, persist — can be exercised in the demo and unit tests
+/// without any screen capture, any network, and any risk of PHI. The live model
+/// is `OllamaScreenReader`; this returns the same `ScreenReadout` shape it will.
+///
+/// The region rectangles mirror the geometry `synthetic_ehr.py` draws, so the
+/// boxes land on the fake panels in the demo frame.
+enum SyntheticScreenTrainerModel {
+    static func readout(
+        for label: WorkflowTag,
+        windowWidth: Int = 1_100,
+        windowHeight: Int = 760
+    ) -> ScreenReadout {
+        ScreenReadout(
+            windowWidth: windowWidth,
+            windowHeight: windowHeight,
+            signature: label.defaultSignature,
+            workflow: label,
+            regions: regions(for: label)
+        )
+    }
+
+    private static func region(
+        _ suffix: String,
+        _ element: ScreenElementKind,
+        _ x: Double,
+        _ y: Double,
+        _ width: Double,
+        _ height: Double,
+        _ confidence: Double
+    ) -> ScreenRegion {
+        ScreenRegion(
+            id: "region-\(suffix)",
+            element: element,
+            normalizedRect: NormalizedRect(x: x, y: y, width: width, height: height),
+            confidence: confidence
+        )
+    }
+
+    private static func titleBar(_ confidence: Double = 0.88) -> ScreenRegion {
+        region("title-bar", .titleBar, 0.0, 0.0, 1.0, 0.053, confidence)
+    }
+
+    private static func regions(for label: WorkflowTag) -> [ScreenRegion] {
+        switch label {
+        case .resultsReview:
+            return [
+                titleBar(),
+                region("grid-header", .sectionHeader, 0.022, 0.068, 0.956, 0.047, 0.83),
+                region("grid-body", .dataGrid, 0.022, 0.115, 0.956, 0.86, 0.94),
+            ]
+        case .orderEntry:
+            return [
+                titleBar(),
+                region("form-header", .sectionHeader, 0.022, 0.068, 0.956, 0.045, 0.8),
+                region("field-stack", .inputFieldStack, 0.022, 0.15, 0.956, 0.7, 0.9),
+                region("submit", .primaryButton, 0.778, 0.905, 0.2, 0.06, 0.86),
+            ]
+        case .problemList:
+            return [
+                titleBar(),
+                region("list", .listColumn, 0.022, 0.068, 0.247, 0.906, 0.9),
+                region("detail", .detailCard, 0.29, 0.068, 0.688, 0.906, 0.88),
+                region("detail-title", .sectionHeader, 0.31, 0.095, 0.62, 0.052, 0.72),
+            ]
+        case .medReconciliation:
+            return [
+                titleBar(),
+                region("home-meds", .comparisonColumn, 0.022, 0.068, 0.458, 0.906, 0.9),
+                region("hospital-meds", .comparisonColumn, 0.52, 0.068, 0.458, 0.906, 0.9),
+            ]
+        }
+    }
+}
+
+// MARK: - On-device learning loop (ported from watchful_memory.py)
+
+/// One PHI-free exemplar: a workflow label and its embedding. Mirrors the record
+/// `watchful_memory.py` embeds and classifies. The embedding is produced locally
+/// (nomic-embed-text over localhost) from the content-free layout signature.
+struct LabeledEmbedding: Equatable, Sendable {
+    let label: String
+    let embedding: [Double]
+}
+
+/// Nearest-class-centroid classification over the clinician's accumulated
+/// corrections — a genuine, incremental, on-device few-shot memory that starts
+/// empty and improves as corrections accrue. This is a faithful Swift port of the
+/// same algorithm in `watchful_memory.py`, so the native overlay and the Python
+/// readout share one learning loop.
+enum ScreenTrainerMemory {
+    static func cosine(_ a: [Double], _ b: [Double]) -> Double {
+        guard a.count == b.count else { return 0 }
+        return zip(a, b).reduce(0) { $0 + $1.0 * $1.1 }
+    }
+
+    /// L2-normalize a vector; a zero vector is returned unchanged.
+    static func normalize(_ v: [Double]) -> [Double] {
+        let norm = (v.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        guard norm > 0 else { return v }
+        return v.map { $0 / norm }
+    }
+
+    /// Mean (L2-normalized) embedding per label.
+    static func centroids(_ exemplars: [LabeledEmbedding]) -> [String: [Double]] {
+        var buckets: [String: [[Double]]] = [:]
+        for exemplar in exemplars {
+            buckets[exemplar.label, default: []].append(exemplar.embedding)
+        }
+        var result: [String: [Double]] = [:]
+        for (label, vectors) in buckets {
+            guard let width = vectors.first?.count, width > 0 else { continue }
+            var mean = [Double](repeating: 0, count: width)
+            for vector in vectors where vector.count == width {
+                for index in 0..<width { mean[index] += vector[index] }
+            }
+            let count = Double(vectors.count)
+            mean = mean.map { $0 / count }
+            result[label] = normalize(mean)
+        }
+        return result
+    }
+
+    /// Nearest centroid for `vec`, with confidence mapped from cosine `[-1,1]`
+    /// into `[0,1]`. Returns `(nil, 0)` when the memory is empty.
+    static func classify(
+        _ centroids: [String: [Double]],
+        _ vec: [Double]
+    ) -> (label: String?, confidence: Double) {
+        guard !centroids.isEmpty else { return (nil, 0) }
+        var best: (label: String, score: Double)?
+        for (label, centroid) in centroids {
+            let score = cosine(vec, centroid)
+            if best == nil || score > best!.score {
+                best = (label, score)
+            }
+        }
+        guard let best else { return (nil, 0) }
+        return (best.label, (best.score + 1.0) / 2.0)
+    }
+
+    /// Leave-one-out nearest-centroid accuracy over the clinician's OWN
+    /// corrections — "does my teaching predict my next correction?". Only items
+    /// whose class has at least two examples are scored.
+    static func leaveOneOutAccuracy(
+        _ exemplars: [LabeledEmbedding]
+    ) -> (correct: Int, scored: Int, note: String) {
+        var counts: [String: Int] = [:]
+        for exemplar in exemplars { counts[exemplar.label, default: 0] += 1 }
+        let scorable = exemplars.indices.filter { counts[exemplars[$0].label, default: 0] >= 2 }
+        guard scorable.count >= 2 else {
+            return (0, 0, "need >=2 corrections in >=2 workflow tags to score")
+        }
+        var correct = 0
+        for index in scorable {
+            let rest = exemplars.enumerated()
+                .filter { $0.offset != index }
+                .map { $0.element }
+            let (predicted, _) = classify(centroids(rest), exemplars[index].embedding)
+            if predicted == exemplars[index].label { correct += 1 }
+        }
+        return (correct, scorable.count, "scored \(scorable.count)/\(exemplars.count) corrections")
+    }
+}
+
+// MARK: - Correction modality (one loop, many inputs)
+
+/// How a correction reached the loop. Pointer (click/drag) and typed free-text
+/// feedback are built in slice 1; `voice` is ARCHITECTED here so the next layer
+/// (mic -> local speech-to-text -> the same funnel) plugs in without touching the
+/// store, the memory, or the overlay. Every modality feeds the ONE PHI-free
+/// on-device store below.
+enum CorrectionModality: String, Codable, CaseIterable, Sendable {
+    case pointer
+    case typed
+    case voice
+
+    var displayName: String {
+        switch self {
+        case .pointer: return "pointer"
+        case .typed: return "typed"
+        case .voice: return "voice"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .pointer: return "hand.point.up.left.fill"
+        case .typed: return "keyboard.fill"
+        case .voice: return "mic.fill"
+        }
+    }
+}
+
+// MARK: - Learning ledger ("what I'm learning")
+
+/// One human-readable line for the live "what I'm learning" panel. Produced when
+/// the clinician corrects something, regardless of modality, so pointer, typed,
+/// and (later) voice all narrate through the same feed.
+struct LearningEvent: Identifiable, Equatable, Sendable {
+    let id: String
+    let modality: CorrectionModality
+    /// The short headline, e.g. "grid-body: data-grid → list-column".
+    let summary: String
+    /// Optional extra context, e.g. the clinician's typed note.
+    let detail: String?
+    /// A short, preformatted timestamp for display.
+    let timeText: String
+}
+
+/// Derives the "what it now believes" summary from accumulated corrections. Pure
+/// so the panel text is testable without any UI or network.
+enum ScreenTrainerLedger {
+    /// How many times the clinician has reinforced a given workflow label.
+    static func reinforcementCount(
+        _ corrections: [ScreenTrainerCorrection],
+        label: String
+    ) -> Int {
+        corrections.lazy.filter { $0.label == label }.count
+    }
+
+    /// A one-line current belief for a readout given corrections so far.
+    static func belief(
+        for readout: ScreenReadout,
+        corrections: [ScreenTrainerCorrection]
+    ) -> String {
+        let count = reinforcementCount(corrections, label: readout.workflow.rawValue)
+        let base = "This screen → \(readout.workflow.displayName) "
+            + "(\(readout.signature.displayName))"
+        switch count {
+        case 0: return base + " · not yet reinforced"
+        case 1: return base + " · reinforced 1×"
+        default: return base + " · reinforced \(count)×"
+        }
+    }
+}
+
+// MARK: - Correction store (PHI-free, JSONL — shared with watchful_memory.py)
+
+/// One persisted correction. This is a superset of the
+/// `{ts,label,signature,embedding}` shape `watchful_memory.py` writes, one JSON
+/// object per line, so the native overlay and the Python loop append to the same
+/// on-device store (the Python reader ignores the extra keys). It records only a
+/// layout signature token, a workflow tag, an optional local embedding, the input
+/// modality, and — only when the clinician types one — his own free-text teaching
+/// note.
+///
+/// PHI boundary: nothing here is extracted from the EHR screen. The signature and
+/// tags are content-free geometry; the `note` is the clinician's OWN annotation,
+/// authored by him, kept on-device only, and never embedded or transmitted. No
+/// frame, no pixels, no screen text. Never PHI.
+struct ScreenTrainerCorrection: Equatable, Codable, Sendable {
+    let ts: String
+    /// The workflow tag the clinician confirmed or corrected to.
+    let label: String
+    /// The content-free macro-layout signature token.
+    let signature: String
+    /// Local embedding of the signature. Empty until the local embed model
+    /// (nomic-embed-text over localhost) backfills it; the geometry loop attaches
+    /// it exactly as `watchful_memory.add_exemplar` does.
+    let embedding: [Double]
+    /// Which input produced this correction (pointer / typed / voice).
+    let modality: String?
+    /// The clinician's own free-text teaching note, when he typed one. On-device
+    /// only; never embedded, never sent.
+    let note: String?
+
+    init(
+        ts: String,
+        label: String,
+        signature: String,
+        embedding: [Double] = [],
+        modality: CorrectionModality? = nil,
+        note: String? = nil
+    ) {
+        self.ts = ts
+        self.label = label
+        self.signature = signature
+        self.embedding = embedding
+        self.modality = modality?.rawValue
+        let trimmed = note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.note = (trimmed?.isEmpty ?? true) ? nil : trimmed
+    }
+}
+
+/// Append-only JSONL persistence for corrections. Load tolerates blank and
+/// corrupt lines exactly like `watchful_memory.load_memory`.
+final class ScreenTrainerCorrectionStore {
+    private let fileURL: URL
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// The default on-device store path, git-ignored and never transmitted.
+    static func defaultStore(source: String = "citrix-ehr") -> ScreenTrainerCorrectionStore {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let safe = source.map { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" ? $0 : "-" }
+        let dir = base
+            .appendingPathComponent("OperationsFloater", isDirectory: true)
+            .appendingPathComponent("screen-trainer-memory", isDirectory: true)
+        return ScreenTrainerCorrectionStore(
+            fileURL: dir.appendingPathComponent("\(String(safe)).jsonl")
+        )
+    }
+
+    @discardableResult
+    func append(_ correction: ScreenTrainerCorrection) throws -> ScreenTrainerCorrection {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        var line = try encoder.encode(correction)
+        line.append(0x0A)  // newline
+
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            let handle = try FileHandle(forWritingTo: fileURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: line)
+        } else {
+            try line.write(to: fileURL, options: [.atomic])
+        }
+        return correction
+    }
+
+    func load() -> [ScreenTrainerCorrection] {
+        guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        return text.split(separator: "\n").compactMap { rawLine in
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+            return try? decoder.decode(ScreenTrainerCorrection.self, from: data)
+        }
+    }
+}
+
+// MARK: - Live vision path (wired, not productionized)
+
+/// The seams the live path uses to turn a frame into a `ScreenReadout` from the
+/// local qwen2.5vl model. The actual capture + network call runs ONLY on the
+/// clinician's machine at runtime (frame -> `http://localhost:11434` only, then
+/// deleted); these pure request/parse functions make the wiring reviewable and
+/// testable without ever capturing or loading a real frame. No frame ever
+/// reaches this process here — the synthetic model drives demo and tests.
+enum OllamaScreenReader {
+    static let endpoint = URL(string: "http://localhost:11434/api/generate")!
+    static let visionModel = "qwen2.5vl:7b"
+
+    /// A structure-only region prompt in the same spirit as the geometry prompt
+    /// in `watchful_train.py`: describe WHERE elements sit, never WHAT they say.
+    static let regionPrompt = """
+        You are a screen-LAYOUT analyst calibrating a clinical workflow assistant.
+        Return ONLY compact JSON describing the geometry of this EHR screen:
+        {"signature": one of \
+        ["stacked-form","full-width-grid","left-list-right-detail","two-parallel-columns"], \
+        "workflow": one of \
+        ["order-entry","results-review","problem-list","med-reconciliation"], \
+        "regions": [{"element": one of \
+        ["title-bar","section-header","data-grid","input-field-stack","list-column",\
+        "detail-card","comparison-column","primary-button"], \
+        "x": 0..1, "y": 0..1, "w": 0..1, "h": 0..1, "confidence": 0..1}]}
+        Coordinates are normalized to the window, origin top-left.
+        HARD RULES: describe STRUCTURE and PURPOSE only. Do NOT transcribe or read
+        any text. Do NOT report any patient name, MRN, number, date, dose, lab
+        value, or any content. No PHI. Output JSON only.
+        """
+
+    /// The localhost request body. `base64Frame` is produced and consumed only on
+    /// the clinician's machine at runtime; it is never persisted or transmitted
+    /// off-device.
+    static func requestBody(base64Frame: String, prompt: String = regionPrompt) -> Data {
+        let payload: [String: Any] = [
+            "model": visionModel,
+            "prompt": prompt,
+            "images": [base64Frame],
+            "stream": false,
+            "options": ["temperature": 0.1, "num_predict": 512],
+        ]
+        return (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
+    }
+
+    /// The model reply shape (Ollama wraps the model text in `response`).
+    private struct Envelope: Decodable { let response: String }
+    private struct RawRegion: Decodable {
+        let element: String
+        let x: Double
+        let y: Double
+        let w: Double
+        let h: Double
+        let confidence: Double?
+    }
+    private struct RawReadout: Decodable {
+        let signature: String
+        let workflow: String
+        let regions: [RawRegion]
+    }
+
+    /// Parse the model's JSON reply into a clamped `ScreenReadout`. Unknown
+    /// element/signature/workflow tokens fail closed (dropped or defaulted) so a
+    /// malformed reply can never inject an out-of-vocabulary label.
+    static func parseReadout(
+        from responseData: Data,
+        windowWidth: Int,
+        windowHeight: Int
+    ) -> ScreenReadout? {
+        let decoder = JSONDecoder()
+        let jsonText: String
+        if let envelope = try? decoder.decode(Envelope.self, from: responseData) {
+            jsonText = envelope.response
+        } else if let text = String(data: responseData, encoding: .utf8) {
+            jsonText = text
+        } else {
+            return nil
+        }
+        guard let start = jsonText.firstIndex(of: "{"),
+              let end = jsonText.lastIndex(of: "}"),
+              let raw = try? decoder.decode(
+                  RawReadout.self,
+                  from: Data(jsonText[start...end].utf8)
+              ),
+              let signature = ScreenLayoutSignature(rawValue: raw.signature),
+              let workflow = WorkflowTag(rawValue: raw.workflow) else {
+            return nil
+        }
+        let regions: [ScreenRegion] = raw.regions.enumerated().compactMap { index, item in
+            guard let element = ScreenElementKind(rawValue: item.element) else { return nil }
+            return ScreenRegion(
+                id: "region-\(index)",
+                element: element,
+                normalizedRect: NormalizedRect(x: item.x, y: item.y, width: item.w, height: item.h),
+                confidence: item.confidence ?? 0.5
+            )
+        }
+        return ScreenReadout(
+            windowWidth: windowWidth,
+            windowHeight: windowHeight,
+            signature: signature,
+            workflow: workflow,
+            regions: regions
+        )
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
@@ -1,0 +1,862 @@
+import AppKit
+import Combine
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+// MARK: - Element accents
+
+extension ScreenElementKind {
+    /// A stable accent per element kind, used for the overlay stroke and legend.
+    var accent: Color {
+        switch self {
+        case .titleBar: return .gray
+        case .sectionHeader: return .teal
+        case .dataGrid: return .blue
+        case .inputFieldStack: return .green
+        case .listColumn: return .purple
+        case .detailCard: return .indigo
+        case .comparisonColumn: return .orange
+        case .primaryButton: return .pink
+        }
+    }
+}
+
+// MARK: - Session (interaction state + correction persistence)
+
+/// Drives one Screen Trainer overlay: the model's readout, the selected region,
+/// and the corrections the clinician makes. Every correction is appended to the
+/// PHI-free on-device store — the same signature+label memory the Python loop
+/// uses. No screen capture, no network, and no PHI live here.
+@MainActor
+final class ScreenTrainerSession: ObservableObject {
+    @Published private(set) var readout: ScreenReadout
+    @Published var selectedRegionID: String?
+    @Published private(set) var corrections: [ScreenTrainerCorrection]
+    /// The live "what I'm learning" feed — one line per correction, any modality.
+    @Published private(set) var learningEvents: [LearningEvent]
+    /// The free-text feedback the clinician is typing. Submitting it records a
+    /// typed correction into the same on-device store.
+    @Published var typedFeedback: String = ""
+    @Published var clickThrough: Bool
+
+    private let store: ScreenTrainerCorrectionStore?
+    private let clock: () -> Date
+    private var eventOrdinal = 0
+
+    init(
+        readout: ScreenReadout,
+        store: ScreenTrainerCorrectionStore? = nil,
+        clickThrough: Bool = false,
+        clock: @escaping () -> Date = Date.init
+    ) {
+        self.readout = readout
+        self.store = store
+        self.clickThrough = clickThrough
+        self.clock = clock
+        corrections = store?.load() ?? []
+        learningEvents = []
+    }
+
+    /// The one-line current belief for the "what I'm learning" panel.
+    var currentBelief: String {
+        ScreenTrainerLedger.belief(for: readout, corrections: corrections)
+    }
+
+    var selectedRegion: ScreenRegion? {
+        readout.regions.first { $0.id == selectedRegionID }
+    }
+
+    func select(_ id: String?) {
+        selectedRegionID = id
+    }
+
+    /// Select whichever region contains a normalized point (topmost / smallest
+    /// wins so an inner region stays reachable), or clear when none matches.
+    func selectRegion(at point: CGPoint) {
+        let hit = readout.regions
+            .filter { $0.normalizedRect.contains(point) }
+            .min { areaOf($0.normalizedRect) < areaOf($1.normalizedRect) }
+        selectedRegionID = hit?.id
+    }
+
+    /// Cycle the selected region's element tag, mark it corrected, and narrate the
+    /// change in the "what I'm learning" feed (pointer modality).
+    func relabelSelectedElement() {
+        guard let region = selectedRegion else { return }
+        let from = region.element
+        let to = from.next
+        mutateSelected { $0.element = to; $0.corrected = true }
+        commit(
+            modality: .pointer,
+            summary: "\(region.id.replacingOccurrences(of: "region-", with: "")): "
+                + "\(from.displayName) → \(to.displayName)",
+            note: nil,
+            persist: true
+        )
+    }
+
+    /// Confirm the selected region as-is (marks it corrected) and reinforce the
+    /// current workflow in the on-device memory (pointer modality).
+    func confirmSelected() {
+        guard let region = selectedRegion else { return }
+        mutateSelected { $0.corrected = true }
+        commit(
+            modality: .pointer,
+            summary: "confirmed \(region.element.displayName) · "
+                + "\(readout.workflow.displayName) reinforced",
+            note: nil,
+            persist: true
+        )
+    }
+
+    /// Set the workflow tag the clinician believes this screen depicts, then
+    /// record the correction (pointer modality).
+    func setWorkflow(_ tag: WorkflowTag) {
+        let from = readout.workflow
+        readout.workflow = tag
+        commit(
+            modality: .pointer,
+            summary: from == tag
+                ? "\(tag.displayName) reinforced"
+                : "workflow: \(from.displayName) → \(tag.displayName)",
+            note: nil,
+            persist: true
+        )
+    }
+
+    /// Replace the selected region's rectangle (drag-resize) and mark it
+    /// corrected. The rect is clamped to the window by `NormalizedRect`. Geometry
+    /// nudges are not persisted to the memory (which learns the workflow, not the
+    /// pixels); they surface in the feed as an adjustment.
+    func resizeSelected(to rect: NormalizedRect) {
+        guard let region = selectedRegion else { return }
+        mutateSelected { $0.normalizedRect = rect; $0.corrected = true }
+        commit(
+            modality: .pointer,
+            summary: "adjusted \(region.element.displayName) box",
+            note: nil,
+            persist: false
+        )
+    }
+
+    /// Nudge one corner of the selected region to a normalized point.
+    func dragCorner(_ corner: RegionCorner, to point: CGPoint) {
+        guard let rect = selectedRegion?.normalizedRect else { return }
+        resizeSelected(to: corner.applying(point, to: rect))
+    }
+
+    /// Submit the typed free-text feedback: capture it alongside a workflow
+    /// correction in the SAME on-device store, narrate it in the feed, and clear
+    /// the field. This is the typed modality of the one learning loop.
+    func submitTypedFeedback() {
+        let trimmed = typedFeedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        commit(
+            modality: .typed,
+            summary: "note on \(readout.workflow.displayName)",
+            note: trimmed,
+            persist: true
+        )
+        typedFeedback = ""
+    }
+
+    /// ARCHITECTED SEAM (not built in slice 1). The voice layer — mic -> local
+    /// speech-to-text -> here — routes through this single method, so it teaches
+    /// the exact same store and feed as pointer and typed input. Voice is added
+    /// in the next slice; this keeps the plug-in point explicit and tested.
+    func applyVoiceCorrection(
+        workflow: WorkflowTag?,
+        transcript: String
+    ) {
+        if let workflow { readout.workflow = workflow }
+        commit(
+            modality: .voice,
+            summary: workflow.map { "voice: \($0.displayName)" } ?? "voice note",
+            note: transcript,
+            persist: true
+        )
+    }
+
+    /// The single funnel every modality routes through: append a learning-feed
+    /// event and, when the correction teaches the memory, persist a PHI-free
+    /// exemplar to the on-device store.
+    @discardableResult
+    private func commit(
+        modality: CorrectionModality,
+        summary: String,
+        note: String?,
+        persist: Bool
+    ) -> ScreenTrainerCorrection? {
+        let now = clock()
+        eventOrdinal += 1
+        learningEvents.append(
+            LearningEvent(
+                id: "learn-\(eventOrdinal)",
+                modality: modality,
+                summary: summary,
+                detail: note,
+                timeText: Self.timeFormatter.string(from: now)
+            )
+        )
+        guard persist else { return nil }
+        let correction = ScreenTrainerCorrection(
+            ts: ISO8601DateFormatter().string(from: now),
+            label: readout.workflow.rawValue,
+            signature: readout.signature.rawValue,
+            modality: modality,
+            note: note
+        )
+        _ = try? store?.append(correction)
+        corrections.append(correction)
+        return correction
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    /// Leave-one-out recall over the corrections taught so far, once embeddings
+    /// exist. Surfaces "is it learning from me?" without any network here.
+    func recallAccuracy() -> (correct: Int, scored: Int, note: String) {
+        let exemplars = corrections
+            .filter { !$0.embedding.isEmpty }
+            .map { LabeledEmbedding(label: $0.label, embedding: $0.embedding) }
+        return ScreenTrainerMemory.leaveOneOutAccuracy(exemplars)
+    }
+
+    private func mutateSelected(_ transform: (inout ScreenRegion) -> Void) {
+        guard let id = selectedRegionID,
+              let index = readout.regions.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        transform(&readout.regions[index])
+    }
+
+    private func areaOf(_ rect: NormalizedRect) -> Double {
+        rect.width * rect.height
+    }
+}
+
+/// ARCHITECTED, not built in slice 1. The voice layer will conform to something
+/// like this: capture mic audio, transcribe with an on-device recognizer (no
+/// cloud), and route each recognized correction into
+/// `ScreenTrainerSession.applyVoiceCorrection`. It teaches the same PHI-free store
+/// and the same "what I'm learning" feed as pointer and typed input — one loop,
+/// three modalities. No audio, transcript, or frame ever leaves the device, and
+/// listening stays default-off and explicit, matching the app's voice posture.
+@MainActor
+protocol ScreenTrainerVoiceIntake {
+    var isListening: Bool { get }
+    func startListening()
+    func stopListening()
+}
+
+/// Which corner of a region a drag handle adjusts.
+enum RegionCorner: CaseIterable, Sendable {
+    case topLeading, topTrailing, bottomLeading, bottomTrailing
+
+    /// Return a new rect with `corner` moved to `point`, keeping the opposite
+    /// corner fixed. `NormalizedRect` clamps the result into the window.
+    func applying(_ point: CGPoint, to rect: NormalizedRect) -> NormalizedRect {
+        let px = Double(point.x)
+        let py = Double(point.y)
+        let left: Double
+        let top: Double
+        let right: Double
+        let bottom: Double
+        switch self {
+        case .topLeading:
+            left = min(px, rect.maxX); top = min(py, rect.maxY)
+            right = rect.maxX; bottom = rect.maxY
+        case .topTrailing:
+            left = rect.x; top = min(py, rect.maxY)
+            right = max(px, rect.x); bottom = rect.maxY
+        case .bottomLeading:
+            left = min(px, rect.maxX); top = rect.y
+            right = rect.maxX; bottom = max(py, rect.y)
+        case .bottomTrailing:
+            left = rect.x; top = rect.y
+            right = max(px, rect.x); bottom = max(py, rect.y)
+        }
+        return NormalizedRect(x: left, y: top, width: right - left, height: bottom - top)
+    }
+
+    func point(in rect: NormalizedRect) -> CGPoint {
+        switch self {
+        case .topLeading: return CGPoint(x: rect.x, y: rect.y)
+        case .topTrailing: return CGPoint(x: rect.maxX, y: rect.y)
+        case .bottomLeading: return CGPoint(x: rect.x, y: rect.maxY)
+        case .bottomTrailing: return CGPoint(x: rect.maxX, y: rect.maxY)
+        }
+    }
+}
+
+// MARK: - Regions layer (the z-index overlay)
+
+/// Draws the model's candidate regions as labeled boxes over the target area.
+/// Reused by the live overlay window and the headless demo renderer.
+struct ScreenTrainerRegionsLayer: View {
+    let readout: ScreenReadout
+    let selectedRegionID: String?
+    var showHandles: Bool = true
+
+    var body: some View {
+        GeometryReader { geometry in
+            let size = geometry.size
+            ZStack(alignment: .topLeading) {
+                ForEach(readout.regions) { region in
+                    regionBox(region, in: size)
+                }
+            }
+            .frame(width: size.width, height: size.height)
+        }
+    }
+
+    @ViewBuilder
+    private func regionBox(_ region: ScreenRegion, in size: CGSize) -> some View {
+        let rect = region.normalizedRect.cgRect(in: size)
+        let isSelected = region.id == selectedRegionID
+        let accent = region.element.accent
+
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 3)
+                .strokeBorder(
+                    accent,
+                    style: StrokeStyle(
+                        lineWidth: isSelected ? 3 : 1.6,
+                        dash: region.corrected ? [] : [6, 3]
+                    )
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(accent.opacity(isSelected ? 0.14 : 0.06))
+                )
+                .frame(width: rect.width, height: rect.height)
+
+            regionTag(region, accent: accent)
+                .offset(y: -1)
+
+            if isSelected && showHandles {
+                ForEach(Array(RegionCorner.allCases.enumerated()), id: \.offset) { _, corner in
+                    let p = corner.point(in: region.normalizedRect)
+                    Rectangle()
+                        .fill(accent)
+                        .frame(width: 9, height: 9)
+                        .overlay(Rectangle().stroke(.white, lineWidth: 1.5))
+                        .position(
+                            x: (p.x - region.normalizedRect.x) * rect.width,
+                            y: (p.y - region.normalizedRect.y) * rect.height
+                        )
+                }
+            }
+        }
+        .frame(width: rect.width, height: rect.height, alignment: .topLeading)
+        .offset(x: rect.minX, y: rect.minY)
+    }
+
+    private func regionTag(_ region: ScreenRegion, accent: Color) -> some View {
+        HStack(spacing: 4) {
+            Text(region.element.displayName)
+                .font(.system(size: 9, weight: .bold))
+            Text("\(Int(region.confidence * 100))%")
+                .font(.system(size: 8, weight: .semibold).monospacedDigit())
+                .opacity(0.85)
+            if region.corrected {
+                Image(systemName: "checkmark.seal.fill").font(.system(size: 8))
+            }
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(accent, in: RoundedRectangle(cornerRadius: 3))
+        .fixedSize()
+    }
+}
+
+// MARK: - Live overlay view
+
+/// The interactive overlay: a workflow banner, the regions layer, and a compact
+/// correction bar. In the live window it sits transparent and always-on-top over
+/// the EHR; here it is a pure SwiftUI view so it also renders headlessly.
+struct ScreenTrainerOverlayView: View {
+    @ObservedObject var session: ScreenTrainerSession
+
+    var body: some View {
+        VStack(spacing: 0) {
+            banner
+            GeometryReader { geometry in
+                ScreenTrainerRegionsLayer(
+                    readout: session.readout,
+                    selectedRegionID: session.selectedRegionID
+                )
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0).onEnded { value in
+                        let point = CGPoint(
+                            x: value.location.x / geometry.size.width,
+                            y: value.location.y / geometry.size.height
+                        )
+                        session.selectRegion(at: point)
+                    }
+                )
+            }
+            correctionBar
+            LearningPanel(session: session)
+        }
+    }
+
+    private var banner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "rectangle.dashed.badge.record")
+            Text("Screen Trainer")
+                .font(.system(size: 11, weight: .bold))
+            Text("workflow: \(session.readout.workflow.displayName)")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.yellow)
+            Text("· layout: \(session.readout.signature.displayName)")
+                .font(.system(size: 10))
+                .foregroundStyle(.white.opacity(0.7))
+            Spacer()
+            Toggle("Click-through", isOn: $session.clickThrough)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .font(.system(size: 9))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.72))
+    }
+
+    @ViewBuilder
+    private var correctionBar: some View {
+        HStack(spacing: 8) {
+            if let region = session.selectedRegion {
+                Text("Selected: \(region.element.displayName)")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.white)
+                Button("Relabel") { session.relabelSelectedElement() }
+                    .controlSize(.mini)
+                Button("Confirm") { session.confirmSelected() }
+                    .controlSize(.mini)
+                Text("drag a corner handle to adjust the box")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white.opacity(0.6))
+            } else {
+                Text("Click a box to confirm, relabel, or resize it.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+            Spacer()
+            Text("\(session.corrections.count) corrections taught")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.6))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.72))
+    }
+}
+
+// MARK: - "What I'm learning" panel
+
+/// The live learning feed: what it now believes, the recent corrections narrated
+/// as they happen (any modality), and a typed free-text field that teaches the
+/// same on-device store. Shared by the live overlay and the demo render.
+struct LearningPanel: View {
+    @ObservedObject var session: ScreenTrainerSession
+    /// Live overlay uses the real text field; the headless demo renders a static
+    /// placeholder (SwiftUI `TextField` does not rasterize cleanly offscreen).
+    var interactive: Bool = true
+
+    private static let feedbackPlaceholder =
+        "Type feedback, e.g. \"the grid is the results panel\""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "brain.head.profile").font(.system(size: 10))
+                Text("WHAT I'M LEARNING")
+                    .font(.system(size: 9, weight: .bold))
+                Spacer()
+                Text("\(session.corrections.count) taught")
+                    .font(.system(size: 9).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .foregroundStyle(.white)
+
+            Text(session.currentBelief)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.yellow)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                if session.learningEvents.isEmpty {
+                    Text("Correct a box, pick a workflow, or type a note — I'll show what changed here.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.55))
+                } else {
+                    ForEach(session.learningEvents.suffix(4).reversed()) { event in
+                        eventRow(event)
+                    }
+                }
+            }
+
+            HStack(spacing: 6) {
+                Image(systemName: "keyboard").font(.system(size: 10))
+                if interactive {
+                    TextField(Self.feedbackPlaceholder, text: $session.typedFeedback)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 10))
+                        .onSubmit { session.submitTypedFeedback() }
+                    Button("Teach") { session.submitTypedFeedback() }
+                        .controlSize(.mini)
+                        .disabled(session.typedFeedback.trimmingCharacters(in: .whitespaces).isEmpty)
+                } else {
+                    Text(Self.feedbackPlaceholder)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(.white.opacity(0.08))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 5)
+                                        .stroke(.white.opacity(0.25), lineWidth: 1)
+                                )
+                        )
+                    Text("Teach")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.5))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+                }
+            }
+
+            HStack(spacing: 5) {
+                Image(systemName: "mic.slash").font(.system(size: 9))
+                Text("Voice teaching arrives next — mic → on-device speech → this same feed.")
+                    .font(.system(size: 9))
+            }
+            .foregroundStyle(.white.opacity(0.45))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.black.opacity(0.78))
+    }
+
+    private func eventRow(_ event: LearningEvent) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: event.modality.symbolName)
+                .font(.system(size: 9))
+                .foregroundStyle(.cyan)
+                .frame(width: 14)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(event.summary)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.white)
+                if let detail = event.detail {
+                    Text("“\(detail)”")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.7))
+                        .lineLimit(2)
+                }
+            }
+            Spacer(minLength: 4)
+            Text(event.timeText)
+                .font(.system(size: 8).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.45))
+        }
+    }
+}
+
+// MARK: - Overlay window (transparent, always-on-top, click-through toggle)
+
+/// Hosts the overlay in a borderless, transparent, floating window that can join
+/// all Spaces and be made click-through so the clinician keeps working in the EHR
+/// beneath it. It never captures pixels; it only *draws over* the screen. Real
+/// capture, when wired, happens out-of-band and feeds only the local model.
+@MainActor
+final class ScreenTrainerOverlayWindowController {
+    private var window: NSWindow?
+    private let session: ScreenTrainerSession
+
+    init(session: ScreenTrainerSession) {
+        self.session = session
+    }
+
+    @discardableResult
+    func show() -> NSWindow {
+        let window = self.window ?? makeWindow()
+        window.orderFrontRegardless()
+        applyClickThrough(session.clickThrough)
+        return window
+    }
+
+    func close() {
+        window?.orderOut(nil)
+    }
+
+    func setClickThrough(_ enabled: Bool) {
+        session.clickThrough = enabled
+        applyClickThrough(enabled)
+    }
+
+    private func applyClickThrough(_ enabled: Bool) {
+        window?.ignoresMouseEvents = enabled
+    }
+
+    private func makeWindow() -> NSWindow {
+        let size = NSSize(width: 720, height: 620)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.level = .floating
+        window.isMovableByWindowBackground = true
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(
+            rootView: ScreenTrainerOverlayView(session: session)
+        )
+        window.center()
+        self.window = window
+        return window
+    }
+}
+
+// MARK: - Headless demo renderer
+
+/// Renders a still demo of the Screen Trainer over a synthetic EHR frame to a
+/// PNG, without opening or foregrounding any window — so the concept can be
+/// reviewed as an image. Mirrors `CompanionPreviewRenderer`. Only synthetic
+/// frames are ever used; no real capture and no PHI are involved.
+enum ScreenTrainerDemoRenderer {
+    static let argument = "--render-trainer-demo"
+    static let frameArgument = "--trainer-demo-frame"
+    static let labelArgument = "--trainer-demo-label"
+
+    static func requestedOutputPath(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> String? {
+        value(for: argument, in: arguments)
+    }
+
+    static func requestedFramePath(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> String? {
+        value(for: frameArgument, in: arguments)
+    }
+
+    static func requestedLabel(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> WorkflowTag {
+        value(for: labelArgument, in: arguments)
+            .flatMap(WorkflowTag.init(rawValue:)) ?? .resultsReview
+    }
+
+    private static func value(for flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    @MainActor
+    static func render(
+        to path: String,
+        framePath: String?,
+        label: WorkflowTag,
+        scale: CGFloat = 2
+    ) -> Bool {
+        let session = ScreenTrainerSession(
+            readout: SyntheticScreenTrainerModel.readout(for: label),
+            clock: { Date(timeIntervalSince1970: 1_753_900_000) }
+        )
+        // Simulate a short teaching burst so the demo shows real corrections and
+        // a populated "what I'm learning" feed, not just first-pass detection.
+        if let primary = session.readout.regions.first(where: {
+            $0.element == .dataGrid || $0.element == .inputFieldStack
+                || $0.element == .listColumn || $0.element == .comparisonColumn
+        }) {
+            session.select(primary.id)
+            session.confirmSelected()  // pointer: reinforce this workflow
+        }
+        session.typedFeedback = "the big grid is the results panel"
+        session.submitTypedFeedback()  // typed: same store, with a note
+        // Re-select the primary region so the demo shows the selected box with
+        // its drag handles and correction chip.
+        if let primary = session.readout.regions.first(where: {
+            $0.element == .dataGrid || $0.element == .inputFieldStack
+                || $0.element == .listColumn || $0.element == .comparisonColumn
+        }) {
+            session.select(primary.id)
+        }
+        let content = ScreenTrainerDemoView(session: session, framePath: framePath)
+            .frame(width: 1_180, height: 760)
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = scale
+        guard let cgImage = renderer.cgImage else { return false }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let data = rep.representation(using: .png, properties: [:]) else { return false }
+        do {
+            try data.write(to: URL(fileURLWithPath: path))
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+/// The composited demo: caption, the synthetic EHR frame with the overlay drawn
+/// on top beside the live "what I'm learning" panel, and a legend explaining the
+/// correction loop and PHI boundary.
+struct ScreenTrainerDemoView: View {
+    @ObservedObject var session: ScreenTrainerSession
+    let framePath: String?
+
+    private static let frameSize = CGSize(width: 760, height: 520)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            caption
+            HStack(alignment: .top, spacing: 12) {
+                frameWithOverlay
+                LearningPanel(session: session, interactive: false)
+                    .frame(width: 360)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .padding(.horizontal, 14)
+            legend
+        }
+        .background(Color(red: 0.09, green: 0.10, blue: 0.12))
+    }
+
+    private var caption: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Screen Trainer — the local model's read, drawn on your screen")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(.white)
+            Text(
+                "The local vision model marks where it thinks the EHR elements sit. "
+                    + "You confirm, relabel, or drag a box — or type a note — and the "
+                    + "\"what I'm learning\" panel narrates what changed and what it now "
+                    + "believes. Every modality teaches one on-device memory. No frame or "
+                    + "text ever leaves the machine."
+            )
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.75))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+    }
+
+    private var frameWithOverlay: some View {
+        ZStack(alignment: .topLeading) {
+            frameBackground
+            ScreenTrainerRegionsLayer(
+                readout: session.readout,
+                selectedRegionID: session.selectedRegionID
+            )
+            relabelChip
+        }
+        .frame(width: Self.frameSize.width, height: Self.frameSize.height)
+        .clipped()
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(.white.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var frameBackground: some View {
+        if let framePath, let image = NSImage(contentsOfFile: framePath) {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: Self.frameSize.width, height: Self.frameSize.height)
+        } else {
+            // Self-contained fallback so the render never fails when a synthetic
+            // frame file is absent. Still content-free — plain panels only.
+            Rectangle()
+                .fill(Color(red: 0.96, green: 0.96, blue: 0.97))
+                .frame(width: Self.frameSize.width, height: Self.frameSize.height)
+                .overlay(alignment: .top) {
+                    Rectangle().fill(Color(red: 0.11, green: 0.2, blue: 0.37))
+                        .frame(height: 28)
+                }
+        }
+    }
+
+    /// A floating chip that shows the correction affordance on the selected box.
+    @ViewBuilder
+    private var relabelChip: some View {
+        if let region = session.selectedRegion {
+            let rect = region.normalizedRect.cgRect(in: Self.frameSize)
+            HStack(spacing: 6) {
+                Image(systemName: "hand.tap.fill").font(.system(size: 9))
+                Text("Confirm").font(.system(size: 10, weight: .bold))
+                Text("· Relabel").font(.system(size: 10))
+                Text("· Drag corners").font(.system(size: 10))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.black.opacity(0.82), in: Capsule())
+            .offset(
+                x: min(rect.midX - 60, Self.frameSize.width - 190),
+                y: max(6, rect.minY + 18)
+            )
+        }
+    }
+
+    private var legend: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("ELEMENT TAGS DETECTED")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.6))
+                ForEach(distinctElements, id: \.self) { element in
+                    HStack(spacing: 6) {
+                        Rectangle().fill(element.accent).frame(width: 11, height: 11)
+                        Text(element.displayName)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.white.opacity(0.85))
+                    }
+                }
+            }
+            Spacer()
+            VStack(alignment: .leading, spacing: 4) {
+                Text("PHI BOUNDARY")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.6))
+                Label("Synthetic frame — no real EHR", systemImage: "checkmark.shield.fill")
+                Label("Boxes are normalized geometry, not pixels", systemImage: "square.dashed")
+                Label("Corrections store a tag only, on-device", systemImage: "internaldrive.fill")
+            }
+            .font(.system(size: 10))
+            .foregroundStyle(.green.opacity(0.85))
+        }
+        .padding(14)
+    }
+
+    private var distinctElements: [ScreenElementKind] {
+        var seen: [ScreenElementKind] = []
+        for region in session.readout.regions where !seen.contains(region.element) {
+            seen.append(region.element)
+        }
+        return seen
+    }
+}

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/GuidePresentationTests.swift
@@ -170,7 +170,7 @@ struct GuidePresentationTests {
         #expect(minimumMetrics.estimatedCardWidth(containerWidth: 380) == 352)
     }
 
-    @Test("Application entitlements allow only explicit audio input, selected files, and outbound networking")
+    @Test("Application entitlements request only the Hardened Runtime audio-input exception")
     func entitlementsRemainLocalOnly() throws {
         let data = try Data(
             contentsOf: packageRoot().appendingPathComponent("OperationsFloater.entitlements")
@@ -182,14 +182,17 @@ struct GuidePresentationTests {
         )
         let entitlements = try #require(value as? [String: Any])
 
-        #expect(entitlements.count == 4)
-        #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
-        #expect(
-            entitlements["com.apple.security.files.user-selected.read-write"] as? Bool == true
-        )
-        #expect(entitlements["com.apple.security.network.client"] as? Bool == true)
-        #expect(entitlements["com.apple.security.network.server"] == nil)
+        // Developer ID (direct) + Hardened Runtime, NOT sandboxed: the Relative XY
+        // recorder needs cross-process Input Monitoring, which the App Sandbox
+        // blocks. So the only entitlement is the microphone resource-access
+        // exception; the former sandbox-only keys are intentionally absent. See
+        // OperationsFloater.entitlements and docs/SIGNING.md.
+        #expect(entitlements.count == 1)
         #expect(entitlements["com.apple.security.device.audio-input"] as? Bool == true)
+        #expect(entitlements["com.apple.security.app-sandbox"] == nil)
+        #expect(entitlements["com.apple.security.files.user-selected.read-write"] == nil)
+        #expect(entitlements["com.apple.security.network.client"] == nil)
+        #expect(entitlements["com.apple.security.network.server"] == nil)
         #expect(entitlements["com.apple.security.device.camera"] == nil)
     }
 

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerTests.swift
@@ -1,0 +1,382 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Screen Trainer model and learning loop")
+struct ScreenTrainerModelTests {
+    @Test("Synthetic readout is deterministic, in-bounds, and matches the layout")
+    func syntheticReadoutIsWellFormed() {
+        for label in WorkflowTag.allCases {
+            let readout = SyntheticScreenTrainerModel.readout(for: label)
+            #expect(readout.workflow == label)
+            #expect(readout.signature == label.defaultSignature)
+            #expect(!readout.regions.isEmpty)
+            #expect(readout.regions.contains { $0.element == .titleBar })
+            for region in readout.regions {
+                let rect = region.normalizedRect
+                #expect(rect.x >= 0 && rect.y >= 0)
+                #expect(rect.maxX <= 1.0 + 1e-9)
+                #expect(rect.maxY <= 1.0 + 1e-9)
+                #expect(rect.width > 0 && rect.height > 0)
+                #expect(region.confidence >= 0 && region.confidence <= 1)
+            }
+            // Deterministic across calls.
+            #expect(SyntheticScreenTrainerModel.readout(for: label) == readout)
+        }
+    }
+
+    @Test("NormalizedRect clamps out-of-range input and maps to pixels")
+    func normalizedRectClampsAndMaps() {
+        let rect = NormalizedRect(x: -0.5, y: 0.8, width: 5, height: 5)
+        #expect(rect.x == 0)
+        #expect(rect.y == 0.8)
+        #expect(rect.maxX <= 1.0 + 1e-9)
+        #expect(rect.maxY <= 1.0 + 1e-9)
+
+        let mid = NormalizedRect(x: 0.25, y: 0.5, width: 0.5, height: 0.25)
+        let mapped = mid.cgRect(in: CGSize(width: 400, height: 200))
+        #expect(mapped.origin.x == 100)
+        #expect(mapped.origin.y == 100)
+        #expect(mapped.width == 200)
+        #expect(mapped.height == 50)
+        #expect(mid.contains(CGPoint(x: 0.5, y: 0.6)))
+        #expect(!mid.contains(CGPoint(x: 0.9, y: 0.6)))
+    }
+
+    @Test("Element relabel cycles through the closed vocabulary")
+    func elementRelabelCycles() {
+        var element = ScreenElementKind.titleBar
+        var seen: Set<ScreenElementKind> = [element]
+        for _ in 0..<ScreenElementKind.allCases.count {
+            element = element.next
+            seen.insert(element)
+        }
+        #expect(seen.count == ScreenElementKind.allCases.count)
+        #expect(element == .titleBar)  // wraps around
+    }
+}
+
+@Suite("Screen Trainer nearest-centroid memory")
+struct ScreenTrainerMemoryTests {
+    private func exemplar(_ label: String, _ vector: [Double]) -> LabeledEmbedding {
+        LabeledEmbedding(label: label, embedding: ScreenTrainerMemory.normalize(vector))
+    }
+
+    @Test("Cosine of a normalized vector with itself is one")
+    func cosineIdentity() {
+        let v = ScreenTrainerMemory.normalize([0.3, 0.9, 0.1, 0.4])
+        #expect(abs(ScreenTrainerMemory.cosine(v, v) - 1.0) < 1e-9)
+    }
+
+    @Test("Classify picks the nearest class centroid with a 0...1 confidence")
+    func classifyPicksNearest() {
+        let memory = [
+            exemplar("order-entry", [1, 0, 0, 0]),
+            exemplar("order-entry", [0.98, 0.05, 0, 0]),
+            exemplar("results-review", [0, 1, 0, 0]),
+            exemplar("results-review", [0.02, 0.99, 0, 0]),
+        ]
+        let centroids = ScreenTrainerMemory.centroids(memory)
+        let probe = ScreenTrainerMemory.normalize([0.1, 0.95, 0, 0])
+        let (label, confidence) = ScreenTrainerMemory.classify(centroids, probe)
+        #expect(label == "results-review")
+        #expect(confidence > 0.9 && confidence <= 1.0)
+
+        let (emptyLabel, emptyConfidence) = ScreenTrainerMemory.classify([:], probe)
+        #expect(emptyLabel == nil)
+        #expect(emptyConfidence == 0)
+    }
+
+    @Test("Leave-one-out recall is perfect on separable corrections")
+    func leaveOneOutSeparable() {
+        let memory = [
+            exemplar("a", [1, 0, 0, 0]),
+            exemplar("a", [0.97, 0.1, 0, 0]),
+            exemplar("b", [0, 1, 0, 0]),
+            exemplar("b", [0.05, 0.98, 0, 0]),
+        ]
+        let (correct, scored, _) = ScreenTrainerMemory.leaveOneOutAccuracy(memory)
+        #expect(scored == 4)
+        #expect(correct == 4)
+    }
+
+    @Test("Leave-one-out declines to score too-small memories")
+    func leaveOneOutNeedsCoverage() {
+        let memory = [exemplar("a", [1, 0, 0, 0])]
+        let (correct, scored, note) = ScreenTrainerMemory.leaveOneOutAccuracy(memory)
+        #expect(correct == 0)
+        #expect(scored == 0)
+        #expect(note.contains(">=2"))
+    }
+}
+
+@Suite("Screen Trainer correction store (PHI-free JSONL)")
+struct ScreenTrainerCorrectionStoreTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("screen-trainer-\(UUID().uuidString).jsonl")
+    }
+
+    @Test("Corrections round-trip and share the watchful_memory line shape")
+    func roundTripsAndMatchesShape() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ScreenTrainerCorrectionStore(fileURL: url)
+
+        try store.append(
+            ScreenTrainerCorrection(
+                ts: "2026-07-30T12:00:00Z",
+                label: "results-review",
+                signature: "full-width-grid"
+            )
+        )
+        try store.append(
+            ScreenTrainerCorrection(
+                ts: "2026-07-30T12:01:00Z",
+                label: "order-entry",
+                signature: "stacked-form",
+                embedding: [0.1, 0.2, 0.3]
+            )
+        )
+
+        let loaded = store.load()
+        #expect(loaded.count == 2)
+        #expect(loaded[0].label == "results-review")
+        #expect(loaded[1].embedding == [0.1, 0.2, 0.3])
+
+        // The persisted line carries only PHI-free keys — the same shape the
+        // Python watchful_memory store reads.
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(text.contains("\"label\""))
+        #expect(text.contains("\"signature\""))
+        #expect(text.contains("\"ts\""))
+        #expect(text.contains("\"embedding\""))
+        let lowered = text.lowercased()
+        for banned in ["pixel", "screenshot", "frame", "patient", "mrn", "\"text\""] {
+            #expect(!lowered.contains(banned))
+        }
+    }
+
+    @Test("Load tolerates blank and corrupt lines")
+    func loadTolerant() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let good = "{\"embedding\":[],\"label\":\"a\",\"signature\":\"s\",\"ts\":\"t\"}"
+        try "\n\(good)\n{not json}\n\n".write(to: url, atomically: true, encoding: .utf8)
+        let store = ScreenTrainerCorrectionStore(fileURL: url)
+        #expect(store.load().count == 1)
+    }
+}
+
+@Suite("Screen Trainer session interaction")
+struct ScreenTrainerSessionTests {
+    @MainActor
+    private func session() -> (ScreenTrainerSession, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("session-\(UUID().uuidString).jsonl")
+        return (
+            ScreenTrainerSession(
+                readout: SyntheticScreenTrainerModel.readout(for: .resultsReview),
+                store: ScreenTrainerCorrectionStore(fileURL: url)
+            ),
+            url
+        )
+    }
+
+    @Test("Selecting a point picks the smallest containing region")
+    @MainActor
+    func selectionPicksSmallest() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        // The header band sits inside the grid's horizontal span but is smaller.
+        session.selectRegion(at: CGPoint(x: 0.5, y: 0.09))
+        #expect(session.selectedRegion?.element == .sectionHeader)
+        session.selectRegion(at: CGPoint(x: 0.99, y: 0.99))
+        #expect(session.selectedRegionID == nil || session.selectedRegion != nil)
+    }
+
+    @Test("Relabel marks the region corrected and advances the tag")
+    @MainActor
+    func relabelMutates() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let grid = session.readout.regions.first { $0.element == .dataGrid }!
+        session.select(grid.id)
+        session.relabelSelectedElement()
+        #expect(session.selectedRegion?.corrected == true)
+        #expect(session.selectedRegion?.element == ScreenElementKind.dataGrid.next)
+    }
+
+    @Test("Confirming a region persists a PHI-free workflow correction")
+    @MainActor
+    func confirmPersists() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let grid = session.readout.regions.first { $0.element == .dataGrid }!
+        session.select(grid.id)
+        session.confirmSelected()
+        #expect(session.corrections.count == 1)
+        #expect(session.corrections.first?.label == "results-review")
+        #expect(session.corrections.first?.signature == "full-width-grid")
+        #expect(session.selectedRegion?.corrected == true)
+    }
+
+    @Test("Dragging a corner resizes the selected region within bounds")
+    @MainActor
+    func dragCornerResizes() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let grid = session.readout.regions.first { $0.element == .dataGrid }!
+        session.select(grid.id)
+        session.dragCorner(.bottomTrailing, to: CGPoint(x: 0.6, y: 0.6))
+        let rect = session.selectedRegion!.normalizedRect
+        #expect(abs(rect.maxX - 0.6) < 1e-9)
+        #expect(abs(rect.maxY - 0.6) < 1e-9)
+        #expect(session.selectedRegion?.corrected == true)
+    }
+
+    @Test("Every correction narrates one learning-feed event")
+    @MainActor
+    func correctionsNarrate() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(session.learningEvents.isEmpty)
+        let grid = session.readout.regions.first { $0.element == .dataGrid }!
+        session.select(grid.id)
+        session.relabelSelectedElement()
+        session.confirmSelected()
+        #expect(session.learningEvents.count == 2)
+        #expect(session.learningEvents.allSatisfy { $0.modality == .pointer })
+        // The most recent event is last; it reflects the confirm.
+        #expect(session.learningEvents.last?.summary.contains("reinforced") == true)
+    }
+
+    @Test("Typed feedback teaches the same store with a note and clears the field")
+    @MainActor
+    func typedFeedbackPersists() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        session.typedFeedback = "  the big grid is the results panel  "
+        session.submitTypedFeedback()
+        #expect(session.typedFeedback.isEmpty)
+        #expect(session.corrections.count == 1)
+        let correction = session.corrections[0]
+        #expect(correction.modality == CorrectionModality.typed.rawValue)
+        #expect(correction.note == "the big grid is the results panel")
+        #expect(correction.label == "results-review")
+        #expect(session.learningEvents.last?.modality == .typed)
+        #expect(session.learningEvents.last?.detail == "the big grid is the results panel")
+
+        // Empty feedback is a no-op.
+        session.typedFeedback = "   "
+        session.submitTypedFeedback()
+        #expect(session.corrections.count == 1)
+    }
+
+    @Test("The architected voice seam routes through the one funnel")
+    @MainActor
+    func voiceSeamRoutesThroughFunnel() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        session.applyVoiceCorrection(
+            workflow: .orderEntry,
+            transcript: "this is the order entry screen"
+        )
+        #expect(session.readout.workflow == .orderEntry)
+        #expect(session.corrections.count == 1)
+        #expect(session.corrections[0].modality == CorrectionModality.voice.rawValue)
+        #expect(session.corrections[0].label == "order-entry")
+        #expect(session.corrections[0].note == "this is the order entry screen")
+        #expect(session.learningEvents.last?.modality == .voice)
+    }
+
+    @Test("Belief line reflects accumulated reinforcement")
+    @MainActor
+    func beliefReflectsReinforcement() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(session.currentBelief.contains("not yet reinforced"))
+        let grid = session.readout.regions.first { $0.element == .dataGrid }!
+        session.select(grid.id)
+        session.confirmSelected()
+        session.confirmSelected()
+        #expect(session.currentBelief.contains("reinforced 2×"))
+        #expect(session.currentBelief.contains("results review"))
+    }
+}
+
+@Suite("Screen Trainer learning ledger")
+struct ScreenTrainerLedgerTests {
+    @Test("Reinforcement count tallies corrections per workflow label")
+    func reinforcementCount() {
+        let corrections = [
+            ScreenTrainerCorrection(ts: "t", label: "results-review", signature: "full-width-grid"),
+            ScreenTrainerCorrection(ts: "t", label: "results-review", signature: "full-width-grid"),
+            ScreenTrainerCorrection(ts: "t", label: "order-entry", signature: "stacked-form"),
+        ]
+        #expect(ScreenTrainerLedger.reinforcementCount(corrections, label: "results-review") == 2)
+        #expect(ScreenTrainerLedger.reinforcementCount(corrections, label: "order-entry") == 1)
+        #expect(ScreenTrainerLedger.reinforcementCount(corrections, label: "problem-list") == 0)
+    }
+
+    @Test("Belief text names the workflow, layout, and reinforcement")
+    func beliefText() {
+        let readout = SyntheticScreenTrainerModel.readout(for: .medReconciliation)
+        let none = ScreenTrainerLedger.belief(for: readout, corrections: [])
+        #expect(none.contains("med reconciliation"))
+        #expect(none.contains("two parallel columns"))
+        #expect(none.contains("not yet reinforced"))
+
+        let taught = [
+            ScreenTrainerCorrection(ts: "t", label: "med-reconciliation", signature: "two-parallel-columns")
+        ]
+        #expect(ScreenTrainerLedger.belief(for: readout, corrections: taught).contains("reinforced 1×"))
+    }
+}
+
+@Suite("Screen Trainer live vision path wiring")
+struct OllamaScreenReaderTests {
+    @Test("Request body targets the local vision model with a no-PHI prompt")
+    func requestBodyIsLocalAndSafe() throws {
+        let data = OllamaScreenReader.requestBody(base64Frame: "QUJD")
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["model"] as? String == "qwen2.5vl:7b")
+        #expect((json["images"] as? [String])?.first == "QUJD")
+        #expect(json["stream"] as? Bool == false)
+        let prompt = try #require(json["prompt"] as? String)
+        #expect(prompt.contains("No PHI"))
+        #expect(OllamaScreenReader.endpoint.absoluteString.contains("localhost:11434"))
+    }
+
+    @Test("Parse clamps regions and rejects out-of-vocabulary tokens")
+    func parseClampsAndFailsClosed() throws {
+        let reply = """
+            {"response":"{\\"signature\\":\\"full-width-grid\\",\\"workflow\\":\\"results-review\\",\\"regions\\":[{\\"element\\":\\"data-grid\\",\\"x\\":0.1,\\"y\\":0.1,\\"w\\":2.0,\\"h\\":0.5,\\"confidence\\":0.9},{\\"element\\":\\"not-a-real-element\\",\\"x\\":0,\\"y\\":0,\\"w\\":1,\\"h\\":1}]}"}
+            """
+        let readout = try #require(
+            OllamaScreenReader.parseReadout(
+                from: Data(reply.utf8),
+                windowWidth: 1_000,
+                windowHeight: 800
+            )
+        )
+        #expect(readout.workflow == .resultsReview)
+        #expect(readout.signature == .fullWidthGrid)
+        // The unknown element is dropped; the valid one is clamped into bounds.
+        #expect(readout.regions.count == 1)
+        #expect(readout.regions[0].normalizedRect.maxX <= 1.0 + 1e-9)
+
+        // A reply with an out-of-vocabulary workflow fails closed.
+        let bad = "{\"response\":\"{\\\"signature\\\":\\\"x\\\",\\\"workflow\\\":\\\"y\\\",\\\"regions\\\":[]}\"}"
+        #expect(
+            OllamaScreenReader.parseReadout(
+                from: Data(bad.utf8),
+                windowWidth: 100,
+                windowHeight: 100
+            ) == nil
+        )
+    }
+}

--- a/prototypes/operations-floater/docs/SCREEN_TRAINER.md
+++ b/prototypes/operations-floater/docs/SCREEN_TRAINER.md
@@ -1,0 +1,103 @@
+# Screen Trainer (visual EHR-layout trainer)
+
+The Screen Trainer replaces the terminal `watchful_train.py` geometry read-out
+with an on-screen **overlay**: the local vision model's read is *drawn* on top of
+the screen as labeled boxes, and the clinician corrects it visually and by typing.
+Every correction feeds the same PHI-free, on-device learning loop.
+
+This is **slice 1** — a bounded first cut for owner review. It ships the overlay,
+pointer + typed correction, and the "what I'm learning" feed, and it *architects*
+(does not build) the voice layer.
+
+## PHI boundary (absolute)
+
+Nothing in this feature is, or can become, PHI.
+
+- **Development and tests use synthetic frames only** (`synthetic_ehr.py`). No real
+  Citrix/EHR screen is ever captured, read, or loaded during development.
+- At runtime on the clinician's machine, real capture (a separate, out-of-band
+  step) sends a frame **only** to the local model at `http://localhost:11434`,
+  then deletes it. No frame, pixel, or screen text ever leaves the device, and
+  none ever enters this app's model or persistence.
+- The overlay **draws over** the screen; it never captures pixels.
+- Regions are **normalized rectangles** (`0…1`) plus a structure-only element tag
+  — never pixels, never absolute screen coordinates, never screen text.
+- The correction store holds only a content-free layout **signature** + a workflow
+  **tag** (+ an optional local embedding, and the clinician's own typed note). The
+  note is authored by him, kept on-device, and never embedded or transmitted.
+
+## What slice 1 does
+
+1. **Overlay** — `ScreenTrainerOverlayWindowController` hosts the overlay in a
+   borderless, transparent, always-on-top `NSWindow` that can join all Spaces and
+   be toggled **click-through** (`ignoresMouseEvents`) so work continues in the
+   EHR beneath it. `ScreenTrainerRegionsLayer` draws each candidate region as a
+   labeled box (element tag + confidence), dashed until corrected, with corner
+   handles on the selected box.
+2. **Correct it visually** — click a box to select it; **Confirm** (reinforce),
+   **Relabel** (cycle the element tag), or **drag a corner** to adjust the box.
+3. **Correct it by typing** — a free-text field captures the clinician's own note
+   alongside the correction, into the **same** on-device store.
+4. **"What I'm learning" panel** — a live feed that narrates each correction as it
+   happens (any modality) and states what it now believes, e.g.
+   *"This screen → results-review (full-width-grid) · reinforced 2×"*.
+5. **The learning loop** — `ScreenTrainerMemory` is a faithful Swift port of
+   `watchful_memory.py` (nearest-class-centroid over local embeddings, with
+   leave-one-out recall), and `ScreenTrainerCorrectionStore` writes the same
+   `{ts,label,signature,embedding,…}` JSONL the Python loop reads. Native overlay
+   and Python read-out share one on-device memory.
+
+## Data path
+
+```
+frame (synthetic in dev; real only at runtime, local-only, then deleted)
+  → local vision model (qwen2.5vl @ localhost Ollama)         OllamaScreenReader
+  → candidate regions + workflow + layout signature           ScreenReadout
+  → overlay draws labeled boxes                               ScreenTrainerRegionsLayer
+  → clinician corrects: pointer / drag / typed note           ScreenTrainerSession
+  → one funnel: narrate + persist PHI-free exemplar           ScreenTrainerCorrectionStore
+  → nearest-centroid memory improves                          ScreenTrainerMemory  (== watchful_memory.py)
+```
+
+`OllamaScreenReader` is **wired, not productionized**: the request/parse seams are
+pure and tested, but the capture + network call runs only on the clinician's
+machine at runtime. The synthetic model (`SyntheticScreenTrainerModel`) drives the
+demo and every test, so the whole loop runs offline with no capture and no PHI.
+
+## One loop, many inputs (voice is architected, not built)
+
+Pointer, typed, and — next — voice all route through the single funnel
+`ScreenTrainerSession.commit(...)`. The voice seam is explicit:
+`ScreenTrainerSession.applyVoiceCorrection(workflow:transcript:)` and the
+`ScreenTrainerVoiceIntake` protocol. The next slice adds mic → **on-device**
+speech-to-text → `applyVoiceCorrection`, with the same "here's what I just learned"
+narration. No audio, transcript, or frame ever leaves the device; listening stays
+default-off and explicit, matching the app's existing voice posture.
+
+## Try it
+
+Open the overlay in the app: **Operations Floater ▸ Screen Trainer Overlay**
+(seeded with a synthetic read-out). Toggle **Click-through** to keep working
+beneath it.
+
+Render the review still (offscreen, no window shown) over a synthetic frame:
+
+```bash
+python3 /path/to/verbal-orders/tools/synthetic_ehr.py \
+  --one results-review --path /tmp/frame.png
+swift run OperationsFloater \
+  --render-trainer-demo /tmp/screen-trainer-demo.png \
+  --trainer-demo-frame /tmp/frame.png \
+  --trainer-demo-label results-review
+```
+
+## What's next (owner reviews slice 1 first)
+
+- **Voice** — the architected layer above.
+- **Live capture wiring** — connect the runtime capture step to `OllamaScreenReader`
+  on-device (kept out of this slice to hold the PHI boundary during development).
+- **Embedding backfill** — attach the local `nomic-embed-text` embedding on each
+  correction so `ScreenTrainerMemory` recall runs natively, exactly as the Python
+  loop does today.
+- **Per-region workflow inference** and richer element vocabulary as the owner
+  confirms the interaction feels right.


### PR DESCRIPTION
## What this is

Replaces the confusing terminal `watchful_train.py` geometry read-out with an
on-screen **overlay**: the local vision model's read is *drawn* on top of the
screen as labeled, normalized boxes, and the clinician corrects it **visually**
(click to confirm / relabel / drag a corner) and **by typing** a free-text note.
A live **"what I'm learning"** panel narrates each correction and states what it
now believes. Every modality feeds one PHI-free, on-device learning loop.

**This is a bounded slice 1 for owner review — not merged, review before expanding.**

## Slice 1 (built)

- Transparent, always-on-top, **click-through** `NSWindow` overlay drawing the
  model's candidate regions as labeled boxes (element tag + confidence), with
  corner handles on the selected box.
- **Correct visually** (confirm / relabel / drag) and **by typing** (free-text
  note captured alongside the correction) — both route through one funnel.
- **"What I'm learning" panel**: live feed narrating each correction + a current
  belief line (e.g. *results-review (full-width-grid) · reinforced 2×*).
- **Learning loop** ported from `watchful_memory.py` (nearest-class-centroid +
  leave-one-out), writing the same `{ts,label,signature,embedding,…}` JSONL —
  native overlay and the Python read-out share one on-device memory.
- **Live vision path wired, not productionized**: `OllamaScreenReader` has pure,
  tested request/parse seams for qwen2.5vl @ `localhost`. `SyntheticScreenTrainerModel`
  drives the demo and every test offline — no capture, no PHI.
- Menu entry **Screen Trainer Overlay** + a headless demo renderer
  (`--render-trainer-demo` over a `synthetic_ehr.py` frame).

## Architected (not built) — next slice

- **Voice**: `ScreenTrainerSession.applyVoiceCorrection(workflow:transcript:)` +
  the `ScreenTrainerVoiceIntake` protocol route through the same funnel, so
  mic → on-device speech-to-text plugs in without touching the store, memory, or
  overlay. Default-off, on-device, matching the app's voice posture.

## PHI boundary (absolute)

Development and tests use **synthetic frames only**. Real capture happens only at
runtime on the clinician's machine (frame → localhost model only, then deleted),
never in this process. Regions are normalized geometry + structure-only tags; the
store holds a content-free signature + workflow tag (+ the clinician's own
on-device note). Nothing leaves the machine. See
[`docs/SCREEN_TRAINER.md`](prototypes/operations-floater/docs/SCREEN_TRAINER.md).

## Incidental fix

The first commit aligns the `GuidePresentationTests` entitlements assertions with
the non-sandboxed entitlements the signing kit (#68) already committed — it was
red on `master`.

## Validation

- `swift build` clean
- `swift test` — 150 tests, 19 suites, all pass
- `bash Tests/permission-identity-preflight.test.sh` — PASS
- Demo still rendered over a synthetic `results-review` frame (attached in the
  task hand-off for owner QC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)