### PR TITLE
feat(operations-floater): Screen Trainer — author-your-own overlay layer system (Photoshop-style)

### DIFF
--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -52,6 +52,28 @@
   Hardened Runtime entitlement (TCC-gated, like Input Monitoring); adds an
   advisory `NSScreenCaptureUsageDescription`. Verified end-to-end with a
   **synthetic** frame via `--capture-selftest` (no real capture in dev/CI).
+- **Screen Trainer — author-your-own overlay LAYER system (Photoshop-style).**
+  Add a layer model the clinician authors on top of the model's read: each
+  `OverlayLayer` carries `{id, normalizedRect, label, purpose, actionLaneIndex,
+  groupID, visible}` — position, a name, a free-text PURPOSE (why the step
+  exists), a slot in the ACTION LANE (workflow click order), a group, and its own
+  show/hide. `OverlayGroup`s organize layers by clinical context (e.g. inpatient
+  / outpatient) with per-group show/hide. `OverlayComposition` is the pure value
+  type holding the whole document with all Photoshop-style semantics as pure
+  functions (effective visibility = own flag AND group visible; `renderableLayers`
+  excludes anything hidden; `actionLaneSequence` orders by workflow slot; add /
+  reorder / regroup / edit / remove). New `ScreenTrainerLayers.swift` (model +
+  `OverlayCompositionStore` single-document JSON persistence +
+  `OverlayCompositionSession`) and `ScreenTrainerLayersPanel.swift` (the panel +
+  `AuthoredOverlaysLayer`, which reuses the `NormalizedRect` box-drawing plumbing
+  and draws exactly the renderable layers). The overlay now shows a **LAYERS**
+  panel: list groups + layers, toggle visibility per-item and per-group, reorder,
+  and an **add overlay** affordance that authors a component with a label,
+  purpose, action-lane slot, and group. Persistence is PHI-free by construction —
+  only author-supplied labels, purposes, normalized positions, workflow-order
+  indices, group names, and visibility; no frame, pixels, or screen text. This is
+  the semantic-knowledge-graph seed the context-toggle, mermaid-graph, and
+  agentic-composition slices build on next.
 - Add a local-only, read-only receipt-feed 1.1 source with strict shape,
   duplicate-key, provenance, file-type, size, and SHA-256 validation.
 - Read content-addressed `current` first and use LKG only when current fails

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayers.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayers.swift
@@ -1,0 +1,475 @@
+import Combine
+import CoreGraphics
+import Foundation
+
+// MARK: - Author-your-own overlay LAYER system (Photoshop-style)
+//
+// The Screen Trainer's read (the local model's candidate `ScreenRegion`s) is the
+// machine's guess. This file adds the OTHER half the owner asked for: layers the
+// CLINICIAN authors and stacks ON TOP of that read — imagined / annotation
+// components managed Photoshop-style. Each authored overlay carries not just a
+// position and a label but a PURPOSE (why this element exists in the workflow) and
+// a slot in the ACTION LANE (its order in the click-sequence). Grouped by clinical
+// context (e.g. inpatient / outpatient), each layer and each group shows/hides
+// independently. Together these authored overlays are the seed of the semantic
+// knowledge-graph of the EHR UI that the later agentic-composition layer plans
+// over.
+//
+// PHI BOUNDARY (absolute): identical to the rest of the Screen Trainer. Nothing
+// here is extracted from a real EHR screen. A layer is the clinician's OWN
+// annotation — a normalized rectangle (`0…1`, never pixels, never an absolute
+// screen coordinate), a label and purpose HE types, a workflow-order index, and a
+// group name HE chooses. No frame, no pixels, no screen text, no patient value.
+// The persisted document carries only these author-supplied, content-free fields,
+// exactly as the typed correction `note` is kept on-device and never transmitted.
+
+// MARK: - Overlay group (a clinical context)
+
+/// A named collection of authored overlays — a clinical context such as
+/// "inpatient" or "outpatient". Hiding the group hides every layer inside it,
+/// Photoshop-style, without changing each layer's own visibility flag.
+struct OverlayGroup: Identifiable, Equatable, Codable, Sendable {
+    let id: String
+    /// The clinical-context name the clinician chose, e.g. "inpatient". Content-free.
+    var name: String
+    /// Group-level show/hide. When false, none of its layers draw regardless of
+    /// each layer's own `visible` flag.
+    var visible: Bool
+
+    init(id: String = OverlayGroup.newID(), name: String, visible: Bool = true) {
+        self.id = id
+        self.name = name
+        self.visible = visible
+    }
+
+    static func newID() -> String { "group-\(UUID().uuidString.prefix(8))" }
+}
+
+// MARK: - Overlay layer (one authored component)
+
+/// One overlay component the clinician authors and stacks on top of the model's
+/// read. It is the atom of the EHR UI knowledge-graph: WHERE it sits
+/// (`normalizedRect`), WHAT it is (`label`), WHY it exists (`purpose`), WHEN it
+/// happens in the workflow (`actionLaneIndex`), and which clinical context it
+/// belongs to (`groupID`). `visible` is its own Photoshop-style show/hide.
+struct OverlayLayer: Identifiable, Equatable, Codable, Sendable {
+    let id: String
+    /// The short name the clinician gives this component, e.g. "Sign orders".
+    var label: String
+    /// Free text: WHY this component exists / what it accomplishes in the
+    /// workflow. Author-supplied, content-free, on-device only. This is the
+    /// semantic edge the future knowledge-graph carries.
+    var purpose: String
+    /// Position + size, normalized to the window (origin top-left, each axis
+    /// `0…1`). Reuses the Screen Trainer's `NormalizedRect`, so it can never carry
+    /// pixels or an absolute screen coordinate.
+    var normalizedRect: NormalizedRect
+    /// This component's slot in the ACTION LANE — its order in the workflow
+    /// click-sequence. Lower runs earlier. The later agentic layer plans over this
+    /// ordering.
+    var actionLaneIndex: Int
+    /// The group (clinical context) this layer belongs to, or `nil` when ungrouped.
+    var groupID: String?
+    /// This layer's own show/hide. Effective visibility also requires its group to
+    /// be visible (see `OverlayComposition.isEffectivelyVisible`).
+    var visible: Bool
+
+    init(
+        id: String = OverlayLayer.newID(),
+        label: String,
+        purpose: String = "",
+        normalizedRect: NormalizedRect,
+        actionLaneIndex: Int,
+        groupID: String? = nil,
+        visible: Bool = true
+    ) {
+        self.id = id
+        self.label = label
+        self.purpose = purpose
+        self.normalizedRect = normalizedRect
+        self.actionLaneIndex = actionLaneIndex
+        self.groupID = groupID
+        self.visible = visible
+    }
+
+    static func newID() -> String { "layer-\(UUID().uuidString.prefix(8))" }
+}
+
+// MARK: - Overlay composition (the whole authored document)
+
+/// The full authored overlay document: an ordered stack of groups and the layers
+/// within them. This is the persisted, PHI-free knowledge-graph seed. It is a pure
+/// value type with all the Photoshop-style semantics (effective visibility,
+/// render/lane ordering, add / reorder / regroup) expressed as pure functions, so
+/// the whole model is unit-testable with no UI, no window, and no capture.
+struct OverlayComposition: Equatable, Codable, Sendable {
+    /// Groups in panel order (top of the list first).
+    var groups: [OverlayGroup]
+    /// Every authored layer. Panel/z order is this array order; the action-lane
+    /// ordering is derived from `actionLaneIndex` independently.
+    var layers: [OverlayLayer]
+
+    init(groups: [OverlayGroup] = [], layers: [OverlayLayer] = []) {
+        self.groups = groups
+        self.layers = layers
+    }
+
+    /// An empty document — the default before the clinician authors anything.
+    static let empty = OverlayComposition()
+
+    // MARK: Lookups
+
+    func group(withID id: String?) -> OverlayGroup? {
+        guard let id else { return nil }
+        return groups.first { $0.id == id }
+    }
+
+    func group(for layer: OverlayLayer) -> OverlayGroup? {
+        group(withID: layer.groupID)
+    }
+
+    func layer(withID id: String) -> OverlayLayer? {
+        layers.first { $0.id == id }
+    }
+
+    /// The layers belonging to a group (or the ungrouped layers when `groupID` is
+    /// `nil`), in panel/z order.
+    func layers(inGroup groupID: String?) -> [OverlayLayer] {
+        layers.filter { $0.groupID == groupID }
+    }
+
+    // MARK: Effective visibility (the render guarantee)
+
+    /// A layer draws only when it is visible AND its group (if any) is visible.
+    /// A layer whose `groupID` points at a missing group is treated as ungrouped.
+    func isEffectivelyVisible(_ layer: OverlayLayer) -> Bool {
+        guard layer.visible else { return false }
+        guard let groupID = layer.groupID else { return true }
+        guard let group = groups.first(where: { $0.id == groupID }) else { return true }
+        return group.visible
+    }
+
+    /// EXACTLY the layers that should be drawn, in panel/z order. Hidden layers and
+    /// layers in hidden groups are excluded — this is the single source the overlay
+    /// renders, so "hidden overlays don't draw" is guaranteed here, not in the view.
+    var renderableLayers: [OverlayLayer] {
+        layers.filter(isEffectivelyVisible)
+    }
+
+    /// The authored workflow click-sequence: every layer ordered by its action-lane
+    /// slot (ties broken by panel order). This is the ordering the later agentic
+    /// layer plans over.
+    var actionLaneSequence: [OverlayLayer] {
+        layers.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.actionLaneIndex != rhs.element.actionLaneIndex {
+                    return lhs.element.actionLaneIndex < rhs.element.actionLaneIndex
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    /// The next free action-lane slot — one past the current maximum, or 0 when
+    /// empty. Used to auto-assign a slot when authoring a new overlay.
+    var nextActionLaneIndex: Int {
+        (layers.map(\.actionLaneIndex).max() ?? -1) + 1
+    }
+
+    // MARK: Mutations (all pure — return a new composition)
+
+    /// Author a new overlay and append it. When `actionLaneIndex` is omitted it
+    /// takes the next free slot. Returns the new composition and the created layer.
+    @discardableResult
+    mutating func addLayer(
+        label: String,
+        purpose: String = "",
+        normalizedRect: NormalizedRect = OverlayComposition.defaultAuthoredRect,
+        actionLaneIndex: Int? = nil,
+        groupID: String? = nil,
+        visible: Bool = true,
+        id: String = OverlayLayer.newID()
+    ) -> OverlayLayer {
+        let layer = OverlayLayer(
+            id: id,
+            label: label.trimmingCharacters(in: .whitespacesAndNewlines),
+            purpose: purpose.trimmingCharacters(in: .whitespacesAndNewlines),
+            normalizedRect: normalizedRect,
+            actionLaneIndex: actionLaneIndex ?? nextActionLaneIndex,
+            groupID: groupID,
+            visible: visible
+        )
+        layers.append(layer)
+        return layer
+    }
+
+    /// Add a new group at the top of the stack and return it.
+    @discardableResult
+    mutating func addGroup(name: String, visible: Bool = true, id: String = OverlayGroup.newID()) -> OverlayGroup {
+        let group = OverlayGroup(
+            id: id,
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            visible: visible
+        )
+        groups.insert(group, at: 0)
+        return group
+    }
+
+    /// Toggle one layer's own visibility.
+    mutating func toggleLayer(_ id: String) {
+        guard let index = layers.firstIndex(where: { $0.id == id }) else { return }
+        layers[index].visible.toggle()
+    }
+
+    /// Toggle one group's visibility (hides/shows all its layers en masse).
+    mutating func toggleGroup(_ id: String) {
+        guard let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        groups[index].visible.toggle()
+    }
+
+    /// Move a layer to a different group (or ungroup it with `nil`).
+    mutating func assignLayer(_ id: String, toGroup groupID: String?) {
+        guard let index = layers.firstIndex(where: { $0.id == id }) else { return }
+        layers[index].groupID = groupID
+    }
+
+    /// Replace an authored layer wholesale (edit label / purpose / lane / rect).
+    mutating func updateLayer(_ layer: OverlayLayer) {
+        guard let index = layers.firstIndex(where: { $0.id == layer.id }) else { return }
+        layers[index] = layer
+    }
+
+    /// Remove a layer.
+    mutating func removeLayer(_ id: String) {
+        layers.removeAll { $0.id == id }
+    }
+
+    /// Remove a group; its layers become ungrouped (never silently deleted).
+    mutating func removeGroup(_ id: String) {
+        groups.removeAll { $0.id == id }
+        for index in layers.indices where layers[index].groupID == id {
+            layers[index].groupID = nil
+        }
+    }
+
+    /// Reorder a layer within its group siblings (Photoshop up/down in the stack).
+    /// `delta` is -1 to move up, +1 to move down; clamped to the sibling range.
+    mutating func moveLayer(_ id: String, by delta: Int) {
+        guard let layer = layer(withID: id) else { return }
+        let siblingIDs = layers(inGroup: layer.groupID).map(\.id)
+        guard let localIndex = siblingIDs.firstIndex(of: id) else { return }
+        let target = localIndex + delta
+        guard target >= 0, target < siblingIDs.count, target != localIndex else { return }
+        // Swap the two siblings' absolute positions in the flat `layers` array.
+        guard let a = layers.firstIndex(where: { $0.id == siblingIDs[localIndex] }),
+              let b = layers.firstIndex(where: { $0.id == siblingIDs[target] }) else { return }
+        layers.swapAt(a, b)
+    }
+
+    /// Reorder a group within the group stack. `delta` -1 up / +1 down.
+    mutating func moveGroup(_ id: String, by delta: Int) {
+        guard let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        let target = index + delta
+        guard target >= 0, target < groups.count, target != index else { return }
+        groups.swapAt(index, target)
+    }
+
+    /// A sensible default rectangle for a freshly authored overlay: a centered box
+    /// the clinician then drags into place.
+    static let defaultAuthoredRect = NormalizedRect(x: 0.35, y: 0.42, width: 0.3, height: 0.16)
+
+    // MARK: Starter document (demo + first-run illustration)
+
+    /// A small, generic, content-free starter so the panel and the drawn overlay
+    /// illustrate the concept out of the box: two clinical-context groups with a
+    /// couple of authored components each, laid out along the action lane. Purely
+    /// generic workflow annotations — no real screen, no PHI.
+    static var starter: OverlayComposition {
+        let inpatient = OverlayGroup(id: "group-inpatient", name: "inpatient", visible: true)
+        let outpatient = OverlayGroup(id: "group-outpatient", name: "outpatient", visible: true)
+        return OverlayComposition(
+            groups: [inpatient, outpatient],
+            layers: [
+                OverlayLayer(
+                    id: "layer-open-orders",
+                    label: "Open orders tab",
+                    purpose: "Start the order-entry workflow from the chart toolbar.",
+                    normalizedRect: NormalizedRect(x: 0.02, y: 0.0, width: 0.16, height: 0.053),
+                    actionLaneIndex: 0,
+                    groupID: inpatient.id
+                ),
+                OverlayLayer(
+                    id: "layer-order-set",
+                    label: "Admission order set",
+                    purpose: "Apply the standard inpatient admission bundle.",
+                    normalizedRect: NormalizedRect(x: 0.05, y: 0.16, width: 0.5, height: 0.2),
+                    actionLaneIndex: 1,
+                    groupID: inpatient.id
+                ),
+                OverlayLayer(
+                    id: "layer-sign",
+                    label: "Sign & hold",
+                    purpose: "Sign the orders; a propose-confirm gate stops here before execution.",
+                    normalizedRect: NormalizedRect(x: 0.78, y: 0.905, width: 0.2, height: 0.06),
+                    actionLaneIndex: 2,
+                    groupID: inpatient.id
+                ),
+                OverlayLayer(
+                    id: "layer-visit-dx",
+                    label: "Visit diagnosis",
+                    purpose: "Attach the outpatient visit diagnosis before checkout.",
+                    normalizedRect: NormalizedRect(x: 0.29, y: 0.1, width: 0.4, height: 0.14),
+                    actionLaneIndex: 0,
+                    groupID: outpatient.id
+                ),
+            ]
+        )
+    }
+}
+
+// MARK: - Persistence (single PHI-free JSON document, on-device)
+
+/// Atomic single-document JSON persistence for the authored overlay composition.
+/// It sits beside the correction store under Application Support, is git-ignored,
+/// and holds only author-supplied, content-free fields — labels, purposes,
+/// normalized positions, workflow-order indices, group names, and visibility. No
+/// frame, no pixels, no screen text; never PHI.
+final class OverlayCompositionStore {
+    private let fileURL: URL
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// The default on-device store path (git-ignored, never transmitted), grouped
+    /// with the Screen Trainer's other on-device memory.
+    static func defaultStore(source: String = "citrix-ehr") -> OverlayCompositionStore {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let safe = source.map { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" ? $0 : "-" }
+        let dir = base
+            .appendingPathComponent("OperationsFloater", isDirectory: true)
+            .appendingPathComponent("screen-trainer-layers", isDirectory: true)
+        return OverlayCompositionStore(
+            fileURL: dir.appendingPathComponent("\(String(safe)).json")
+        )
+    }
+
+    /// Load the saved composition, or `nil` when none exists / it is unreadable.
+    func load() -> OverlayComposition? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode(OverlayComposition.self, from: data)
+    }
+
+    /// Persist the composition atomically, creating the (0700) directory as needed.
+    func save(_ composition: OverlayComposition) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes, .prettyPrinted]
+        let data = try encoder.encode(composition)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}
+
+// MARK: - Layer session (observable authored state for the panel + overlay)
+
+/// Drives the Layers panel and feeds the drawn overlay. It owns the authored
+/// `OverlayComposition`, applies every Photoshop-style mutation through the pure
+/// model, and persists each change to the on-device store. The selected authored
+/// layer is tracked so the panel and the drawn box stay in sync. No capture, no
+/// network, and no PHI live here.
+@MainActor
+final class OverlayCompositionSession: ObservableObject {
+    @Published private(set) var composition: OverlayComposition
+    /// The authored layer currently selected in the panel (for edit / highlight).
+    @Published var selectedLayerID: String?
+
+    private let store: OverlayCompositionStore?
+
+    init(
+        composition: OverlayComposition = .empty,
+        store: OverlayCompositionStore? = nil
+    ) {
+        // A saved document wins over the seed; otherwise use the provided initial
+        // composition (the app seeds `.starter`, tests pass their own).
+        self.composition = store?.load() ?? composition
+        self.store = store
+    }
+
+    var selectedLayer: OverlayLayer? {
+        guard let id = selectedLayerID else { return nil }
+        return composition.layer(withID: id)
+    }
+
+    /// The layers that should draw (visible, in a visible group), in panel order.
+    var renderableLayers: [OverlayLayer] { composition.renderableLayers }
+
+    // MARK: Authoring
+
+    /// Author a new overlay with a label, purpose, action-lane slot, and group,
+    /// select it, and persist. This is the panel's "add overlay" affordance.
+    @discardableResult
+    func addOverlay(
+        label: String,
+        purpose: String,
+        actionLaneIndex: Int? = nil,
+        groupID: String? = nil,
+        normalizedRect: NormalizedRect = OverlayComposition.defaultAuthoredRect
+    ) -> OverlayLayer? {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let layer = composition.addLayer(
+            label: trimmed,
+            purpose: purpose,
+            normalizedRect: normalizedRect,
+            actionLaneIndex: actionLaneIndex,
+            groupID: groupID
+        )
+        selectedLayerID = layer.id
+        persist()
+        return layer
+    }
+
+    @discardableResult
+    func addGroup(name: String) -> OverlayGroup? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let group = composition.addGroup(name: trimmed)
+        persist()
+        return group
+    }
+
+    // MARK: Visibility
+
+    func toggleLayer(_ id: String) { mutate { $0.toggleLayer(id) } }
+    func toggleGroup(_ id: String) { mutate { $0.toggleGroup(id) } }
+
+    // MARK: Reorder / regroup / edit / delete
+
+    func moveLayer(_ id: String, by delta: Int) { mutate { $0.moveLayer(id, by: delta) } }
+    func moveGroup(_ id: String, by delta: Int) { mutate { $0.moveGroup(id, by: delta) } }
+    func assignLayer(_ id: String, toGroup groupID: String?) {
+        mutate { $0.assignLayer(id, toGroup: groupID) }
+    }
+    func updateLayer(_ layer: OverlayLayer) { mutate { $0.updateLayer(layer) } }
+
+    func removeLayer(_ id: String) {
+        mutate { $0.removeLayer(id) }
+        if selectedLayerID == id { selectedLayerID = nil }
+    }
+    func removeGroup(_ id: String) { mutate { $0.removeGroup(id) } }
+
+    func select(_ id: String?) { selectedLayerID = id }
+
+    private func mutate(_ transform: (inout OverlayComposition) -> Void) {
+        transform(&composition)
+        persist()
+    }
+
+    private func persist() {
+        try? store?.save(composition)
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayersPanel.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayersPanel.swift
@@ -1,0 +1,351 @@
+import AppKit
+import Combine
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+// MARK: - Authored-overlay accents
+
+extension OverlayComposition {
+    /// A stable, generic accent palette indexed by group order — so each clinical
+    /// context reads as its own color in both the panel and the drawn overlay.
+    static let groupPalette: [Color] = [.blue, .orange, .purple, .teal, .pink, .indigo, .green]
+
+    /// The accent for a layer: its group's palette color, or gray when ungrouped.
+    func accent(for layer: OverlayLayer) -> Color {
+        guard let groupID = layer.groupID,
+              let index = groups.firstIndex(where: { $0.id == groupID }) else {
+            return .gray
+        }
+        return Self.groupPalette[index % Self.groupPalette.count]
+    }
+
+    func accent(forGroup group: OverlayGroup) -> Color {
+        guard let index = groups.firstIndex(where: { $0.id == group.id }) else { return .gray }
+        return Self.groupPalette[index % Self.groupPalette.count]
+    }
+}
+
+// MARK: - Authored overlays render layer (reuses the box-drawing plumbing)
+
+/// Draws the CLINICIAN-authored overlays over the target area — the counterpart to
+/// `ScreenTrainerRegionsLayer` (which draws the model's read). It renders EXACTLY
+/// `composition.renderableLayers`, so hidden layers and layers in hidden groups
+/// never draw. Each box is solid (authored, not a guess), carries the label and its
+/// action-lane slot, and reuses the same `NormalizedRect.cgRect(in:)` mapping as
+/// the model-read layer.
+struct AuthoredOverlaysLayer: View {
+    let composition: OverlayComposition
+    var selectedLayerID: String?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let size = geometry.size
+            ZStack(alignment: .topLeading) {
+                ForEach(composition.renderableLayers) { layer in
+                    layerBox(layer, in: size)
+                }
+            }
+            .frame(width: size.width, height: size.height)
+        }
+    }
+
+    @ViewBuilder
+    private func layerBox(_ layer: OverlayLayer, in size: CGSize) -> some View {
+        let rect = layer.normalizedRect.cgRect(in: size)
+        let isSelected = layer.id == selectedLayerID
+        let accent = composition.accent(for: layer)
+
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(accent, lineWidth: isSelected ? 3 : 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(accent.opacity(isSelected ? 0.20 : 0.12))
+                )
+                .frame(width: rect.width, height: rect.height)
+
+            layerTag(layer, accent: accent).offset(y: -1)
+        }
+        .frame(width: rect.width, height: rect.height, alignment: .topLeading)
+        .offset(x: rect.minX, y: rect.minY)
+    }
+
+    private func layerTag(_ layer: OverlayLayer, accent: Color) -> some View {
+        HStack(spacing: 4) {
+            Text("\(layer.actionLaneIndex)")
+                .font(.system(size: 8, weight: .bold).monospacedDigit())
+                .foregroundStyle(accent)
+                .padding(.horizontal, 3)
+                .padding(.vertical, 1)
+                .background(.white, in: RoundedRectangle(cornerRadius: 2))
+            Text(layer.label)
+                .font(.system(size: 9, weight: .bold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(accent, in: RoundedRectangle(cornerRadius: 3))
+        .fixedSize()
+    }
+}
+
+// MARK: - Layers panel (Photoshop-style)
+
+/// The Photoshop-style Layers panel: every group and its authored layers, each
+/// with a show/hide eye and reorder controls, plus an "add overlay" affordance that
+/// authors a component with a label, a PURPOSE, an action-lane slot, and a group.
+/// The live overlay uses the interactive form; the headless demo renders a
+/// read-only list (SwiftUI text fields do not rasterize offscreen).
+struct ScreenTrainerLayersPanel: View {
+    @ObservedObject var session: OverlayCompositionSession
+    var interactive: Bool = true
+
+    @State private var draftLabel = ""
+    @State private var draftPurpose = ""
+    @State private var draftLaneText = ""
+    @State private var draftGroupID: String?
+    @State private var draftGroupName = ""
+    @State private var showAddForm = false
+
+    private var composition: OverlayComposition { session.composition }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            if composition.groups.isEmpty && composition.layers.isEmpty {
+                emptyState
+            } else {
+                stack
+            }
+            if interactive {
+                addControls
+            }
+            phiFootnote
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.black.opacity(0.80))
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "square.stack.3d.up.fill").font(.system(size: 10))
+            Text("LAYERS")
+                .font(.system(size: 9, weight: .bold))
+            Spacer()
+            Text("\(composition.renderableLayers.count)/\(composition.layers.count) shown")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    private var emptyState: some View {
+        Text("No overlays yet. Add a group (a clinical context) and author an overlay "
+            + "with a label, a purpose, and an action-lane slot.")
+            .font(.system(size: 10))
+            .foregroundStyle(.white.opacity(0.55))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: Stack (groups + their layers, then ungrouped)
+
+    private var stack: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(composition.groups) { group in
+                groupRow(group)
+                ForEach(composition.layers(inGroup: group.id)) { layer in
+                    layerRow(layer, groupVisible: group.visible)
+                        .padding(.leading, 16)
+                }
+            }
+            let ungrouped = composition.layers(inGroup: nil)
+            if !ungrouped.isEmpty {
+                Text("UNGROUPED")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .padding(.top, 2)
+                ForEach(ungrouped) { layer in
+                    layerRow(layer, groupVisible: true)
+                }
+            }
+        }
+    }
+
+    private func groupRow(_ group: OverlayGroup) -> some View {
+        HStack(spacing: 6) {
+            eyeButton(isOn: group.visible) { session.toggleGroup(group.id) }
+            Circle().fill(composition.accent(forGroup: group)).frame(width: 8, height: 8)
+            Text(group.name)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(group.visible ? .white : .white.opacity(0.4))
+            Text("(\(composition.layers(inGroup: group.id).count))")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.4))
+            Spacer()
+            if interactive {
+                reorderButtons(
+                    up: { session.moveGroup(group.id, by: -1) },
+                    down: { session.moveGroup(group.id, by: 1) }
+                )
+            }
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 4))
+    }
+
+    private func layerRow(_ layer: OverlayLayer, groupVisible: Bool) -> some View {
+        let effective = session.composition.isEffectivelyVisible(layer)
+        let isSelected = layer.id == session.selectedLayerID
+        return HStack(alignment: .top, spacing: 6) {
+            eyeButton(isOn: layer.visible) { session.toggleLayer(layer.id) }
+            laneBadge(layer.actionLaneIndex, accent: composition.accent(for: layer))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(layer.label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(effective ? .white : .white.opacity(0.4))
+                if !layer.purpose.isEmpty {
+                    Text(layer.purpose)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(effective ? 0.7 : 0.35))
+                        .lineLimit(2)
+                }
+                if layer.visible && !groupVisible {
+                    Text("hidden by group")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundStyle(.orange.opacity(0.8))
+                }
+            }
+            Spacer(minLength: 4)
+            if interactive {
+                reorderButtons(
+                    up: { session.moveLayer(layer.id, by: -1) },
+                    down: { session.moveLayer(layer.id, by: 1) }
+                )
+            }
+        }
+        .padding(.vertical, 3)
+        .padding(.horizontal, 5)
+        .background(
+            (isSelected ? Color.white.opacity(0.14) : Color.clear),
+            in: RoundedRectangle(cornerRadius: 4)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { session.select(isSelected ? nil : layer.id) }
+    }
+
+    private func laneBadge(_ index: Int, accent: Color) -> some View {
+        Text("\(index)")
+            .font(.system(size: 9, weight: .bold).monospacedDigit())
+            .foregroundStyle(.white)
+            .frame(width: 16, height: 16)
+            .background(accent, in: RoundedRectangle(cornerRadius: 3))
+    }
+
+    private func eyeButton(isOn: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: isOn ? "eye.fill" : "eye.slash")
+                .font(.system(size: 10))
+                .foregroundStyle(isOn ? .white : .white.opacity(0.35))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isOn ? "Hide" : "Show")
+    }
+
+    private func reorderButtons(
+        up: @escaping () -> Void,
+        down: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 2) {
+            Button(action: up) { Image(systemName: "chevron.up") }
+                .buttonStyle(.plain).font(.system(size: 8)).foregroundStyle(.white.opacity(0.6))
+            Button(action: down) { Image(systemName: "chevron.down") }
+                .buttonStyle(.plain).font(.system(size: 8)).foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    // MARK: Add controls (author your own overlay)
+
+    @ViewBuilder
+    private var addControls: some View {
+        Divider().overlay(Color.white.opacity(0.15))
+        HStack(spacing: 6) {
+            TextField("New group (e.g. inpatient)", text: $draftGroupName)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 10))
+                .onSubmit(addGroup)
+            Button("Add group", action: addGroup)
+                .controlSize(.mini)
+                .disabled(draftGroupName.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button(showAddForm ? "Cancel" : "Add overlay") {
+                showAddForm.toggle()
+            }
+            .controlSize(.mini)
+        }
+        if showAddForm {
+            addOverlayForm
+        }
+    }
+
+    private var addOverlayForm: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            TextField("Label (e.g. Sign orders)", text: $draftLabel)
+                .textFieldStyle(.roundedBorder).font(.system(size: 10))
+            TextField("Purpose — why this step exists", text: $draftPurpose)
+                .textFieldStyle(.roundedBorder).font(.system(size: 10))
+            HStack(spacing: 6) {
+                Text("Action-lane slot")
+                    .font(.system(size: 9)).foregroundStyle(.white.opacity(0.7))
+                TextField("\(composition.nextActionLaneIndex)", text: $draftLaneText)
+                    .textFieldStyle(.roundedBorder).font(.system(size: 10).monospacedDigit())
+                    .frame(width: 46)
+                Picker("Group", selection: $draftGroupID) {
+                    Text("Ungrouped").tag(String?.none)
+                    ForEach(composition.groups) { group in
+                        Text(group.name).tag(String?.some(group.id))
+                    }
+                }
+                .controlSize(.mini)
+                .font(.system(size: 9))
+                Spacer()
+                Button("Author") { addOverlay() }
+                    .controlSize(.small)
+                    .disabled(draftLabel.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(7)
+        .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var phiFootnote: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark.shield.fill").font(.system(size: 9))
+            Text("Layers store only your labels, purposes, positions & order — on-device, never PHI.")
+                .font(.system(size: 9))
+        }
+        .foregroundStyle(.green.opacity(0.7))
+    }
+
+    // MARK: Actions
+
+    private func addGroup() {
+        _ = session.addGroup(name: draftGroupName)
+        draftGroupName = ""
+    }
+
+    private func addOverlay() {
+        let lane = Int(draftLaneText.trimmingCharacters(in: .whitespaces))
+        _ = session.addOverlay(
+            label: draftLabel,
+            purpose: draftPurpose,
+            actionLaneIndex: lane,
+            groupID: draftGroupID
+        )
+        draftLabel = ""
+        draftPurpose = ""
+        draftLaneText = ""
+        showAddForm = false
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
@@ -520,29 +520,41 @@ struct ScreenTrainerRegionsLayer: View {
 struct ScreenTrainerOverlayView: View {
     @ObservedObject var session: ScreenTrainerSession
     @ObservedObject var captureController: ScreenCaptureController
+    @ObservedObject var layerSession: OverlayCompositionSession
 
     var body: some View {
         VStack(spacing: 0) {
             banner
             ScreenTrainerCaptureBar(controller: captureController)
             GeometryReader { geometry in
-                ScreenTrainerRegionsLayer(
-                    readout: session.readout,
-                    selectedRegionID: session.selectedRegionID
-                )
-                .contentShape(Rectangle())
-                .gesture(
-                    DragGesture(minimumDistance: 0).onEnded { value in
-                        let point = CGPoint(
-                            x: value.location.x / geometry.size.width,
-                            y: value.location.y / geometry.size.height
-                        )
-                        session.selectRegion(at: point)
-                    }
-                )
+                ZStack(alignment: .topLeading) {
+                    ScreenTrainerRegionsLayer(
+                        readout: session.readout,
+                        selectedRegionID: session.selectedRegionID
+                    )
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 0).onEnded { value in
+                            let point = CGPoint(
+                                x: value.location.x / geometry.size.width,
+                                y: value.location.y / geometry.size.height
+                            )
+                            session.selectRegion(at: point)
+                        }
+                    )
+                    // The clinician-authored layers draw ON TOP of the model's read.
+                    // Hit-testing stays off so selecting the model's regions still
+                    // works beneath; authored layers are selected from the panel.
+                    AuthoredOverlaysLayer(
+                        composition: layerSession.composition,
+                        selectedLayerID: layerSession.selectedLayerID
+                    )
+                    .allowsHitTesting(false)
+                }
             }
             correctionBar
             LearningPanel(session: session)
+            ScreenTrainerLayersPanel(session: layerSession)
         }
     }
 
@@ -834,9 +846,17 @@ final class ScreenTrainerOverlayWindowController {
     private var window: NSWindow?
     private let session: ScreenTrainerSession
     private let captureController: ScreenCaptureController
+    private let layerSession: OverlayCompositionSession
 
-    init(session: ScreenTrainerSession) {
+    init(
+        session: ScreenTrainerSession,
+        layerSession: OverlayCompositionSession = OverlayCompositionSession(
+            composition: .starter,
+            store: OverlayCompositionStore.defaultStore()
+        )
+    ) {
         self.session = session
+        self.layerSession = layerSession
         // Wire the real-capture controller to feed the model's read into the
         // session, replacing the synthetic default. Deliver hops to the main
         // actor because `ScreenCaptureController` is @MainActor.
@@ -869,7 +889,7 @@ final class ScreenTrainerOverlayWindowController {
     }
 
     private func makeWindow() -> NSWindow {
-        let size = NSSize(width: 720, height: 664)
+        let size = NSSize(width: 720, height: 860)
         let window = NSWindow(
             contentRect: NSRect(origin: .zero, size: size),
             styleMask: [.borderless],
@@ -886,7 +906,8 @@ final class ScreenTrainerOverlayWindowController {
         window.contentView = NSHostingView(
             rootView: ScreenTrainerOverlayView(
                 session: session,
-                captureController: captureController
+                captureController: captureController,
+                layerSession: layerSession
             )
         )
         window.center()
@@ -962,8 +983,17 @@ enum ScreenTrainerDemoRenderer {
         }) {
             session.select(primary.id)
         }
-        let content = ScreenTrainerDemoView(session: session, framePath: framePath)
-            .frame(width: 1_180, height: 760)
+        // A starter set of clinician-authored overlays (grouped by clinical
+        // context) so the demo shows the Photoshop-style layer stack drawn over the
+        // read and listed in the panel. No store, no capture, all synthetic.
+        let layerSession = OverlayCompositionSession(composition: .starter)
+        layerSession.select("layer-sign")
+        let content = ScreenTrainerDemoView(
+            session: session,
+            layerSession: layerSession,
+            framePath: framePath
+        )
+        .frame(width: 1_180, height: 900)
         let renderer = ImageRenderer(content: content)
         renderer.scale = scale
         guard let cgImage = renderer.cgImage else { return false }
@@ -983,6 +1013,7 @@ enum ScreenTrainerDemoRenderer {
 /// correction loop and PHI boundary.
 struct ScreenTrainerDemoView: View {
     @ObservedObject var session: ScreenTrainerSession
+    @ObservedObject var layerSession: OverlayCompositionSession
     let framePath: String?
 
     private static let frameSize = CGSize(width: 760, height: 520)
@@ -992,9 +1023,13 @@ struct ScreenTrainerDemoView: View {
             caption
             HStack(alignment: .top, spacing: 12) {
                 frameWithOverlay
-                LearningPanel(session: session, interactive: false)
-                    .frame(width: 360)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                VStack(spacing: 10) {
+                    LearningPanel(session: session, interactive: false)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    ScreenTrainerLayersPanel(session: layerSession, interactive: false)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .frame(width: 360)
             }
             .padding(.horizontal, 14)
             legend
@@ -1027,6 +1062,10 @@ struct ScreenTrainerDemoView: View {
             ScreenTrainerRegionsLayer(
                 readout: session.readout,
                 selectedRegionID: session.selectedRegionID
+            )
+            AuthoredOverlaysLayer(
+                composition: layerSession.composition,
+                selectedLayerID: layerSession.selectedLayerID
             )
             relabelChip
         }

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerLayersTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerLayersTests.swift
@@ -1,0 +1,343 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+@Suite("Overlay layer/group model")
+struct OverlayCompositionModelTests {
+    private func composition() -> OverlayComposition {
+        var c = OverlayComposition()
+        let g = c.addGroup(name: "inpatient")  // inserted at top
+        c.addLayer(label: "Open orders", normalizedRect: .init(x: 0, y: 0, width: 0.2, height: 0.1),
+                   actionLaneIndex: 0, groupID: g.id)
+        c.addLayer(label: "Sign", normalizedRect: .init(x: 0.5, y: 0.5, width: 0.2, height: 0.1),
+                   actionLaneIndex: 1, groupID: g.id)
+        return c
+    }
+
+    @Test("Authoring an overlay records label, purpose, action-lane slot, and group")
+    func authorsOverlayWithAllFields() {
+        var c = OverlayComposition()
+        let group = c.addGroup(name: "outpatient")
+        let layer = c.addLayer(
+            label: "  Attach visit dx  ",
+            purpose: "  Attach the visit diagnosis before checkout.  ",
+            normalizedRect: .init(x: 0.2, y: 0.2, width: 0.4, height: 0.2),
+            actionLaneIndex: 3,
+            groupID: group.id
+        )
+        #expect(layer.label == "Attach visit dx")  // trimmed
+        #expect(layer.purpose == "Attach the visit diagnosis before checkout.")
+        #expect(layer.actionLaneIndex == 3)
+        #expect(layer.groupID == group.id)
+        #expect(layer.visible)
+        #expect(c.layers.contains(layer))
+    }
+
+    @Test("A new overlay auto-assigns the next free action-lane slot")
+    func nextActionLaneIndexIsUsedByDefault() {
+        var c = OverlayComposition()
+        c.addLayer(label: "a", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1), actionLaneIndex: 0)
+        c.addLayer(label: "b", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1), actionLaneIndex: 5)
+        #expect(c.nextActionLaneIndex == 6)
+        let auto = c.addLayer(label: "c", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1))
+        #expect(auto.actionLaneIndex == 6)
+    }
+
+    @Test("Per-item visibility toggle hides just that layer")
+    func perItemVisibilityToggle() {
+        var c = composition()
+        let target = c.layers(inGroup: c.groups[0].id).first { $0.label == "Sign" }!
+        #expect(c.isEffectivelyVisible(target))
+        c.toggleLayer(target.id)
+        let after = c.layer(withID: target.id)!
+        #expect(after.visible == false)
+        #expect(!c.isEffectivelyVisible(after))
+        // The sibling is unaffected.
+        let sibling = c.layers.first { $0.label == "Open orders" }!
+        #expect(c.isEffectivelyVisible(sibling))
+    }
+
+    @Test("Per-group visibility toggle hides every layer in the group")
+    func perGroupVisibilityToggle() {
+        var c = composition()
+        let groupID = c.groups[0].id
+        #expect(c.renderableLayers.count == 2)
+        c.toggleGroup(groupID)
+        // Group hidden: layers keep their own visible=true but no longer render.
+        #expect(c.groups[0].visible == false)
+        #expect(c.renderableLayers.isEmpty)
+        for layer in c.layers(inGroup: groupID) {
+            #expect(layer.visible)  // own flag untouched
+            #expect(!c.isEffectivelyVisible(layer))
+        }
+    }
+
+    @Test("Hidden overlays (by item or by group) are excluded from what renders")
+    func hiddenOverlaysDoNotRender() {
+        var c = OverlayComposition()
+        let inp = c.addGroup(name: "inpatient")
+        let out = c.addGroup(name: "outpatient")
+        let a = c.addLayer(label: "a", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1),
+                           actionLaneIndex: 0, groupID: inp.id)
+        let b = c.addLayer(label: "b", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1),
+                           actionLaneIndex: 1, groupID: inp.id, visible: false)
+        let d = c.addLayer(label: "d", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1),
+                           actionLaneIndex: 2, groupID: out.id)
+
+        // b is hidden by its own flag; a and d render.
+        var ids = Set(c.renderableLayers.map(\.id))
+        #expect(ids == [a.id, d.id])
+        #expect(!ids.contains(b.id))
+
+        // Hide the outpatient group: d drops out too, even though d.visible == true.
+        c.toggleGroup(out.id)
+        ids = Set(c.renderableLayers.map(\.id))
+        #expect(ids == [a.id])
+        #expect(c.layer(withID: d.id)!.visible)
+    }
+
+    @Test("Action-lane sequence orders layers by their workflow slot")
+    func actionLaneSequenceOrders() {
+        var c = OverlayComposition()
+        c.addLayer(label: "third", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1), actionLaneIndex: 2)
+        c.addLayer(label: "first", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1), actionLaneIndex: 0)
+        c.addLayer(label: "second", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1), actionLaneIndex: 1)
+        #expect(c.actionLaneSequence.map(\.label) == ["first", "second", "third"])
+    }
+
+    @Test("Reordering a layer swaps it within its group siblings only")
+    func reorderLayerWithinGroup() {
+        var c = composition()
+        let groupID = c.groups[0].id
+        let siblings = c.layers(inGroup: groupID)
+        #expect(siblings.map(\.label) == ["Open orders", "Sign"])
+        c.moveLayer(siblings[1].id, by: -1)  // move "Sign" up
+        #expect(c.layers(inGroup: groupID).map(\.label) == ["Sign", "Open orders"])
+        // Out-of-range move is a no-op.
+        c.moveLayer(siblings[1].id, by: -5)
+        #expect(c.layers(inGroup: groupID).map(\.label) == ["Sign", "Open orders"])
+    }
+
+    @Test("Reordering a group moves it within the group stack")
+    func reorderGroup() {
+        var c = OverlayComposition()
+        let a = c.addGroup(name: "a")  // stack: [a]
+        let b = c.addGroup(name: "b")  // insert at top -> [b, a]
+        #expect(c.groups.map(\.name) == ["b", "a"])
+        c.moveGroup(a.id, by: -1)      // move a up -> [a, b]
+        #expect(c.groups.map(\.name) == ["a", "b"])
+        _ = b
+    }
+
+    @Test("Reassigning a layer moves it to another group; removing a group ungroups its layers")
+    func regroupAndRemoveGroup() {
+        var c = composition()
+        let inp = c.groups[0].id
+        let out = c.addGroup(name: "outpatient").id
+        let layer = c.layers.first { $0.label == "Sign" }!
+        c.assignLayer(layer.id, toGroup: out)
+        #expect(c.layer(withID: layer.id)!.groupID == out)
+
+        // Removing a group never deletes its layers — they become ungrouped.
+        c.removeGroup(inp)
+        #expect(c.group(withID: inp) == nil)
+        let orphan = c.layers.first { $0.label == "Open orders" }!
+        #expect(orphan.groupID == nil)
+        #expect(c.isEffectivelyVisible(orphan))  // ungrouped renders on its own flag
+    }
+
+    @Test("A layer pointing at a missing group is treated as ungrouped, not hidden")
+    func danglingGroupTreatedAsUngrouped() {
+        var c = OverlayComposition()
+        let layer = c.addLayer(label: "x", normalizedRect: .init(x: 0, y: 0, width: 0.1, height: 0.1),
+                               actionLaneIndex: 0, groupID: "group-does-not-exist")
+        #expect(c.isEffectivelyVisible(layer))
+    }
+
+    @Test("The starter document is well-formed and content-free")
+    func starterIsWellFormed() {
+        let c = OverlayComposition.starter
+        #expect(c.groups.count == 2)
+        #expect(c.layers.count == 4)
+        #expect(c.renderableLayers.count == 4)
+        for layer in c.layers {
+            let rect = layer.normalizedRect
+            #expect(rect.maxX <= 1.0 + 1e-9)
+            #expect(rect.maxY <= 1.0 + 1e-9)
+            #expect(!layer.label.isEmpty)
+        }
+    }
+}
+
+@Suite("Overlay composition persistence (PHI-free JSON)")
+struct OverlayCompositionStoreTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("overlay-composition-\(UUID().uuidString).json")
+    }
+
+    @Test("Composition round-trips through the store")
+    func roundTrips() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = OverlayCompositionStore(fileURL: url)
+        #expect(store.load() == nil)  // nothing saved yet
+
+        var original = OverlayComposition()
+        let group = original.addGroup(name: "inpatient")
+        original.addLayer(
+            label: "Sign orders",
+            purpose: "Sign, then stop at the propose-confirm gate.",
+            normalizedRect: .init(x: 0.3, y: 0.4, width: 0.3, height: 0.15),
+            actionLaneIndex: 2,
+            groupID: group.id,
+            visible: false
+        )
+        try store.save(original)
+
+        let loaded = try #require(store.load())
+        #expect(loaded == original)
+        #expect(loaded.groups.first?.name == "inpatient")
+        let layer = try #require(loaded.layers.first)
+        #expect(layer.label == "Sign orders")
+        #expect(layer.purpose == "Sign, then stop at the propose-confirm gate.")
+        #expect(layer.actionLaneIndex == 2)
+        #expect(layer.visible == false)
+    }
+
+    @Test("Persisted document carries only PHI-free, author-supplied fields")
+    func persistedShapeIsPHIFree() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = OverlayCompositionStore(fileURL: url)
+
+        // The starter's expected content-free field keys are present.
+        try store.save(OverlayComposition.starter)
+        let starterText = try String(contentsOf: url, encoding: .utf8)
+        for key in ["\"label\"", "\"purpose\"", "\"actionLaneIndex\"", "\"groupID\"", "\"visible\""] {
+            #expect(starterText.contains(key))
+        }
+
+        // No PHI-shaped token is ever serialized. Neutral group/label names are used
+        // here so the scan is not confused by the legitimate clinical-context names
+        // "inpatient"/"outpatient" (which contain the substring "patient").
+        var neutral = OverlayComposition()
+        let group = neutral.addGroup(name: "context-a")
+        neutral.addLayer(
+            label: "step one",
+            purpose: "advance the workflow",
+            normalizedRect: .init(x: 0.1, y: 0.1, width: 0.2, height: 0.2),
+            actionLaneIndex: 0,
+            groupID: group.id
+        )
+        try store.save(neutral)
+        let lowered = try String(contentsOf: url, encoding: .utf8).lowercased()
+        for banned in ["pixel", "screenshot", "frame", "patient", "mrn", "base64", "\"image\"", "\"text\""] {
+            #expect(!lowered.contains(banned))
+        }
+    }
+
+    @Test("Load tolerates a corrupt document")
+    func loadTolerantOfCorruption() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "{ not valid json".write(to: url, atomically: true, encoding: .utf8)
+        let store = OverlayCompositionStore(fileURL: url)
+        #expect(store.load() == nil)
+    }
+}
+
+@Suite("Overlay composition session")
+struct OverlayCompositionSessionTests {
+    @MainActor
+    private func session(_ composition: OverlayComposition = .empty)
+        -> (OverlayCompositionSession, URL)
+    {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("layer-session-\(UUID().uuidString).json")
+        return (
+            OverlayCompositionSession(
+                composition: composition,
+                store: OverlayCompositionStore(fileURL: url)
+            ),
+            url
+        )
+    }
+
+    @Test("Authoring through the session persists and selects the new overlay")
+    @MainActor
+    func authorPersistsAndSelects() throws {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let group = try #require(session.addGroup(name: "inpatient"))
+        let layer = try #require(
+            session.addOverlay(
+                label: "Sign orders",
+                purpose: "Sign then confirm.",
+                actionLaneIndex: 4,
+                groupID: group.id
+            )
+        )
+        #expect(session.selectedLayerID == layer.id)
+        #expect(session.composition.layers.count == 1)
+
+        // Persisted: a fresh session over the same file sees the authored overlay.
+        let reopened = OverlayCompositionSession(store: OverlayCompositionStore(fileURL: url))
+        #expect(reopened.composition.layers.first?.label == "Sign orders")
+        #expect(reopened.composition.layers.first?.actionLaneIndex == 4)
+        #expect(reopened.composition.groups.first?.name == "inpatient")
+    }
+
+    @Test("Blank label or group name is rejected")
+    @MainActor
+    func blankInputsRejected() {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(session.addOverlay(label: "   ", purpose: "x") == nil)
+        #expect(session.addGroup(name: "   ") == nil)
+        #expect(session.composition.layers.isEmpty)
+        #expect(session.composition.groups.isEmpty)
+    }
+
+    @Test("Session visibility toggles drive what renders")
+    @MainActor
+    func sessionVisibilityDrivesRender() {
+        let (session, url) = session(.starter)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let before = session.renderableLayers.count
+        #expect(before == 4)
+        let firstGroup = session.composition.groups[0]
+        session.toggleGroup(firstGroup.id)
+        let hiddenInGroup = session.composition.layers(inGroup: firstGroup.id).count
+        #expect(session.renderableLayers.count == before - hiddenInGroup)
+    }
+
+    @Test("A saved document overrides the seeded composition on init")
+    @MainActor
+    func savedDocumentWinsOverSeed() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("layer-seed-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = OverlayCompositionStore(fileURL: url)
+        var saved = OverlayComposition()
+        saved.addGroup(name: "saved-context")
+        try store.save(saved)
+
+        // Even though we seed `.starter`, the saved document is loaded instead.
+        let session = OverlayCompositionSession(composition: .starter, store: store)
+        #expect(session.composition.groups.map(\.name) == ["saved-context"])
+    }
+
+    @Test("Removing the selected layer clears the selection")
+    @MainActor
+    func removeSelectedClearsSelection() throws {
+        let (session, url) = session()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let layer = try #require(session.addOverlay(label: "temp", purpose: ""))
+        #expect(session.selectedLayerID == layer.id)
+        session.removeLayer(layer.id)
+        #expect(session.selectedLayerID == nil)
+        #expect(session.composition.layers.isEmpty)
+    }
+}

