### PR TITLE
feat(operations-floater): one-click "Record a session" flow with window picker

### DIFF
--- a/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/OperationsFloaterApp.swift
@@ -5,6 +5,13 @@ import Darwin
 import SwiftUI
 import UniformTypeIdentifiers
 
+extension Notification.Name {
+    /// Posted by the "Record a Session" App-menu item / ⌘R so the dashboard's
+    /// one-click recorder card can start the flow from the AppKit menu bridge.
+    static let operationsFloaterStartRecording =
+        Notification.Name("com.example.operationsfloater.startRecording")
+}
+
 struct DashboardLaunchConfiguration: Equatable {
     static let backgroundUITestArgument = "--background-ui-test"
     static let syntheticConversationUITestArgument =
@@ -195,6 +202,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         windowController.show(sender)
     }
 
+    /// Bridges the App-menu / ⌘R entry point to the SwiftUI dashboard: shows the
+    /// window, then posts a notification the recorder card observes to kick off the
+    /// one-click "Record a session" flow (enable → select recorder → window picker).
+    @objc private func startRecordingSession(_ sender: Any?) {
+        showDashboard(sender)
+        NotificationCenter.default.post(
+            name: .operationsFloaterStartRecording,
+            object: nil
+        )
+    }
+
     /// Opens the Screen Trainer overlay: a transparent, always-on-top window that
     /// draws the local model's candidate EHR regions for visual correction. It is
     /// seeded with a synthetic readout; real capture is a separate runtime step
@@ -315,6 +333,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: "0"
         )
         showItem.target = self