--- a/prototypes/operations-floater/docs/SCREEN_TRAINER.md
+++ b/prototypes/operations-floater/docs/SCREEN_TRAINER.md
@@ -149,13 +149,48 @@ swift run OperationsFloater \
   --trainer-demo-label results-review
 ```
 
-## What's next (owner reviews slice 1 first)
+## Author-your-own overlay LAYER system (Photoshop-style)
 
-- **Voice** — the architected layer above.
-- ~~Live capture wiring~~ — **done in slice 2** (ScreenCaptureKit → local model).
-  Next: continuous / interval re-capture and per-frame confidence gating.
+Beyond correcting the model's read, the clinician **authors his own overlays** and
+stacks them on top, managed Photoshop-style. This is the foundation for the
+semantic knowledge-graph of the EHR UI that the later agentic layer plans over.
+
+- **Data model** (`ScreenTrainerLayers.swift`). An `OverlayLayer` is one authored
+  component: `{id, normalizedRect, label, purpose, actionLaneIndex, groupID,
+  visible}` — WHERE it sits, WHAT it is (`label`), WHY it exists (`purpose`, free
+  text), WHEN it happens (`actionLaneIndex`, its slot in the workflow
+  click-sequence), which clinical context it belongs to (`groupID`), and its own
+  show/hide. `OverlayGroup`s (e.g. `inpatient` / `outpatient`) collect layers with
+  per-group show/hide. `OverlayComposition` is the pure document holding the whole
+  stack, with all Photoshop semantics as pure functions:
+  - `isEffectivelyVisible` = the layer's own flag **AND** its group's flag.
+  - `renderableLayers` returns EXACTLY what draws (hidden layers and layers in
+    hidden groups are excluded) — the render guarantee lives in the model, not the
+    view.
+  - `actionLaneSequence` orders every layer by its workflow slot — the sequence the
+    agentic layer will plan over.
+  - `addLayer` / `addGroup` / `toggleLayer` / `toggleGroup` / `moveLayer` /
+    `moveGroup` / `assignLayer` / `updateLayer` / `removeLayer` / `removeGroup`.
+- **Layers panel** (`ScreenTrainerLayersPanel.swift`). Lists groups and their
+  layers, each with a show/hide eye and reorder controls, plus an **add overlay**
+  affordance: label + purpose + action-lane slot + group. `AuthoredOverlaysLayer`
+  reuses the `NormalizedRect` box-drawing plumbing and draws only
+  `renderableLayers` — hidden layers never draw.
+- **Persistence** (`OverlayCompositionStore`). A single PHI-free JSON document
+  beside the correction store under Application Support, git-ignored, holding only
+  author-supplied labels, purposes, normalized positions, workflow-order indices,
+  group names, and visibility. No frame, pixels, or screen text — never PHI, the
+  same posture as the typed correction note.
+
+## What's next
+
+- **Context toggle** — surface groups as first-class clinical-context switches in
+  the overlay (show only the active context's layers).
+- **Mermaid graph** — export the authored layers + action lanes as the EHR-UI
+  knowledge graph.
+- **Agentic composition** — plan click-sequences over `actionLaneSequence` to
+  accomplish untaught goals, behind a hard propose-confirm safety gate.
+- **Voice** — the architected correction layer above.
 - **Embedding backfill** — attach the local `nomic-embed-text` embedding on each
   correction so `ScreenTrainerMemory` recall runs natively, exactly as the Python
   loop does today.
-- **Per-region workflow inference** and richer element vocabulary as the owner
-  confirms the interaction feels right.


### PR DESCRIPTION
## What this adds

The next Screen Trainer slice: the **author-your-own overlay LAYER system**, managed Photoshop-style. Beyond correcting the local model's read, the clinician now **authors his own overlays** and stacks them on top — each carrying not just a position and a label but a **PURPOSE** (why the step exists) and a slot in the **ACTION LANE** (its order in the workflow click-sequence), grouped by clinical context (inpatient / outpatient) with per-group show/hide. This is the semantic **knowledge-graph seed** the context-toggle, mermaid-graph, and agentic-composition slices build on next.

## Layer / group model

`ScreenTrainerLayers.swift` — pure value types, all Photoshop semantics as pure functions:

- **`OverlayLayer`** = `{id, normalizedRect, label, purpose, actionLaneIndex, groupID, visible}` — WHERE it sits, WHAT it is, WHY it exists, WHEN it happens, which context it belongs to, and its own show/hide.
- **`OverlayGroup`** = `{id, name, visible}` — a clinical context; hiding the group hides all its layers without touching each layer's own flag.
- **`OverlayComposition`** — the whole document:
  - `isEffectivelyVisible` = the layer's own flag **AND** its group's flag.
  - `renderableLayers` returns **exactly** what draws (hidden layers and layers in hidden groups excluded) — the render guarantee lives in the model, not the view.
  - `actionLaneSequence` orders every layer by its workflow slot — the sequence the agentic layer will plan over.
  - `addLayer` / `addGroup` / `toggleLayer` / `toggleGroup` / `moveLayer` / `moveGroup` / `assignLayer` / `updateLayer` / `removeLayer` (a removed group ungroups its layers, never deletes them).

## Panel UX + rendering

`ScreenTrainerLayersPanel.swift` — a Photoshop-style **LAYERS** panel: lists groups and their layers, each with a show/hide **eye** and up/down reorder, plus an **add overlay** affordance. Authoring an overlay = **label + purpose + action-lane slot + group** (the slot auto-fills the next free lane; the group picker defaults to Ungrouped). `AuthoredOverlaysLayer` reuses the existing `NormalizedRect` box-drawing plumbing and draws only `renderableLayers`, so hidden overlays never draw. Wired into both the live overlay and the headless demo still (screenshot below); additive — the existing read / correct / recorder loop is unchanged.

## Persistence (PHI-free)

`OverlayCompositionStore` writes a single atomic JSON document beside the correction store under Application Support (git-ignored, never transmitted), holding **only** author-supplied labels, purposes, normalized positions, workflow-order indices, group names, and visibility. No frame, pixels, or screen text — the same on-device posture as the typed correction note. Development and tests use **synthetic** fixtures only; no real EHR is ever captured or read.

## Verification

- `swift build` — clean.
- `swift test` — **185 tests green** (166 baseline + **19 new**): visibility toggles per-item and per-group, authoring an overlay with label/purpose/action-lane slot/group, persistence round-trip, PHI-free serialized shape (no `pixel`/`screenshot`/`frame`/`base64`/`mrn` tokens), reorder/regroup, dangling-group fallback, and that **hidden overlays don't render**.
- Rendered the demo still headlessly (`--render-trainer-demo`) — authored overlays draw on top of the model's dashed read with action-lane badges, and the LAYERS panel shows the grouped stack with per-item/per-group eyes.

Not merged — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)