+
+        let recordItem = applicationMenu.addItem(
+            withTitle: "Record a Session",
+            action: #selector(startRecordingSession(_:)),
+            keyEquivalent: "r"
+        )
+        recordItem.target = self
 
         let trainerItem = applicationMenu.addItem(
             withTitle: "Screen Trainer Overlay",
@@ -601,6 +626,7 @@ final class DashboardState: ObservableObject {
 private struct DashboardView: View {
     @StateObject private var state: DashboardState
     @StateObject private var chat: RouterChatSession
+    @StateObject private var voice = VoiceConversationSession()
     @StateObject private var companion = CompanionController()
     @State private var didPrepareConversationFixture = false
     @AppStorage("OperationsFloater.GuideCollapsedV1")
@@ -645,8 +671,15 @@ private struct DashboardView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: metrics.sectionSpacing) {
                         guideStrip(metrics: metrics)
+                        RecorderQuickStartCard(
+                            session: chat,
+                            voice: voice,
+                            metrics: metrics,
+                            assistantCollapsed: $assistantCollapsed
+                        )
                         RouterChatPanel(
                             session: chat,
+                            voice: voice,
                             metrics: metrics,
                             isCollapsed: $assistantCollapsed
                         )

--- a/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/RouterChat.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreGraphics
 import Foundation
 import SwiftUI
 
@@ -679,6 +680,11 @@ final class RouterChatSession: ObservableObject {
     @Published private(set) var critiques: [UUID: RouterChatCritique] = [:]
     @Published private(set) var reviewingMessageIDs: Set<UUID> = []
     @Published private(set) var recorderTrace = RecorderPipelineTrace.idle
+    /// Drives the one-click "Record a session" window picker. The floor is never
+    /// granted until a window is chosen here, which satisfies the recorder's
+    /// existing "choose a visible window first" guard and kills the old
+    /// chicken-and-egg where the picker was unreachable before the floor.
+    @Published var isChoosingRecordingWindow = false
 
     let modules: ConversationModuleHostSession
     let geometryCapture: NeutralGeometryCaptureSession
@@ -696,18 +702,31 @@ final class RouterChatSession: ObservableObject {
     private var moduleContextTurns: [ConversationModuleContextTurn] = []
     private var allowsRelativeXYTestFixture = false
     private var pendingVoiceMessageID: UUID?
+    // Screen Recording is not enforced by the recorder (Input Monitoring is), but
+    // window-owner names are richer with it, so the one-click flow offers to
+    // request it. Injectable so unit tests never touch the real TCC prompt.
+    private let screenRecordingPreflight: () -> Bool
+    private let screenRecordingRequest: () -> Bool
 
     init(
         transport: any RouterChatTransport = RouterChatClient(),
         recorderNormalizer: any RecorderNarrationNormalizing = RouterChatClient(),
         modules: ConversationModuleHostSession = ConversationModuleHostSession(),
         geometryCapture: NeutralGeometryCaptureSession =
-            NeutralGeometryCaptureSession()
+            NeutralGeometryCaptureSession(),
+        screenRecordingPreflight: @escaping () -> Bool = {
+            CGPreflightScreenCaptureAccess()
+        },
+        screenRecordingRequest: @escaping () -> Bool = {
+            CGRequestScreenCaptureAccess()
+        }
     ) {
         self.transport = transport
         self.recorderNormalizer = recorderNormalizer
         self.modules = modules
         self.geometryCapture = geometryCapture
+        self.screenRecordingPreflight = screenRecordingPreflight
+        self.screenRecordingRequest = screenRecordingRequest
         moduleObservation = modules.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
@@ -1174,6 +1193,73 @@ final class RouterChatSession: ObservableObject {
         }
     }
 
+    /// One-click entry point for "Record a session". Ensures the assistant is
+    /// enabled and the Relative XY recorder is selected, proactively requests the
+    /// permissions the recorder needs, refreshes the window list, and then presents
+    /// the window picker. Crucially, no floor is granted here — that happens only
+    /// after the user picks a window in ``chooseRecordingWindow(_:voice:)``, which
+    /// is exactly what the recorder's "choose a visible window first" guard
+    /// requires. This is what removes the old chicken-and-egg.
+    func beginOneClickRecording() async {
+        // A recording (or its paused state) is already live — surface it, don't
+        // restart or reopen the picker.
+        if geometryCapture.mode == .recording || geometryCapture.mode == .paused {
+            return
+        }
+        lastError = nil
+        if !isEnabled {
+            await enable()
+        }
+        // Clear any prior review/idle floor so the fresh grant in the activation
+        // transaction cannot collide with an already-granted floor.
+        if modules.activeFloor != nil {
+            await revokeModuleFloor()
+        }
+        if modules.selectedModuleID
+            != ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID {
+            selectConversationTarget(
+                ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+            )
+        }
+        requestRecordingPermissions()
+        isChoosingRecordingWindow = true
+    }
+
+    /// Re-requests the recorder's permissions and refreshes the window list. Wired
+    /// to the picker's "Request again" and "Refresh" affordances so a permission
+    /// denial never dead-ends: the user grants access, taps again, and continues.
+    func requestRecordingPermissions() {
+        if !geometryCapture.inputMonitoringAvailable {
+            geometryCapture.requestInputMonitoring()
+        }
+        if !screenRecordingPreflight() {
+            _ = screenRecordingRequest()
+        }
+        geometryCapture.refreshWindows()
+    }
+
+    /// Whether macOS Screen Recording is granted. Window enumeration works without
+    /// it; the picker uses this only to explain why owner names may be sparse.
+    var isScreenRecordingAvailable: Bool {
+        screenRecordingPreflight()
+    }
+
+    /// Completes the one-click flow: bind the chosen window, dismiss the picker, and
+    /// grant the floor + start voice and geometry recording together through the
+    /// existing, transactional activation path.
+    func chooseRecordingWindow(
+        _ windowID: CGWindowID,
+        voice: VoiceConversationSession
+    ) async {
+        geometryCapture.select(windowID: windowID)
+        isChoosingRecordingWindow = false
+        await activateSelectedRecorder(with: voice)
+    }
+
+    func cancelRecordingWindowSelection() {
+        isChoosingRecordingWindow = false
+    }
+
     func selectConversationTarget(_ moduleID: String?) {
         guard modules.activeFloor == nil,
               modules.selectedModuleID != moduleID else {
@@ -1347,17 +1433,18 @@ final class RouterChatSession: ObservableObject {
 
 struct RouterChatPanel: View {
     @ObservedObject var session: RouterChatSession
-    @StateObject private var voice: VoiceConversationSession
+    @ObservedObject var voice: VoiceConversationSession
     let metrics: DashboardLayoutMetrics
     @Binding var isCollapsed: Bool
 
     init(
         session: RouterChatSession,
+        voice: VoiceConversationSession,
         metrics: DashboardLayoutMetrics,
         isCollapsed: Binding<Bool> = .constant(false)
     ) {
         _session = ObservedObject(wrappedValue: session)
-        _voice = StateObject(wrappedValue: VoiceConversationSession())
+        _voice = ObservedObject(wrappedValue: voice)
         _isCollapsed = isCollapsed
         self.metrics = metrics
     }
@@ -2161,5 +2248,337 @@ struct RouterChatPanel: View {
         case .offline:
             .orange
         }
+    }
+}
+
+/// The PRIMARY, one-click path to recording. A single prominent button enables the
+/// assistant, selects the Relative XY recorder, requests permissions, and presents
+/// a window picker — after which the floor is granted and voice + geometry
+/// recording start together. The detailed conversation-floor controls in
+/// ``RouterChatPanel`` remain available underneath as the advanced path.
+struct RecorderQuickStartCard: View {
+    @ObservedObject var session: RouterChatSession
+    @ObservedObject var voice: VoiceConversationSession
+    let metrics: DashboardLayoutMetrics
+    @Binding var assistantCollapsed: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 7) {
+                Image(systemName: "record.circle")
+                    .foregroundStyle(isRecordingActive ? .red : .secondary)
+                Text("RECORD A SESSION")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                stateBadge
+            }
+
+            content
+
+            Text(
+                "One click starts voice narration and selected-window geometry "
+                    + "recording together. Only mouse, scroll, and key-code geometry "
+                    + "is captured — never pixels, characters, titles, or screenshots."
+            )
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if let error = session.lastError, !isRecordingActive {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(
+                    Color.red.opacity(isRecordingActive ? 0.5 : 0.22),
+                    lineWidth: 1
+                )
+        )
+        .sheet(isPresented: $session.isChoosingRecordingWindow) {
+            RecordingWindowPickerSheet(
+                session: session,
+                voice: voice,
+                assistantCollapsed: $assistantCollapsed
+            )
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .operationsFloaterStartRecording
+            )
+        ) { _ in
+            start()
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Record a session")
+    }
+
+    private var isRecordingActive: Bool {
+        switch session.geometryCapture.mode {
+        case .recording, .paused:
+            true
+        default:
+            false
+        }
+    }
+
+    @ViewBuilder
+    private var stateBadge: some View {
+        switch session.geometryCapture.mode {
+        case .recording:
+            badge("RECORDING", .red)
+        case .paused:
+            badge("PAUSED", .orange)
+        case .review:
+            badge("REVIEW", .secondary)
+        case .disarmed, .armed:
+            EmptyView()
+        }
+    }
+
+    private func badge(_ text: String, _ color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 8, weight: .bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.14), in: Capsule())
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch session.geometryCapture.mode {
+        case .disarmed, .armed:
+            Button(action: start) {
+                Label("Record a session", systemImage: "record.circle.fill")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 3)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .controlSize(.large)
+            .accessibilityHint(
+                "Choose a window, then start voice and geometry recording."
+            )
+        case .recording:
+            HStack(spacing: 8) {
+                Text("\(session.geometryCapture.capturedEvents.count) events")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button("Pause") { pause() }
+                    .controlSize(.small)
+                Button("Stop & review") { stopAndReview() }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+            }
+            expandHint("Full controls and JSON export are in the Assistant panel below.")
+        case .paused:
+            HStack(spacing: 8) {
+                Text("Recording paused")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.orange)
+                Spacer(minLength: 0)
+                Button("Resume") { resume() }
+                    .controlSize(.small)
+                Button("Stop & review") { stopAndReview() }
+                    .controlSize(.small)
+            }
+            expandHint("Full controls and JSON export are in the Assistant panel below.")
+        case .review:
+            HStack(spacing: 8) {
+                Text("Recording ready to review")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button("New recording") { start() }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+            }
+            expandHint("Review the captured events and export the JSON in the Assistant panel below.")
+        }
+    }
+
+    private func expandHint(_ text: String) -> some View {
+        Button {
+            assistantCollapsed = false
+        } label: {
+            HStack(spacing: 4) {
+                Text(text)
+                Image(systemName: "chevron.down")
+            }
+            .font(.system(size: 9))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .accessibilityHint("Opens the Assistant panel with the full recorder controls.")
+    }
+
+    private func start() {
+        assistantCollapsed = false
+        Task { await session.beginOneClickRecording() }
+    }
+
+    private func pause() {
+        voice.pause()
+        session.geometryCapture.pause()
+    }
+
+    private func resume() {
+        session.geometryCapture.resume()
+        voice.resume()
+    }
+
+    private func stopAndReview() {
+        voice.stop()
+        session.geometryCapture.stop()
+    }
+}
+
+/// The window picker presented FIRST by the one-click flow, before any floor is
+/// granted. Choosing a row binds the window and immediately starts recording.
+struct RecordingWindowPickerSheet: View {
+    @ObservedObject var session: RouterChatSession
+    @ObservedObject var voice: VoiceConversationSession
+    @Binding var assistantCollapsed: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Choose a window to record")
+                    .font(.headline)
+                Text(
+                    "Recording captures mouse, scroll, and key-code geometry from "
+                        + "only the window you pick — never pixels, characters, "
+                        + "titles, OCR, or screenshots."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            permissionNotes
+            windowList
+
+            HStack {
+                Button("Refresh") { session.requestRecordingPermissions() }
+                Spacer()
+                Button("Cancel") {
+                    session.cancelRecordingWindowSelection()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(18)
+        .frame(width: 470, height: 430)
+    }
+
+    @ViewBuilder
+    private var permissionNotes: some View {
+        if !session.geometryCapture.inputMonitoringAvailable {
+            noteRow(
+                systemImage: "keyboard.badge.ellipsis",
+                text: "Allow Operations Floater in Privacy & Security → Input "
+                    + "Monitoring, then choose a window (or Refresh) to start."
+            )
+        }
+        if !session.isScreenRecordingAvailable {
+            noteRow(
+                systemImage: "rectangle.on.rectangle",
+                text: "Window names stay sparse until Screen Recording is granted "
+                    + "in Privacy & Security → Screen Recording. Recording still "
+                    + "captures geometry only."
+            )
+        }
+    }
+
+    private func noteRow(systemImage: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: systemImage)
+                .foregroundStyle(.orange)
+            Text(text)
+                .font(.caption2)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            Button("Request again") { session.requestRecordingPermissions() }
+                .controlSize(.mini)
+        }
+        .padding(8)
+        .background(Color.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var windowList: some View {
+        if session.geometryCapture.availableWindows.isEmpty {
+            VStack(spacing: 6) {
+                Image(systemName: "macwindow.badge.plus")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                Text("No windows found.")
+                    .font(.caption.weight(.semibold))
+                Text("Open the app you want to record, then Refresh.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 170)
+        } else {
+            ScrollView {
+                VStack(spacing: 4) {
+                    ForEach(session.geometryCapture.availableWindows) { window in
+                        Button {
+                            pick(window.id)
+                        } label: {
+                            HStack(spacing: 9) {
+                                Image(systemName: "macwindow")
+                                    .foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(window.ownerName)
+                                        .font(.caption.weight(.semibold))
+                                        .lineLimit(1)
+                                    Text(
+                                        "\(Int(window.bounds.width))"
+                                            + "×\(Int(window.bounds.height))"
+                                    )
+                                    .font(.caption2.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                }
+                                Spacer(minLength: 0)
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 7)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                .quinary,
+                                in: RoundedRectangle(cornerRadius: 8)
+                            )
+                            .contentShape(RoundedRectangle(cornerRadius: 8))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Record \(window.displayName)")
+                    }
+                }
+            }
+            .frame(maxHeight: 230)
+        }
+    }
+
+    private func pick(_ windowID: CGWindowID) {
+        assistantCollapsed = false
+        Task { await session.chooseRecordingWindow(windowID, voice: voice) }
+        dismiss()
     }
 }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/RouterChatTests.swift
@@ -832,6 +832,97 @@ struct RouterChatSessionTests {
         #expect(probe.removeMonitorCount == 1)
     }
 
+    @Test("One-click record enables the assistant, selects the recorder, and opens the picker without a floor")
+    func oneClickRecordingOpensPickerBeforeGrantingFloor() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: true,
+            monitorStarts: true,
+            probe: probe
+        )
+        // Start from a fresh, disabled session with no module selected so we
+        // exercise the full one-click preparation path.
+        let session = makeRecorderSession(
+            capture: capture,
+            selectRecorder: false
+        )
+        session.disable()
+        session.modules.selectedModuleID = nil
+        #expect(!session.isEnabled)
+
+        await session.beginOneClickRecording()
+
+        #expect(session.isEnabled)
+        #expect(
+            session.modules.selectedModuleID
+                == ConversationModuleAllowlist.relativeXYRecorderManifest.moduleID
+        )
+        // The picker is shown, and critically NO floor was granted and NO window is
+        // bound yet — the window is chosen first (in the picker), which is exactly
+        // what the recorder's "choose a visible window first" guard requires.
+        #expect(session.isChoosingRecordingWindow)
+        #expect(session.modules.activeFloor == nil)
+        #expect(session.geometryCapture.selectedWindow == nil)
+        #expect(capture.mode == .disarmed)
+        // The window list was refreshed and is offered in the picker.
+        #expect(!session.geometryCapture.availableWindows.isEmpty)
+        // Input Monitoring was already available, so no TCC request was made.
+        #expect(probe.requestPermissionCount == 0)
+        #expect(probe.addMonitorCount == 0)
+    }
+
+    @Test("Choosing a window in the one-click flow grants the floor and starts recording + voice")
+    func oneClickChooseWindowStartsRecordingAndVoice() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: true,
+            monitorStarts: true,
+            probe: probe
+        )
+        let session = makeRecorderSession(capture: capture)
+        await session.enable()
+        session.isChoosingRecordingWindow = true
+        let voice = VoiceConversationSession(
+            engine: RecorderVoiceEngine(),
+            speechOutput: SilentSpeechOutput()
+        )
+
+        // 42 is the fixture window id produced by makeRecorderCapture.
+        await session.chooseRecordingWindow(42, voice: voice)
+
+        #expect(!session.isChoosingRecordingWindow)
+        #expect(session.modules.activeFloor != nil)
+        #expect(capture.mode == .recording)
+        #expect(voice.state == .listening)
+        #expect(probe.addMonitorCount == 1)
+        #expect(probe.removeMonitorCount == 0)
+    }
+
+    @Test("One-click record is a no-op while a recording is already live")
+    func oneClickRecordingIsNoOpWhileRecording() async {
+        let probe = RecorderActivationProbe()
+        let capture = makeRecorderCapture(
+            inputMonitoringAvailable: true,
+            monitorStarts: true,
+            probe: probe
+        )
+        let session = makeRecorderSession(capture: capture)
+        await session.enable()
+        let voice = VoiceConversationSession(
+            engine: RecorderVoiceEngine(),
+            speechOutput: SilentSpeechOutput()
+        )
+        await session.activateSelectedRecorder(with: voice)
+        #expect(capture.mode == .recording)
+
+        await session.beginOneClickRecording()
+
+        // The live recording is untouched and the picker is not reopened.
+        #expect(capture.mode == .recording)
+        #expect(!session.isChoosingRecordingWindow)
+        #expect(session.modules.activeFloor != nil)
+    }
+
     @Test("Recorder startup revokes floor when recording cannot start")
     func recorderStartupRollsBackRecordingFailure() async {
         var calls: [String] = []
@@ -1006,7 +1097,9 @@ struct RouterChatSessionTests {
     }
 
     private func makeRecorderSession(
-        capture: NeutralGeometryCaptureSession
+        capture: NeutralGeometryCaptureSession,
+        screenRecordingAvailable: Bool = true,
+        selectRecorder: Bool = true
     ) -> RouterChatSession {
         let manifest = ConversationModuleAllowlist.relativeXYRecorderManifest
         let modules = ConversationModuleHostSession(
@@ -1023,9 +1116,13 @@ struct RouterChatSessionTests {
                 result: .success(localReply(text: "Unused"))
             ),
             modules: modules,
-            geometryCapture: capture
+            geometryCapture: capture,
+            screenRecordingPreflight: { screenRecordingAvailable },
+            screenRecordingRequest: { screenRecordingAvailable }
         )
-        session.selectConversationTarget(manifest.moduleID)
+        if selectRecorder {
+            session.selectConversationTarget(manifest.moduleID)
+        }
         return session
     }
 


### PR DESCRIPTION
## The problem (owner hit it live)

Starting the recorder today meant: enable the Assistant, pick the **Relative XY recorder** in the *Conversation floor* dropdown, and click **Give floor · start voice + recording** — which then errored **"Choose a visible window before giving the recorder the floor"** while the window-picker control was hidden until *after* the floor was granted. Chicken-and-egg: it needed a window chosen first, but the chooser wasn't reachable.

## The fix

A prominent one-click **● Record a session** button that starts everything and prompts with a window picker first.

- **`RecorderQuickStartCard`** renders as a dedicated card **above** the Assistant section. An App-menu item **"Record a Session"** + **⌘R** trigger the same flow via a `NotificationCenter` bridge.
- One click, no other steps:
  1. Enable the Router if off, select the Relative XY recorder module.
  2. Request Input Monitoring / Screen Recording if missing.
  3. Present a **"Choose a window to record"** sheet over `capture.availableWindows` (with **Refresh**) — the window is chosen **before** the floor is granted, satisfying the existing guard and killing the chicken-and-egg.
  4. On pick: `capture.select(windowID:)` → grant the floor → `capture.start()` (voice narration + geometry recording start together, via the unchanged `RecorderActivationTransaction`).
- **Permission-resilient:** denials surface the existing Input Monitoring guidance and never dead-end — grant, then click again.
- Live state afterward: **Recording · Pause · Stop & review · New recording**, pointing to the existing detailed panel for **Export**.

## Additive / safety

- Existing Conversation-floor controls, `NeutralGeometryCapturePanel`, guards, and wording are **all intact**.
- **PHI-local posture preserved**: geometry only (mouse/scroll/key-code), never pixels, characters, titles, OCR, or screenshots; frames only to the on-device model.
- `VoiceConversationSession` hoisted to `DashboardView` so the card and Assistant panel share one correctly-wired voice session.

## Verification

- `swift build` ✅ and `swift test` ✅ — **166 tests pass**, including 3 new one-click tests (picker opens before any floor is granted; choosing a window starts recording + voice; no-op while already recording).
- Ad-hoc-signed `.app` built with `xcodebuild` for owner testing. **Not** Developer-ID signed/notarized (owner-gated); the installed `/Applications` copy was **not** touched.

## Click-path the owner now sees

Dashboard → **● Record a session** (top card, or ⌘R) → **Choose a window to record** sheet → pick a window → recording + voice start immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)