### PR TITLE
feat(operations-floater): Screen Trainer knowledge-graph relationships + mermaid round-trip

### DIFF
--- a/prototypes/operations-floater/CHANGELOG.md
+++ b/prototypes/operations-floater/CHANGELOG.md
@@ -74,6 +74,26 @@
   indices, group names, and visibility; no frame, pixels, or screen text. This is
   the semantic-knowledge-graph seed the context-toggle, mermaid-graph, and
   agentic-composition slices build on next.
+- **Screen Trainer — knowledge-graph relationships + mermaid round-trip.** Turn the
+  authored overlays into a real EHR-UI knowledge graph and make it editable as
+  mermaid — the "what I've learned" area the owner asked for. Add
+  `OverlayRelationship {id, fromLayerID, toLayerID, kind}` (the edge set on top of
+  the layer nodes) with an **extensible** `OverlayRelationshipKind` (well-knowns:
+  houses, navigatesTo, opens, triggers, partOf, precedes; new kinds may be coined in
+  the text). `OverlayComposition` gains pure add/remove/edit/validate relationship
+  functions (endpoints must exist and differ; identical edges de-dupe; `removeLayer`
+  prunes incident edges). New `ScreenTrainerMermaid.swift` adds `mermaidExport()` —
+  deterministic `flowchart TD` with a subgraph per group, nodes carrying label +
+  purpose (purpose/hidden as `%%` metadata), and relationships as labeled edges
+  (`a -->|houses| b`) — and `applyingMermaid(_:)`, which parses a reasonable subset of
+  mermaid and **merges onto** the current model (rename / re-group / add nodes,
+  add / remove / relabel edges). `export → import → export` is stable; malformed
+  input returns a specific `OverlayMermaidError` and never mutates the model. The
+  overlay adds a **"WHAT I'VE LEARNED"** panel (`LearnedGraphPanel`) showing the graph
+  BOTH as plain statements AND as editable mermaid with **Apply** / **Refresh**.
+  Relationships persist in the same PHI-free JSON document (backward-compatible: a
+  pre-relationships doc decodes with an empty edge set); the mermaid text carries only
+  labels, purposes, group names, and kinds — never pixels, screen text, or PHI.
 - Add a local-only, read-only receipt-feed 1.1 source with strict shape,
   duplicate-key, provenance, file-type, size, and SHA-256 validation.
 - Read content-addressed `current` first and use LKG only when current fails

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayers.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayers.swift
@@ -108,10 +108,42 @@ struct OverlayComposition: Equatable, Codable, Sendable {
     /// Every authored layer. Panel/z order is this array order; the action-lane
     /// ordering is derived from `actionLaneIndex` independently.
     var layers: [OverlayLayer]
+    /// The knowledge-graph EDGE set: typed relationships between authored overlays
+    /// (the layers above are the nodes). See `OverlayRelationship`. Kept content-free
+    /// exactly like everything else here — only layer IDs and a relationship kind.
+    var relationships: [OverlayRelationship]
 
-    init(groups: [OverlayGroup] = [], layers: [OverlayLayer] = []) {
+    init(
+        groups: [OverlayGroup] = [],
+        layers: [OverlayLayer] = [],
+        relationships: [OverlayRelationship] = []
+    ) {
         self.groups = groups
         self.layers = layers
+        self.relationships = relationships
+    }
+
+    // Backward-compatible decoding: a document written by the layer-only slice (#72)
+    // has no `relationships` key. Decode it as an empty edge set rather than failing,
+    // so upgrading never drops a previously authored composition. Encoding always
+    // writes the key (as `[]` when empty), keeping the on-disk shape explicit.
+    private enum CodingKeys: String, CodingKey {
+        case groups, layers, relationships
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.groups = try container.decodeIfPresent([OverlayGroup].self, forKey: .groups) ?? []
+        self.layers = try container.decodeIfPresent([OverlayLayer].self, forKey: .layers) ?? []
+        self.relationships =
+            try container.decodeIfPresent([OverlayRelationship].self, forKey: .relationships) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(groups, forKey: .groups)
+        try container.encode(layers, forKey: .layers)
+        try container.encode(relationships, forKey: .relationships)
     }
 
     /// An empty document — the default before the clinician authors anything.
@@ -239,9 +271,11 @@ struct OverlayComposition: Equatable, Codable, Sendable {
         layers[index] = layer
     }
 
-    /// Remove a layer.
+    /// Remove a layer. Any relationship touching it is dropped too, so the
+    /// knowledge-graph edge set can never dangle onto a node that no longer exists.
     mutating func removeLayer(_ id: String) {
         layers.removeAll { $0.id == id }
+        relationships.removeAll { $0.fromLayerID == id || $0.toLayerID == id }
     }
 
     /// Remove a group; its layers become ungrouped (never silently deleted).
@@ -322,6 +356,23 @@ struct OverlayComposition: Equatable, Codable, Sendable {
                     actionLaneIndex: 0,
                     groupID: outpatient.id
                 ),
+            ],
+            // A couple of illustrative edges so the knowledge graph — and its mermaid
+            // rendering — show relationships out of the box. Generic workflow order,
+            // no real screen, no PHI.
+            relationships: [
+                OverlayRelationship(
+                    id: "rel-open-to-set",
+                    fromLayerID: "layer-open-orders",
+                    toLayerID: "layer-order-set",
+                    kind: .navigatesTo
+                ),
+                OverlayRelationship(
+                    id: "rel-set-to-sign",
+                    fromLayerID: "layer-order-set",
+                    toLayerID: "layer-sign",
+                    kind: .precedes
+                ),
             ]
         )
     }
@@ -386,6 +437,13 @@ final class OverlayCompositionSession: ObservableObject {
     @Published private(set) var composition: OverlayComposition
     /// The authored layer currently selected in the panel (for edit / highlight).
     @Published var selectedLayerID: String?
+    /// The editable mermaid rendering of the graph, shown in the "What I've learned"
+    /// panel. Two-way: it is regenerated from the model after every mutation, and the
+    /// owner's edits are committed back via `applyMermaid()`.
+    @Published var mermaidDraft: String = ""
+    /// The message from the last failed `applyMermaid()`, or `nil` when the text is
+    /// clean. A failed import never mutates the model — this is the only side effect.
+    @Published private(set) var mermaidError: String?
 
     private let store: OverlayCompositionStore?
 
@@ -395,8 +453,10 @@ final class OverlayCompositionSession: ObservableObject {
     ) {
         // A saved document wins over the seed; otherwise use the provided initial
         // composition (the app seeds `.starter`, tests pass their own).
-        self.composition = store?.load() ?? composition
+        let initial = store?.load() ?? composition
+        self.composition = initial
         self.store = store
+        self.mermaidDraft = initial.mermaidExport()
     }
 
     var selectedLayer: OverlayLayer? {
@@ -464,6 +524,56 @@ final class OverlayCompositionSession: ObservableObject {
 
     func select(_ id: String?) { selectedLayerID = id }
 
+    // MARK: Relationships (knowledge-graph edges)
+
+    /// The plain-statement narration of the graph for the "What I've learned" view.
+    var learnedStatements: [String] { composition.learnedStatements }
+
+    /// Link two authored overlays with a typed relationship. Returns `nil` when the
+    /// endpoints are invalid (missing or identical).
+    @discardableResult
+    func addRelationship(
+        from: String,
+        to: String,
+        kind: OverlayRelationshipKind
+    ) -> OverlayRelationship? {
+        var created: OverlayRelationship?
+        mutate { created = $0.addRelationship(from: from, to: to, kind: kind) }
+        return created
+    }
+
+    func removeRelationship(_ id: String) { mutate { $0.removeRelationship(id) } }
+    func updateRelationship(_ relationship: OverlayRelationship) {
+        mutate { $0.updateRelationship(relationship) }
+    }
+
+    // MARK: Mermaid two-way bridge
+
+    /// Re-render the editable mermaid text from the current model, discarding any
+    /// uncommitted edits. The panel's "Refresh from graph" affordance.
+    func refreshMermaidFromModel() {
+        mermaidDraft = composition.mermaidExport()
+        mermaidError = nil
+    }
+
+    /// Commit the owner's edited mermaid text to the model. On success the composition
+    /// is replaced, persisted, and the text re-canonicalized; on failure the model is
+    /// left untouched and `mermaidError` is set (fail-safe — a bad edit never corrupts
+    /// the authored graph).
+    func applyMermaid() {
+        switch composition.applyingMermaid(mermaidDraft) {
+        case .success(let updated):
+            composition = updated
+            if let selected = selectedLayerID, composition.layer(withID: selected) == nil {
+                selectedLayerID = nil
+            }
+            mermaidError = nil
+            persist()  // persists AND regenerates the canonical mermaid text
+        case .failure(let error):
+            mermaidError = error.description
+        }
+    }
+
     private func mutate(_ transform: (inout OverlayComposition) -> Void) {
         transform(&composition)
         persist()
@@ -471,5 +581,9 @@ final class OverlayCompositionSession: ObservableObject {
 
     private func persist() {
         try? store?.save(composition)
+        // Keep the editable mermaid text a faithful mirror of the model after every
+        // structural change (authoring, visibility, reorder, relationship edits).
+        mermaidDraft = composition.mermaidExport()
+        mermaidError = nil
     }
 }

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayersPanel.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerLayersPanel.swift
@@ -349,3 +349,119 @@ struct ScreenTrainerLayersPanel: View {
         showAddForm = false
     }
 }
+
+// MARK: - "What I've learned" panel (statements + editable mermaid)
+
+/// The knowledge-graph view the owner asked for: what the trainer has learned about
+/// the EHR UI, shown BOTH as plain statements ("Open orders tab navigates to Admission
+/// order set") AND as an editable mermaid graph he can visualize and hand-edit. Apply
+/// commits the edited mermaid back into the semantic model; a bad edit is rejected with
+/// a message and never corrupts the graph. Reuses the Layers panel's styling. The live
+/// overlay uses the editable `TextEditor`; the headless demo renders the mermaid as
+/// static text (SwiftUI editors do not rasterize offscreen).
+struct LearnedGraphPanel: View {
+    @ObservedObject var session: OverlayCompositionSession
+    var interactive: Bool = true
+
+    private var composition: OverlayComposition { session.composition }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            statements
+            Divider().overlay(Color.white.opacity(0.15))
+            mermaidSection
+            phiFootnote
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.black.opacity(0.80))
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "brain.head.profile").font(.system(size: 10))
+            Text("WHAT I'VE LEARNED")
+                .font(.system(size: 9, weight: .bold))
+            Spacer()
+            Text("\(composition.layers.count) nodes · \(composition.relationships.count) links")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    @ViewBuilder
+    private var statements: some View {
+        let lines = session.learnedStatements
+        if lines.isEmpty {
+            Text("Nothing yet. Author overlays and link them (e.g. a tab houses a button) "
+                + "to build the graph.")
+                .font(.system(size: 10))
+                .foregroundStyle(.white.opacity(0.55))
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                    HStack(alignment: .top, spacing: 5) {
+                        Text("•").foregroundStyle(.white.opacity(0.5))
+                        Text(line)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.white.opacity(0.85))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var mermaidSection: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "point.3.connected.trianglepath.dotted").font(.system(size: 10))
+            Text("MERMAID — edit the graph, then Apply")
+                .font(.system(size: 9, weight: .bold))
+            Spacer()
+        }
+        .foregroundStyle(.white.opacity(0.85))
+
+        if interactive {
+            TextEditor(text: $session.mermaidDraft)
+                .font(.system(size: 10, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 120, maxHeight: 220)
+                .padding(6)
+                .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+            HStack(spacing: 8) {
+                Button("Apply edits") { session.applyMermaid() }
+                    .controlSize(.small)
+                Button("Refresh from graph") { session.refreshMermaidFromModel() }
+                    .controlSize(.small)
+                Spacer()
+            }
+            if let error = session.mermaidError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            Text(session.mermaidDraft)
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.8))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(6)
+                .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private var phiFootnote: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark.shield.fill").font(.system(size: 9))
+            Text("The graph stores only your labels, purposes & relationship types — "
+                + "on-device, never PHI.")
+                .font(.system(size: 9))
+        }
+        .foregroundStyle(.green.opacity(0.7))
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerMermaid.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerMermaid.swift
@@ -1,0 +1,753 @@
+import Foundation
+
+// MARK: - Screen Trainer knowledge-graph: typed relationships + mermaid round-trip
+//
+// The layer system (`ScreenTrainerLayers.swift`, slice from #72) gives the owner the
+// NODES of a semantic knowledge-graph of the EHR UI: each authored `OverlayLayer` is
+// a component with a label, a purpose, an action-lane slot, and a clinical-context
+// group. This file adds the EDGES — typed relationships between those nodes (a tab
+// HOUSES a button, a link NAVIGATES TO a screen, an order set PRECEDES a signature) —
+// and makes the whole graph expressible AND editable as mermaid text.
+//
+// The owner's explicit ask: "when it tells me what it's learning, that goes in a
+// 'what I've learned' area — originally as a statement and as `a tab -(houses)-> b
+// button` or some mermaid-metadata language I can quickly visualize and edit." So the
+// composition can be rendered to mermaid, hand-edited, and imported back — a two-way
+// bridge between the value model and a diagram the owner reads and edits.
+//
+// PHI BOUNDARY (absolute, identical to the rest of the Screen Trainer): a relationship
+// carries only two layer IDs and a relationship KIND — a content-free classification
+// the owner chooses. The mermaid rendering carries only the owner's labels, purposes,
+// group names, and relationship kinds. No frame, no pixels, no screen text, no patient
+// value ever appears here or in the exported text.
+
+// MARK: - Relationship kind (the extensible edge vocabulary)
+
+/// The TYPE of a relationship between two authored overlays — the edge label in the
+/// knowledge graph and in the exported mermaid (`a -->|houses| b`).
+///
+/// Modeled as an extensible token rather than a closed enum so the clinician can coin
+/// new clinical-UI relations simply by typing a new edge label in the mermaid text,
+/// and those custom kinds round-trip losslessly. The static constants below are the
+/// well-known vocabulary the picker offers; the set is open by design.
+struct OverlayRelationshipKind: RawRepresentable, Codable, Sendable, Hashable, CustomStringConvertible {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = OverlayRelationshipKind.normalize(rawValue)
+    }
+
+    /// Normalize a coined kind to a single mermaid-safe edge token: trim, collapse
+    /// internal whitespace to single spaces, and strip the characters that would break
+    /// a mermaid edge label (`|`, quotes, brackets, angle brackets, newlines). A kind
+    /// that normalizes to empty falls back to `related`.
+    static func normalize(_ raw: String) -> String {
+        let banned: Set<Character> = ["|", "\"", "[", "]", "{", "}", "<", ">", "\n", "\r", "\t"]
+        let cleaned = raw.filter { !banned.contains($0) }
+        let collapsed = cleaned
+            .split(whereSeparator: { $0 == " " })
+            .joined(separator: " ")
+        return collapsed.isEmpty ? "related" : collapsed
+    }
+
+    // Well-known clinical-UI relations. OPEN vocabulary — new kinds are allowed.
+    static let houses = OverlayRelationshipKind(rawValue: "houses")            // contains / holds
+    static let navigatesTo = OverlayRelationshipKind(rawValue: "navigatesTo")  // links to a screen
+    static let opens = OverlayRelationshipKind(rawValue: "opens")              // reveals a panel/dialog
+    static let triggers = OverlayRelationshipKind(rawValue: "triggers")        // fires an action
+    static let partOf = OverlayRelationshipKind(rawValue: "partOf")            // membership
+    static let precedes = OverlayRelationshipKind(rawValue: "precedes")        // workflow order
+    static let related = OverlayRelationshipKind(rawValue: "related")          // generic fallback
+
+    /// The kinds the authoring UI offers by default. Not exhaustive — the owner may
+    /// type any other kind into the mermaid text.
+    static let wellKnown: [OverlayRelationshipKind] =
+        [.houses, .navigatesTo, .opens, .triggers, .partOf, .precedes, .related]
+
+    var description: String { rawValue }
+
+    /// A natural-language phrase for the plain-statement view, e.g. "navigates to".
+    var displayPhrase: String {
+        switch self {
+        case .houses: return "houses"
+        case .navigatesTo: return "navigates to"
+        case .opens: return "opens"
+        case .triggers: return "triggers"
+        case .partOf: return "is part of"
+        case .precedes: return "precedes"
+        case .related: return "relates to"
+        default: return OverlayRelationshipKind.humanize(rawValue)
+        }
+    }
+
+    /// Split a camelCase / underscored / hyphenated token into spaced lowercase words
+    /// for display: `navigatesTo` -> "navigates to", `escalates_to` -> "escalates to".
+    static func humanize(_ token: String) -> String {
+        var words: [String] = []
+        var current = ""
+        for ch in token {
+            if ch == "_" || ch == "-" || ch == " " {
+                if !current.isEmpty { words.append(current); current = "" }
+            } else if ch.isUppercase, !current.isEmpty {
+                words.append(current)
+                current = String(ch).lowercased()
+            } else {
+                current.append(ch)
+            }
+        }
+        if !current.isEmpty { words.append(current) }
+        return words.isEmpty ? token : words.joined(separator: " ")
+    }
+
+    // Codable as a bare string so the persisted document stays clean (`"kind": "houses"`).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(rawValue: try container.decode(String.self))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+// MARK: - Overlay relationship (one knowledge-graph edge)
+
+/// A typed, directed edge between two authored overlays. It is the atom of the
+/// knowledge-graph edge set: which node it starts at (`fromLayerID`), which it points
+/// to (`toLayerID`), and WHAT the relationship is (`kind`). Content-free — only IDs
+/// and a kind, persisted alongside the nodes.
+struct OverlayRelationship: Identifiable, Equatable, Codable, Sendable {
+    let id: String
+    var fromLayerID: String
+    var toLayerID: String
+    var kind: OverlayRelationshipKind
+
+    init(
+        id: String = OverlayRelationship.newID(),
+        fromLayerID: String,
+        toLayerID: String,
+        kind: OverlayRelationshipKind
+    ) {
+        self.id = id
+        self.fromLayerID = fromLayerID
+        self.toLayerID = toLayerID
+        self.kind = kind
+    }
+
+    static func newID() -> String { "rel-\(UUID().uuidString.prefix(8))" }
+}
+
+// MARK: - Relationship mutations on the composition (pure value functions)
+
+extension OverlayComposition {
+    // MARK: Lookups
+
+    func relationship(withID id: String) -> OverlayRelationship? {
+        relationships.first { $0.id == id }
+    }
+
+    func relationships(from layerID: String) -> [OverlayRelationship] {
+        relationships.filter { $0.fromLayerID == layerID }
+    }
+
+    func relationships(to layerID: String) -> [OverlayRelationship] {
+        relationships.filter { $0.toLayerID == layerID }
+    }
+
+    func layerExists(_ id: String) -> Bool {
+        layers.contains { $0.id == id }
+    }
+
+    /// Whether a relationship's two endpoints both resolve to real, distinct layers.
+    func canRelate(from: String, to: String) -> Bool {
+        from != to && layerExists(from) && layerExists(to)
+    }
+
+    /// Whether a relationship's endpoints both still exist (used to prune after edits).
+    func endpointsExist(_ relationship: OverlayRelationship) -> Bool {
+        layerExists(relationship.fromLayerID) && layerExists(relationship.toLayerID)
+    }
+
+    // MARK: Mutations (all pure — mutate this value)
+
+    /// Add a typed edge. Validates the endpoints exist and are distinct; an identical
+    /// `(from, to, kind)` edge is de-duplicated (the existing one is returned), so the
+    /// graph and its deterministic export stay stable. Returns `nil` for invalid
+    /// endpoints.
+    @discardableResult
+    mutating func addRelationship(
+        from: String,
+        to: String,
+        kind: OverlayRelationshipKind,
+        id: String = OverlayRelationship.newID()
+    ) -> OverlayRelationship? {
+        guard canRelate(from: from, to: to) else { return nil }
+        if let existing = relationships.first(where: {
+            $0.fromLayerID == from && $0.toLayerID == to && $0.kind == kind
+        }) {
+            return existing
+        }
+        let relationship = OverlayRelationship(id: id, fromLayerID: from, toLayerID: to, kind: kind)
+        relationships.append(relationship)
+        return relationship
+    }
+
+    /// Remove an edge by id.
+    mutating func removeRelationship(_ id: String) {
+        relationships.removeAll { $0.id == id }
+    }
+
+    /// Edit an existing edge (re-point or re-type it). No-op when the id is unknown or
+    /// the new endpoints are invalid, so an edit can never introduce a dangling edge.
+    mutating func updateRelationship(_ relationship: OverlayRelationship) {
+        guard let index = relationships.firstIndex(where: { $0.id == relationship.id }) else { return }
+        guard canRelate(from: relationship.fromLayerID, to: relationship.toLayerID) else { return }
+        relationships[index] = relationship
+    }
+
+    /// Drop any edge whose endpoints no longer exist — the invariant restore after a
+    /// bulk edit (e.g. import) or external mutation.
+    mutating func pruneDanglingRelationships() {
+        let liveIDs = Set(layers.map(\.id))
+        relationships.removeAll { !(liveIDs.contains($0.fromLayerID) && liveIDs.contains($0.toLayerID)) }
+    }
+
+    /// Every edge in a deterministic, position-independent order: by source node
+    /// token, then target node token, then kind. Used by the export and the statement
+    /// view so both are stable regardless of insertion or array order.
+    var orderedRelationships: [OverlayRelationship] {
+        relationships.sorted { lhs, rhs in
+            let lf = OverlayComposition.mermaidToken(lhs.fromLayerID)
+            let rf = OverlayComposition.mermaidToken(rhs.fromLayerID)
+            if lf != rf { return lf < rf }
+            let lt = OverlayComposition.mermaidToken(lhs.toLayerID)
+            let rt = OverlayComposition.mermaidToken(rhs.toLayerID)
+            if lt != rt { return lt < rt }
+            return lhs.kind.rawValue < rhs.kind.rawValue
+        }
+    }
+
+    // MARK: Plain-statement narration ("what I've learned")
+
+    /// The knowledge graph narrated as plain English statements — the "originally as a
+    /// statement" half of the What-I've-learned view. One line per edge (`Open orders
+    /// tab navigates to Admission order set`), then a line per node with no incident
+    /// edge so authored-but-unconnected overlays are never invisible.
+    var learnedStatements: [String] {
+        var out: [String] = []
+        for relationship in orderedRelationships {
+            guard let from = layer(withID: relationship.fromLayerID),
+                  let to = layer(withID: relationship.toLayerID) else { continue }
+            out.append("\(from.label) \(relationship.kind.displayPhrase) \(to.label)")
+        }
+        let connected = Set(relationships.flatMap { [$0.fromLayerID, $0.toLayerID] })
+        for layer in layers where !connected.contains(layer.id) {
+            if layer.purpose.isEmpty {
+                out.append(layer.label)
+            } else {
+                out.append("\(layer.label) — \(layer.purpose)")
+            }
+        }
+        return out
+    }
+}
+
+// MARK: - Mermaid: shared tokens + label escaping
+
+extension OverlayComposition {
+    /// The stable header the export always emits and the import requires.
+    static let mermaidHeader = "flowchart TD"
+
+    /// A mermaid-safe node / subgraph identifier derived from an internal ID. Only
+    /// non-`[A-Za-z0-9_]` characters are mapped to `_`; because our IDs differ solely
+    /// in their alphanumeric suffix, this is injective over a composition's IDs — which
+    /// is exactly what lets import match a node back to its layer, and thus makes
+    /// export -> import -> export a stable round-trip.
+    static func mermaidToken(_ id: String) -> String {
+        let mapped = id.map { ch -> Character in
+            (ch.isLetter || ch.isNumber || ch == "_") ? ch : "_"
+        }
+        let token = String(mapped)
+        return token.isEmpty ? "n" : token
+    }
+
+    /// Whether a string is a bare mermaid identifier: non-empty and only `[A-Za-z0-9_]`.
+    static func isMermaidToken(_ s: String) -> Bool {
+        !s.isEmpty && s.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+    }
+
+    /// Reversibly escape a label for a mermaid `["..."]` node body. `#` is escaped
+    /// first (and unescaped last) so the entity replacements can never collide with a
+    /// literal `#…;` sequence in the label. For ordinary labels this is the identity.
+    static func escapeLabel(_ s: String) -> String {
+        var out = s.replacingOccurrences(of: "\n", with: " ")
+        out = out.replacingOccurrences(of: "\r", with: " ")
+        out = out.replacingOccurrences(of: "#", with: "#35;")
+        out = out.replacingOccurrences(of: "\"", with: "#quot;")
+        out = out.replacingOccurrences(of: "[", with: "#91;")
+        out = out.replacingOccurrences(of: "]", with: "#93;")
+        out = out.replacingOccurrences(of: "|", with: "#124;")
+        // Escape angle brackets so a label can never spell an arrow (`-->`), which
+        // would otherwise make a node line parse as an edge.
+        out = out.replacingOccurrences(of: "<", with: "#60;")
+        out = out.replacingOccurrences(of: ">", with: "#62;")
+        return out
+    }
+
+    static func unescapeLabel(_ s: String) -> String {
+        var out = s.replacingOccurrences(of: "#quot;", with: "\"")
+        out = out.replacingOccurrences(of: "#91;", with: "[")
+        out = out.replacingOccurrences(of: "#93;", with: "]")
+        out = out.replacingOccurrences(of: "#124;", with: "|")
+        out = out.replacingOccurrences(of: "#60;", with: "<")
+        out = out.replacingOccurrences(of: "#62;", with: ">")
+        out = out.replacingOccurrences(of: "#35;", with: "#")
+        return out
+    }
+
+    /// Whether a line carries an edge arrow OUTSIDE any `[...]` label span. Used to
+    /// classify a line as an edge vs a node declaration, so a label that happens to
+    /// contain `-->` or `---` does not masquerade as an edge.
+    static func hasEdgeArrow(_ line: String) -> Bool {
+        var skeleton = ""
+        var depth = 0
+        for ch in line {
+            if ch == "[" { depth += 1; continue }
+            if ch == "]" { if depth > 0 { depth -= 1 }; continue }
+            if depth == 0 { skeleton.append(ch) }
+        }
+        return skeleton.contains("-->") || skeleton.contains("---")
+    }
+
+    /// Collapse a purpose to a single line for a `%%` comment (comments run to EOL, so
+    /// no other escaping is required).
+    static func sanitizeComment(_ s: String) -> String {
+        s.replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+
+    /// Lane-sort a set of layers deterministically: by action-lane slot, ties broken by
+    /// node token (position-independent, so the order survives array reordering).
+    private func laneSorted(_ list: [OverlayLayer]) -> [OverlayLayer] {
+        list.sorted { a, b in
+            if a.actionLaneIndex != b.actionLaneIndex { return a.actionLaneIndex < b.actionLaneIndex }
+            return OverlayComposition.mermaidToken(a.id) < OverlayComposition.mermaidToken(b.id)
+        }
+    }
+}
+
+// MARK: - Mermaid export (deterministic, stable)
+
+extension OverlayComposition {
+    /// Render the whole composition to mermaid `flowchart` text. Nodes are authored
+    /// overlays (label carried in the node body, purpose + hidden state carried as
+    /// structured `%%` comments — mermaid has no native node metadata). Groups become
+    /// subgraphs. Relationships become labeled edges (`a -->|houses| b`). The action-
+    /// lane order is reflected both by node ordering within each subgraph and by a
+    /// trailing note. Output is fully deterministic: no timestamps, no randomness, and
+    /// every collection is emitted in a stable, position-independent order.
+    func mermaidExport() -> String {
+        var lines: [String] = []
+        lines.append(OverlayComposition.mermaidHeader)
+        lines.append("%% Screen Trainer knowledge graph — PHI-free: labels, purposes & relations only.")
+        lines.append("%% Node = authored overlay · subgraph = clinical-context group · edge label = relationship kind.")
+
+        func nodeLine(_ layer: OverlayLayer, indent: String) -> String {
+            "\(indent)\(OverlayComposition.mermaidToken(layer.id))[\"\(OverlayComposition.escapeLabel(layer.label))\"]"
+        }
+
+        // Nodes, grouped into subgraphs in group order; each group's nodes lane-sorted.
+        for group in groups {
+            lines.append(
+                "subgraph \(OverlayComposition.mermaidToken(group.id))[\"\(OverlayComposition.escapeLabel(group.name))\"]"
+            )
+            for layer in laneSorted(layers(inGroup: group.id)) {
+                lines.append(nodeLine(layer, indent: "  "))
+            }
+            lines.append("end")
+        }
+        // Ungrouped nodes at the top level, lane-sorted.
+        for layer in laneSorted(layers(inGroup: nil)) {
+            lines.append(nodeLine(layer, indent: ""))
+        }
+
+        // Node metadata carried as structured comments so it round-trips.
+        for group in groups where !group.visible {
+            lines.append("%% group-hidden \(OverlayComposition.mermaidToken(group.id))")
+        }
+        for layer in layers.sorted(by: {
+            OverlayComposition.mermaidToken($0.id) < OverlayComposition.mermaidToken($1.id)
+        }) {
+            let token = OverlayComposition.mermaidToken(layer.id)
+            if !layer.purpose.isEmpty {
+                lines.append("%% purpose \(token): \(OverlayComposition.sanitizeComment(layer.purpose))")
+            }
+            if !layer.visible {
+                lines.append("%% hidden \(token)")
+            }
+        }
+
+        // Edges, deterministically ordered.
+        for relationship in orderedRelationships {
+            guard let from = layer(withID: relationship.fromLayerID),
+                  let to = layer(withID: relationship.toLayerID) else { continue }
+            let fromToken = OverlayComposition.mermaidToken(from.id)
+            let toToken = OverlayComposition.mermaidToken(to.id)
+            lines.append("\(fromToken) -->|\(relationship.kind.rawValue)| \(toToken)")
+        }
+
+        // Action-lane order as a non-authoritative note (the workflow click-sequence).
+        let lane = laneSorted(layers)
+        if !lane.isEmpty {
+            let sequence = lane.map { OverlayComposition.mermaidToken($0.id) }.joined(separator: " -> ")
+            lines.append("%% action-lane order: \(sequence)")
+        }
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+}
+
+// MARK: - Mermaid import (fail-safe, merge onto the current model)
+
+/// Why an edited mermaid graph could not be parsed. On any failure the model is left
+/// exactly as it was — a bad edit never corrupts the authored composition.
+enum OverlayMermaidError: Error, Equatable, CustomStringConvertible {
+    case empty
+    case notAGraph
+    case unbalancedSubgraph
+    case malformedEdge(String)
+    case malformedNode(String)
+
+    var description: String {
+        switch self {
+        case .empty:
+            return "Nothing to import — the mermaid text is empty."
+        case .notAGraph:
+            return "Not a mermaid graph — the first line must be `flowchart TD` or `graph TD`."
+        case .unbalancedSubgraph:
+            return "Unbalanced subgraph — every `subgraph` needs a matching `end`."
+        case .malformedEdge(let line):
+            return "Could not read an edge: \"\(line)\". Expected `a -->|kind| b`."
+        case .malformedNode(let line):
+            return "Could not read a node: \"\(line)\". Node ids may use letters, digits, and `_`."
+        }
+    }
+}
+
+extension OverlayComposition {
+    /// Parse an edited mermaid graph and MERGE it onto this composition, returning a
+    /// new composition on success or a specific error on failure (the receiver is
+    /// never mutated).
+    ///
+    /// Merge semantics, matching the owner's "edit the graph as text" mental model:
+    /// - nodes are matched to existing layers by their token, so renames, re-grouping,
+    ///   and purpose edits update in place; brand-new node ids create new layers;
+    /// - existing layers keep their normalized rect and action-lane slot (geometry and
+    ///   ordering are authored in the panel, not the text);
+    /// - the edge set becomes exactly the edges in the text (add / remove / relabel),
+    ///   with an unchanged edge keeping its id so applies don't churn.
+    ///
+    /// Robust to a reasonable subset of mermaid: `graph`/`flowchart` headers, quoted or
+    /// bare node labels, subgraphs, `-->` / `---` edges with optional `|label|` or
+    /// `-- label -->` labels, and unmodeled directives (`classDef`, `style`, `click`,
+    /// `direction`, `%%{…}%%`) which are ignored rather than rejected.
+    func applyingMermaid(_ text: String) -> Result<OverlayComposition, OverlayMermaidError> {
+        let rawLines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let trimmedLines = rawLines.map { $0.trimmingCharacters(in: .whitespaces) }
+        guard trimmedLines.contains(where: { !$0.isEmpty }) else { return .failure(.empty) }
+
+        // Accumulators built in a single pass.
+        var orderedNodeTokens: [String] = []
+        var seenNode = Set<String>()
+        var nodeLabels: [String: String] = [:]
+        var nodeGroupToken: [String: String?] = [:]
+        var nodePurpose: [String: String] = [:]
+        var nodeHidden = Set<String>()
+        var groupOrder: [String] = []
+        var seenGroup = Set<String>()
+        var groupTitles: [String: String] = [:]
+        var groupHidden = Set<String>()
+        var edges: [(from: String, label: String?, to: String)] = []
+
+        var groupStack: [String] = []
+        var headerSeen = false
+
+        // A directive we recognize as valid mermaid but do not model — ignored, so a
+        // pasted graph with styling never fails to import.
+        let ignoredPrefixes = ["classdef", "class ", "style ", "linkstyle", "click ", "direction ", "%%{"]
+
+        func registerNode(token: String, label: String?) {
+            if !seenNode.contains(token) {
+                seenNode.insert(token)
+                orderedNodeTokens.append(token)
+                nodeGroupToken[token] = groupStack.last  // group context at first sight
+            }
+            if let label, !label.isEmpty { nodeLabels[token] = label }
+        }
+
+        for line in trimmedLines {
+            if line.isEmpty { continue }
+
+            // Structured / ignorable comments.
+            if line.hasPrefix("%%") {
+                let body = line.dropFirst(2).trimmingCharacters(in: .whitespaces)
+                if body.hasPrefix("purpose ") {
+                    let rest = body.dropFirst("purpose ".count)
+                    if let colon = rest.firstIndex(of: ":") {
+                        let token = String(rest[..<colon]).trimmingCharacters(in: .whitespaces)
+                        let value = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+                        if !token.isEmpty { nodePurpose[token] = value }
+                    }
+                } else if body.hasPrefix("hidden ") {
+                    let token = String(body.dropFirst("hidden ".count)).trimmingCharacters(in: .whitespaces)
+                    if !token.isEmpty { nodeHidden.insert(token) }
+                } else if body.hasPrefix("group-hidden ") {
+                    let token = String(body.dropFirst("group-hidden ".count)).trimmingCharacters(in: .whitespaces)
+                    if !token.isEmpty { groupHidden.insert(token) }
+                }
+                continue  // all other comments (banner, action-lane note) are ignored
+            }
+
+            let lower = line.lowercased()
+            if ignoredPrefixes.contains(where: { lower.hasPrefix($0) }) { continue }
+
+            // The first meaningful line must be a graph header.
+            if !headerSeen {
+                if lower.hasPrefix("graph") || lower.hasPrefix("flowchart") {
+                    headerSeen = true
+                    continue
+                }
+                return .failure(.notAGraph)
+            }
+
+            if lower == "end" {
+                if groupStack.isEmpty { return .failure(.unbalancedSubgraph) }
+                groupStack.removeLast()
+                continue
+            }
+
+            if lower.hasPrefix("subgraph") {
+                guard let sub = OverlayComposition.parseSubgraph(line) else {
+                    return .failure(.malformedNode(line))
+                }
+                if !seenGroup.contains(sub.token) {
+                    seenGroup.insert(sub.token)
+                    groupOrder.append(sub.token)
+                    groupTitles[sub.token] = sub.title
+                } else if !sub.title.isEmpty {
+                    groupTitles[sub.token] = sub.title
+                }
+                groupStack.append(sub.token)
+                continue
+            }
+
+            // Edge (arrow outside any label) vs node declaration.
+            if OverlayComposition.hasEdgeArrow(line) {
+                guard let parsed = OverlayComposition.parseEdge(line),
+                      let fromNode = OverlayComposition.parseNode(parsed.from),
+                      let toNode = OverlayComposition.parseNode(parsed.to) else {
+                    return .failure(.malformedEdge(line))
+                }
+                registerNode(token: fromNode.token, label: fromNode.label)
+                registerNode(token: toNode.token, label: toNode.label)
+                edges.append((from: fromNode.token, label: parsed.label, to: toNode.token))
+                continue
+            }
+
+            // Node declaration.
+            guard let node = OverlayComposition.parseNode(line) else {
+                return .failure(.malformedNode(line))
+            }
+            registerNode(token: node.token, label: node.label)
+        }
+
+        guard headerSeen else { return .failure(.notAGraph) }
+        guard groupStack.isEmpty else { return .failure(.unbalancedSubgraph) }
+
+        // ---- Build the merged composition -------------------------------------------
+
+        var layersByToken: [String: OverlayLayer] = [:]
+        for layer in layers { layersByToken[OverlayComposition.mermaidToken(layer.id)] = layer }
+        var groupsByToken: [String: OverlayGroup] = [:]
+        var groupsByNameToken: [String: OverlayGroup] = [:]
+        for group in groups {
+            groupsByToken[OverlayComposition.mermaidToken(group.id)] = group
+            groupsByNameToken[OverlayComposition.mermaidToken(group.name)] = group
+        }
+
+        // Groups first, so nodes can resolve their group id.
+        var resultGroups: [OverlayGroup] = []
+        var groupIDForToken: [String: String] = [:]
+        for token in groupOrder {
+            let title = groupTitles[token] ?? ""
+            let visible = !groupHidden.contains(token)
+            let existing = groupsByToken[token] ?? groupsByNameToken[OverlayComposition.mermaidToken(title)]
+            let resolved: OverlayGroup
+            if let existing {
+                resolved = OverlayGroup(
+                    id: existing.id,
+                    name: title.isEmpty ? existing.name : title,
+                    visible: visible
+                )
+            } else {
+                resolved = OverlayGroup(
+                    id: OverlayGroup.newID(),
+                    name: title.isEmpty ? token : title,
+                    visible: visible
+                )
+            }
+            resultGroups.append(resolved)
+            groupIDForToken[token] = resolved.id
+        }
+
+        var resultLayers: [OverlayLayer] = []
+        var layerIDForToken: [String: String] = [:]
+        var newLaneCursor = (layers.map(\.actionLaneIndex).max() ?? -1) + 1
+        for token in orderedNodeTokens {
+            let explicitLabel = nodeLabels[token]
+            let resolvedGroupID = (nodeGroupToken[token] ?? nil).flatMap { groupIDForToken[$0] }
+            let hidden = nodeHidden.contains(token)
+            if let existing = layersByToken[token] {
+                var updated = existing
+                if let label = explicitLabel, !label.isEmpty { updated.label = label }
+                updated.groupID = resolvedGroupID
+                updated.purpose = nodePurpose[token] ?? ""
+                updated.visible = !hidden
+                resultLayers.append(updated)
+                layerIDForToken[token] = updated.id
+            } else {
+                let label = (explicitLabel?.isEmpty == false) ? explicitLabel! : OverlayRelationshipKind.humanize(token)
+                let created = OverlayLayer(
+                    label: label,
+                    purpose: nodePurpose[token] ?? "",
+                    normalizedRect: OverlayComposition.defaultAuthoredRect,
+                    actionLaneIndex: newLaneCursor,
+                    groupID: resolvedGroupID,
+                    visible: !hidden
+                )
+                newLaneCursor += 1
+                resultLayers.append(created)
+                layerIDForToken[token] = created.id
+            }
+        }
+
+        // Edges become exactly the parsed set. An unchanged edge keeps its id so
+        // applying the same graph twice does not churn the model.
+        var resultRelationships: [OverlayRelationship] = []
+        var seenEdgeKey = Set<String>()
+        for edge in edges {
+            guard let fromID = layerIDForToken[edge.from], let toID = layerIDForToken[edge.to],
+                  fromID != toID else { continue }
+            let kind = OverlayRelationshipKind(rawValue: edge.label ?? OverlayRelationshipKind.related.rawValue)
+            let key = "\(fromID)|\(toID)|\(kind.rawValue)"
+            if seenEdgeKey.contains(key) { continue }
+            seenEdgeKey.insert(key)
+            let existing = relationships.first {
+                $0.fromLayerID == fromID && $0.toLayerID == toID && $0.kind == kind
+            }
+            resultRelationships.append(
+                OverlayRelationship(
+                    id: existing?.id ?? OverlayRelationship.newID(),
+                    fromLayerID: fromID,
+                    toLayerID: toID,
+                    kind: kind
+                )
+            )
+        }
+
+        var result = OverlayComposition(
+            groups: resultGroups,
+            layers: resultLayers,
+            relationships: resultRelationships
+        )
+        result.pruneDanglingRelationships()  // belt-and-suspenders; nothing should dangle
+        return .success(result)
+    }
+
+    // MARK: Line parsers
+
+    /// Parse a `subgraph` line into (token, title). Supports `subgraph id["Title"]`,
+    /// `subgraph id[Title]`, `subgraph id`, `subgraph "Title"`, and `subgraph Title`.
+    fileprivate static func parseSubgraph(_ line: String) -> (token: String, title: String)? {
+        var rest = String(line.dropFirst("subgraph".count)).trimmingCharacters(in: .whitespaces)
+        guard !rest.isEmpty else { return (token: "subgraph_anon", title: "") }
+
+        var idPart = rest
+        var title = ""
+        if let bracket = rest.firstIndex(of: "[") {
+            idPart = String(rest[..<bracket]).trimmingCharacters(in: .whitespaces)
+            if rest.hasSuffix("]") {
+                var inner = String(rest[rest.index(after: bracket)..<rest.index(before: rest.endIndex)])
+                    .trimmingCharacters(in: .whitespaces)
+                inner = stripQuotes(inner)
+                title = unescapeLabel(inner)
+            }
+        } else {
+            rest = stripQuotes(rest)
+            idPart = rest
+            title = rest
+        }
+        let token = mermaidToken(idPart.isEmpty ? title : idPart)
+        guard !token.isEmpty else { return nil }
+        return (token, title)
+    }
+
+    /// Parse a node declaration / edge endpoint into (token, optional label). Supports
+    /// `id["Label"]`, `id[Label]`, and a bare `id`.
+    fileprivate static func parseNode(_ raw: String) -> (token: String, label: String?)? {
+        let line = raw.trimmingCharacters(in: .whitespaces)
+        if let bracket = line.firstIndex(of: "["), line.hasSuffix("]") {
+            let token = String(line[..<bracket]).trimmingCharacters(in: .whitespaces)
+            guard isMermaidToken(token) else { return nil }
+            var inner = String(line[line.index(after: bracket)..<line.index(before: line.endIndex)])
+                .trimmingCharacters(in: .whitespaces)
+            inner = stripQuotes(inner)
+            return (token, unescapeLabel(inner))
+        }
+        guard isMermaidToken(line) else { return nil }
+        return (line, nil)
+    }
+
+    /// Parse an edge into (fromRaw, optional kind label, toRaw). Endpoint strings are
+    /// returned raw (they may carry inline `[Label]`s) for `parseNode` to finish.
+    /// Supports `a -->|label| b`, `a --> b`, `a ---|label| b`, `a --- b`, and the
+    /// embedded `a -- label --> b` form.
+    fileprivate static func parseEdge(_ line: String) -> (from: String, label: String?, to: String)? {
+        // Embedded-label form: a -- label --> b
+        if let arrowRange = line.range(of: "-->"),
+           let dashRange = line.range(of: "--"),
+           dashRange.lowerBound < arrowRange.lowerBound {
+            let between = String(line[dashRange.upperBound..<arrowRange.lowerBound])
+                .trimmingCharacters(in: .whitespaces)
+            let from = String(line[..<dashRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let to = String(line[arrowRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+            if !between.isEmpty, !between.contains("|"), !from.isEmpty, !to.isEmpty,
+               !to.hasPrefix("|") {
+                return (from, between, to)
+            }
+        }
+
+        for arrow in ["-->", "---"] {
+            guard let arrowRange = line.range(of: arrow) else { continue }
+            let from = String(line[..<arrowRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            var remainder = String(line[arrowRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+            var label: String?
+            if remainder.hasPrefix("|") {
+                guard let close = remainder.dropFirst().firstIndex(of: "|") else { return nil }
+                label = String(remainder[remainder.index(after: remainder.startIndex)..<close])
+                    .trimmingCharacters(in: .whitespaces)
+                remainder = String(remainder[remainder.index(after: close)...])
+                    .trimmingCharacters(in: .whitespaces)
+            }
+            if from.isEmpty || remainder.isEmpty { return nil }
+            return (from, (label?.isEmpty == true) ? nil : label, remainder)
+        }
+        return nil
+    }
+
+    private static func stripQuotes(_ s: String) -> String {
+        guard s.count >= 2, s.hasPrefix("\""), s.hasSuffix("\"") else { return s }
+        return String(s.dropFirst().dropLast())
+    }
+}

--- a/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
+++ b/prototypes/operations-floater/Sources/OperationsFloater/ScreenTrainerOverlay.swift
@@ -555,6 +555,7 @@ struct ScreenTrainerOverlayView: View {
             correctionBar
             LearningPanel(session: session)
             ScreenTrainerLayersPanel(session: layerSession)
+            LearnedGraphPanel(session: layerSession)
         }
     }
 
@@ -1027,6 +1028,8 @@ struct ScreenTrainerDemoView: View {
                     LearningPanel(session: session, interactive: false)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                     ScreenTrainerLayersPanel(session: layerSession, interactive: false)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    LearnedGraphPanel(session: layerSession, interactive: false)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
                 .frame(width: 360)

--- a/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerMermaidTests.swift
+++ b/prototypes/operations-floater/Tests/OperationsFloaterTests/ScreenTrainerMermaidTests.swift
@@ -1,0 +1,438 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import OperationsFloater
+
+// MARK: - Fixtures (synthetic, PHI-free)
+
+private func rect() -> NormalizedRect { .init(x: 0.1, y: 0.1, width: 0.2, height: 0.1) }
+
+/// A tiny synthetic graph: two contexts, three nodes, two typed edges — enough to
+/// exercise grouping, ordering, and relationships without any real screen or PHI.
+private func sampleComposition() -> OverlayComposition {
+    var c = OverlayComposition()
+    let ctx = c.addGroup(name: "context-a", visible: true, id: "group-ctx")
+    let a = c.addLayer(label: "Alpha tab", purpose: "start here",
+                       normalizedRect: rect(), actionLaneIndex: 0, groupID: ctx.id, id: "layer-a")
+    let b = c.addLayer(label: "Bravo button", purpose: "does the thing",
+                       normalizedRect: rect(), actionLaneIndex: 1, groupID: ctx.id, id: "layer-b")
+    let d = c.addLayer(label: "Delta panel", purpose: "",
+                       normalizedRect: rect(), actionLaneIndex: 2, groupID: nil, id: "layer-d")
+    c.addRelationship(from: a.id, to: b.id, kind: .houses, id: "rel-a-b")
+    c.addRelationship(from: b.id, to: d.id, kind: .opens, id: "rel-b-d")
+    return c
+}
+
+// MARK: - Relationship model
+
+@Suite("Overlay relationship model")
+struct OverlayRelationshipModelTests {
+    @Test("Adding a relationship validates that both endpoints exist and differ")
+    func addValidatesEndpoints() {
+        var c = sampleComposition()
+        // Missing endpoint.
+        #expect(c.addRelationship(from: "layer-a", to: "layer-missing", kind: .opens) == nil)
+        #expect(c.addRelationship(from: "layer-missing", to: "layer-b", kind: .opens) == nil)
+        // Self-loop.
+        #expect(c.addRelationship(from: "layer-a", to: "layer-a", kind: .opens) == nil)
+        // Valid.
+        let ok = c.addRelationship(from: "layer-d", to: "layer-a", kind: .navigatesTo)
+        #expect(ok != nil)
+        #expect(c.relationships.count == 3)
+    }
+
+    @Test("An identical (from,to,kind) edge is de-duplicated")
+    func addDeduplicates() {
+        var c = sampleComposition()
+        let again = c.addRelationship(from: "layer-a", to: "layer-b", kind: .houses)
+        #expect(again?.id == "rel-a-b")     // returns the existing edge
+        #expect(c.relationships.count == 2) // no duplicate appended
+        // A different kind between the same nodes is a distinct edge.
+        _ = c.addRelationship(from: "layer-a", to: "layer-b", kind: .precedes)
+        #expect(c.relationships.count == 3)
+    }
+
+    @Test("Removing and editing edges keeps the endpoints valid")
+    func removeAndUpdate() {
+        var c = sampleComposition()
+        c.removeRelationship("rel-a-b")
+        #expect(c.relationship(withID: "rel-a-b") == nil)
+        #expect(c.relationships.count == 1)
+
+        // Re-point the surviving edge; an invalid re-point is ignored.
+        var edge = c.relationship(withID: "rel-b-d")!
+        edge.kind = .triggers
+        edge.toLayerID = "layer-a"
+        c.updateRelationship(edge)
+        #expect(c.relationship(withID: "rel-b-d")?.kind == .triggers)
+        #expect(c.relationship(withID: "rel-b-d")?.toLayerID == "layer-a")
+
+        var bad = c.relationship(withID: "rel-b-d")!
+        bad.toLayerID = "layer-nope"
+        c.updateRelationship(bad)  // rejected
+        #expect(c.relationship(withID: "rel-b-d")?.toLayerID == "layer-a")
+    }
+
+    @Test("Removing a layer prunes every relationship that touched it")
+    func removeLayerPrunesEdges() {
+        var c = sampleComposition()  // a->b, b->d
+        c.removeLayer("layer-b")
+        // Both edges touched layer-b, so both are gone; no dangling endpoints remain.
+        #expect(c.relationships.isEmpty)
+        #expect(c.layer(withID: "layer-b") == nil)
+    }
+
+    @Test("Pruning drops edges whose endpoints no longer exist")
+    func pruneDangling() {
+        var c = sampleComposition()
+        c.layers.removeAll { $0.id == "layer-d" }  // bypass removeLayer to leave a dangle
+        #expect(c.relationships.count == 2)
+        c.pruneDanglingRelationships()
+        #expect(c.relationships.map(\.id) == ["rel-a-b"])
+    }
+}
+
+@Suite("Relationship kind is an extensible, normalized token")
+struct OverlayRelationshipKindTests {
+    @Test("Normalization trims, collapses whitespace, and strips graph-breaking chars")
+    func normalizes() {
+        #expect(OverlayRelationshipKind(rawValue: "  houses  ").rawValue == "houses")
+        #expect(OverlayRelationshipKind(rawValue: "navigates   to").rawValue == "navigates to")
+        #expect(OverlayRelationshipKind(rawValue: "a|b\"c[d]").rawValue == "abcd")
+        #expect(OverlayRelationshipKind(rawValue: "   ").rawValue == "related")  // empty -> fallback
+    }
+
+    @Test("Custom kinds are allowed and get a humanized display phrase")
+    func customKinds() {
+        let custom = OverlayRelationshipKind(rawValue: "escalatesTo")
+        #expect(custom.rawValue == "escalatesTo")
+        #expect(custom.displayPhrase == "escalates to")
+        #expect(OverlayRelationshipKind.navigatesTo.displayPhrase == "navigates to")
+        #expect(OverlayRelationshipKind.partOf.displayPhrase == "is part of")
+    }
+
+    @Test("Kind serializes as a bare JSON string")
+    func codableBareString() throws {
+        let data = try JSONEncoder().encode(OverlayRelationshipKind.houses)
+        #expect(String(data: data, encoding: .utf8) == "\"houses\"")
+        let back = try JSONDecoder().decode(OverlayRelationshipKind.self, from: data)
+        #expect(back == .houses)
+    }
+}
+
+// MARK: - Mermaid export
+
+@Suite("Mermaid export is deterministic and well-shaped")
+struct MermaidExportTests {
+    @Test("Export is byte-for-byte deterministic")
+    func deterministic() {
+        let c = sampleComposition()
+        #expect(c.mermaidExport() == c.mermaidExport())
+        #expect(OverlayComposition.starter.mermaidExport() == OverlayComposition.starter.mermaidExport())
+    }
+
+    @Test("Export carries header, subgraphs, nodes, labeled edges, and a lane note")
+    func expectedShape() {
+        let text = sampleComposition().mermaidExport()
+        #expect(text.hasPrefix("flowchart TD"))
+        #expect(text.contains("subgraph group_ctx[\"context-a\"]"))
+        #expect(text.contains("end"))
+        #expect(text.contains("layer_a[\"Alpha tab\"]"))
+        #expect(text.contains("layer_d[\"Delta panel\"]"))          // ungrouped node present
+        #expect(text.contains("layer_a -->|houses| layer_b"))       // owner's `a tab houses b button`
+        #expect(text.contains("layer_b -->|opens| layer_d"))
+        #expect(text.contains("%% purpose layer_a: start here"))    // purpose carried as metadata
+        #expect(text.contains("%% action-lane order:"))             // workflow order noted
+    }
+
+    @Test("Grouped nodes appear inside their subgraph, ungrouped at the top level")
+    func groupedSubgraphOutput() {
+        let text = sampleComposition().mermaidExport()
+        let lines = text.split(separator: "\n").map(String.init)
+        let subStart = lines.firstIndex(of: "subgraph group_ctx[\"context-a\"]")!
+        let subEnd = lines[subStart...].firstIndex(of: "end")!
+        let inside = lines[(subStart + 1)..<subEnd]
+        #expect(inside.contains("  layer_a[\"Alpha tab\"]"))
+        #expect(inside.contains("  layer_b[\"Bravo button\"]"))
+        #expect(!inside.contains { $0.contains("layer_d") })  // Delta is ungrouped
+    }
+}
+
+// MARK: - Mermaid import + round-trip
+
+@Suite("Mermaid import round-trips and merges edits")
+struct MermaidImportTests {
+    @Test("export -> import -> export is stable, and merge-onto-self is the identity")
+    func roundTripStable() throws {
+        for c in [sampleComposition(), OverlayComposition.starter] {
+            let m1 = c.mermaidExport()
+            let result = c.applyingMermaid(m1)
+            guard case .success(let c2) = result else {
+                Issue.record("import failed: \(result)")
+                continue
+            }
+            #expect(c2.mermaidExport() == m1)  // textual stability
+            #expect(c2 == c)                   // merge onto self is a no-op
+        }
+    }
+
+    @Test("Importing into an empty model reconstructs nodes, groups, and edges")
+    func importIntoEmpty() throws {
+        let source = sampleComposition()
+        let m1 = source.mermaidExport()
+        guard case .success(let fresh) = OverlayComposition.empty.applyingMermaid(m1) else {
+            Issue.record("import failed"); return
+        }
+        #expect(fresh.layers.count == 3)
+        #expect(fresh.groups.count == 1)
+        #expect(fresh.relationships.count == 2)
+        #expect(Set(fresh.layers.map(\.label)) == ["Alpha tab", "Bravo button", "Delta panel"])
+        #expect(Set(fresh.relationships.map(\.kind.rawValue)) == ["houses", "opens"])
+        #expect(fresh.groups.first?.name == "context-a")
+    }
+
+    @Test("Editing the mermaid renames a node, re-groups it, and edits edges")
+    func editsApply() throws {
+        // The owner's canonical example, hand-written: `a tab houses a button`.
+        let text = """
+        flowchart TD
+        subgraph ctx_one["Orders"]
+          tab["Orders tab"]
+          btn["Sign button"]
+        end
+        tab -->|houses| btn
+        """
+        guard case .success(let c) = OverlayComposition.empty.applyingMermaid(text) else {
+            Issue.record("import failed"); return
+        }
+        #expect(c.layers.count == 2)
+        #expect(c.groups.map(\.name) == ["Orders"])
+        let tab = c.layers.first { $0.label == "Orders tab" }!
+        let btn = c.layers.first { $0.label == "Sign button" }!
+        #expect(c.group(for: tab)?.name == "Orders")
+        #expect(c.group(for: btn)?.name == "Orders")
+        let edge = try #require(c.relationships.first)
+        #expect(edge.fromLayerID == tab.id)
+        #expect(edge.toLayerID == btn.id)
+        #expect(edge.kind == .houses)
+    }
+
+    @Test("Adding and removing edge lines adds and removes relationships")
+    func addAndRemoveEdges() throws {
+        let c = sampleComposition()
+        // Add an edge line.
+        let added = c.mermaidExport() + "layer_a -->|precedes| layer_d\n"
+        guard case .success(let withEdge) = c.applyingMermaid(added) else {
+            Issue.record("add failed"); return
+        }
+        #expect(withEdge.relationships.count == 3)
+        #expect(withEdge.relationships.contains {
+            $0.fromLayerID == "layer-a" && $0.toLayerID == "layer-d" && $0.kind == .precedes
+        })
+
+        // Remove one edge line (the b->d "opens" edge) from the exported text.
+        let pruned = c.mermaidExport()
+            .split(separator: "\n")
+            .filter { $0 != "layer_b -->|opens| layer_d" }
+            .joined(separator: "\n")
+        guard case .success(let withoutEdge) = c.applyingMermaid(pruned) else {
+            Issue.record("remove failed"); return
+        }
+        #expect(withoutEdge.relationships.map(\.id) == ["rel-a-b"])
+    }
+
+    @Test("Visibility (layer + group hidden) round-trips through mermaid")
+    func visibilityRoundTrips() throws {
+        var c = OverlayComposition.starter
+        c.toggleLayer("layer-sign")
+        c.toggleGroup("group-outpatient")
+        let text = c.mermaidExport()
+        #expect(text.contains("%% hidden layer_sign"))
+        #expect(text.contains("%% group-hidden group_outpatient"))
+        guard case .success(let c2) = c.applyingMermaid(text) else {
+            Issue.record("import failed"); return
+        }
+        #expect(c2.layer(withID: "layer-sign")?.visible == false)
+        #expect(c2.group(withID: "group-outpatient")?.visible == false)
+        #expect(c2 == c)
+    }
+}
+
+// MARK: - Malformed input fails safe
+
+@Suite("Malformed mermaid fails safe without corrupting state")
+struct MermaidFailSafeTests {
+    @Test("Specific parse errors are reported and the model is never mutated")
+    func failuresAreClassified() {
+        let base = sampleComposition()
+
+        // Empty / whitespace.
+        #expect(base.applyingMermaid("") == .failure(.empty))
+        #expect(base.applyingMermaid("   \n  ") == .failure(.empty))
+
+        // Missing header.
+        if case .failure(let e) = base.applyingMermaid("tab --> button") {
+            #expect(e == .notAGraph)
+        } else { Issue.record("expected notAGraph") }
+
+        // Malformed edge (no target).
+        if case .failure(let e) = base.applyingMermaid("flowchart TD\na -->") {
+            #expect(e == .malformedEdge("a -->"))
+        } else { Issue.record("expected malformedEdge") }
+
+        // Unbalanced subgraph (no matching end).
+        if case .failure(let e) = base.applyingMermaid("flowchart TD\nsubgraph g[\"x\"]\nn[\"N\"]") {
+            #expect(e == .unbalancedSubgraph)
+        } else { Issue.record("expected unbalancedSubgraph") }
+
+        // Stray `end`.
+        if case .failure(let e) = base.applyingMermaid("flowchart TD\nend") {
+            #expect(e == .unbalancedSubgraph)
+        } else { Issue.record("expected unbalancedSubgraph for stray end") }
+    }
+
+    @Test("A failed apply through the session leaves the composition untouched")
+    @MainActor
+    func sessionApplyIsFailSafe() {
+        let session = OverlayCompositionSession(composition: .starter)
+        let before = session.composition
+        session.mermaidDraft = "this is not a graph"
+        session.applyMermaid()
+        #expect(session.mermaidError != nil)
+        #expect(session.composition == before)  // model preserved on failure
+    }
+
+    @Test("Unmodeled directives (classDef, style, click) are ignored, not rejected")
+    func ignoresUnmodeledDirectives() throws {
+        let text = """
+        flowchart TD
+        classDef ctx fill:#eee
+        n1["Node one"]
+        n2["Node two"]
+        n1 -->|houses| n2
+        click n1 callback
+        style n1 fill:#fff
+        """
+        guard case .success(let c) = OverlayComposition.empty.applyingMermaid(text) else {
+            Issue.record("import failed"); return
+        }
+        #expect(c.layers.count == 2)
+        #expect(c.relationships.count == 1)
+    }
+}
+
+// MARK: - Persistence + PHI boundary
+
+@Suite("Relationships persist PHI-free alongside the composition")
+struct MermaidPersistenceTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-comp-\(UUID().uuidString).json")
+    }
+
+    @Test("A document with relationships round-trips through the store")
+    func storeRoundTrip() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = OverlayCompositionStore(fileURL: url)
+        try store.save(.starter)
+        let loaded = try #require(store.load())
+        #expect(loaded == .starter)
+        #expect(loaded.relationships.count == 2)
+        #expect(loaded.relationships.contains { $0.kind == .navigatesTo })
+    }
+
+    @Test("A pre-relationships document (no relationships key) still decodes")
+    func backwardCompatibleDecode() throws {
+        // Exactly the shape the layer-only slice (#72) wrote — no `relationships`.
+        let json = "{\"groups\":[],\"layers\":[{\"id\":\"layer-x\",\"label\":\"X\",\"purpose\":\"\","
+            + "\"normalizedRect\":{\"x\":0,\"y\":0,\"width\":0.1,\"height\":0.1},"
+            + "\"actionLaneIndex\":0,\"visible\":true}]}"
+        let decoded = try JSONDecoder().decode(OverlayComposition.self, from: Data(json.utf8))
+        #expect(decoded.layers.count == 1)
+        #expect(decoded.relationships.isEmpty)  // defaulted, not a decode failure
+    }
+
+    @Test("The serialized document carries only PHI-free relationship fields")
+    func persistedShapeIsPHIFree() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = OverlayCompositionStore(fileURL: url)
+
+        var neutral = OverlayComposition()
+        let g = neutral.addGroup(name: "context-a")
+        let a = neutral.addLayer(label: "step one", purpose: "advance the workflow",
+                                 normalizedRect: rect(), actionLaneIndex: 0, groupID: g.id)
+        let b = neutral.addLayer(label: "step two", purpose: "finish the workflow",
+                                 normalizedRect: rect(), actionLaneIndex: 1, groupID: g.id)
+        neutral.addRelationship(from: a.id, to: b.id, kind: .precedes)
+        try store.save(neutral)
+
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(text.contains("\"relationships\""))
+        #expect(text.contains("\"fromLayerID\""))
+        #expect(text.contains("\"toLayerID\""))
+        #expect(text.contains("\"kind\""))
+        #expect(text.contains("\"precedes\""))  // kind is a bare string, no PHI
+
+        let lowered = text.lowercased()
+        for banned in ["pixel", "screenshot", "frame", "patient", "mrn", "base64", "\"image\"", "\"text\""] {
+            #expect(!lowered.contains(banned))
+        }
+    }
+}
+
+// MARK: - Session bridge + statements
+
+@Suite("What-I've-learned session bridge")
+struct LearnedGraphSessionTests {
+    @MainActor
+    private func session(_ composition: OverlayComposition) -> (OverlayCompositionSession, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("learned-\(UUID().uuidString).json")
+        return (
+            OverlayCompositionSession(composition: composition,
+                                      store: OverlayCompositionStore(fileURL: url)),
+            url
+        )
+    }
+
+    @Test("The mermaid draft mirrors the model on init and after every mutation")
+    @MainActor
+    func draftMirrorsModel() {
+        let (session, url) = session(sampleComposition())
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(session.mermaidDraft == session.composition.mermaidExport())
+        _ = session.addOverlay(label: "New node", purpose: "note")
+        #expect(session.mermaidDraft == session.composition.mermaidExport())
+        #expect(session.mermaidDraft.contains("New node"))
+    }
+
+    @Test("Applying edited mermaid updates the model and re-canonicalizes the text")
+    @MainActor
+    func applySucceeds() throws {
+        let (session, url) = session(sampleComposition())
+        defer { try? FileManager.default.removeItem(at: url) }
+        session.mermaidDraft = session.mermaidDraft
+            .replacingOccurrences(of: "Bravo button", with: "Bravo control")
+        session.applyMermaid()
+        #expect(session.mermaidError == nil)
+        #expect(session.composition.layer(withID: "layer-b")?.label == "Bravo control")
+        #expect(session.mermaidDraft == session.composition.mermaidExport())
+        // The change persisted.
+        let reopened = OverlayCompositionSession(store: OverlayCompositionStore(fileURL: url))
+        #expect(reopened.composition.layer(withID: "layer-b")?.label == "Bravo control")
+    }
+
+    @Test("Plain statements narrate edges then unconnected nodes")
+    @MainActor
+    func statements() {
+        let (session, url) = session(sampleComposition())
+        defer { try? FileManager.default.removeItem(at: url) }
+        let lines = session.learnedStatements
+        #expect(lines.contains("Alpha tab houses Bravo button"))
+        #expect(lines.contains("Bravo button opens Delta panel"))
+        // Every node here is connected, so no standalone lines.
+        #expect(lines.count == 2)
+    }
+}

--- a/prototypes/operations-floater/docs/SCREEN_TRAINER.md
+++ b/prototypes/operations-floater/docs/SCREEN_TRAINER.md
@@ -179,15 +179,50 @@ semantic knowledge-graph of the EHR UI that the later agentic layer plans over.
 - **Persistence** (`OverlayCompositionStore`). A single PHI-free JSON document
   beside the correction store under Application Support, git-ignored, holding only
   author-supplied labels, purposes, normalized positions, workflow-order indices,
-  group names, and visibility. No frame, pixels, or screen text — never PHI, the
-  same posture as the typed correction note.
+  group names, visibility, and the relationship edge set (below). No frame, pixels,
+  or screen text — never PHI, the same posture as the typed correction note.
+
+## Knowledge graph + mermaid (what I've learned)
+
+The authored overlays are the **nodes** of the EHR-UI knowledge graph; this slice
+adds the **edges** and makes the whole graph expressible AND editable as mermaid —
+the owner's ask: *"that goes in a 'what I've learned' area — originally as a
+statement and as `a tab -(houses)-> b button` … a mermaid-metadata language I can
+quickly visualize and edit."*
+
+- **Typed relationships** (`ScreenTrainerMermaid.swift`). An `OverlayRelationship`
+  is one directed edge: `{id, fromLayerID, toLayerID, kind}`. `kind` is
+  `OverlayRelationshipKind` — an **extensible** token (well-knowns: `houses`,
+  `navigatesTo`, `opens`, `triggers`, `partOf`, `precedes`; new kinds may be coined
+  in the text). `OverlayComposition` gains pure value functions:
+  `addRelationship` (validates endpoints exist + differ, de-dupes), `removeRelationship`,
+  `updateRelationship`, `pruneDanglingRelationships`; `removeLayer` now also prunes
+  any edge that touched it, so the edge set never dangles.
+- **Mermaid export** (`mermaidExport()`). Deterministic `flowchart TD`: each group is
+  a `subgraph`, each overlay a node (`label` in the node, `purpose` + hidden state as
+  structured `%%` comments), each relationship a labeled edge (`a -->|houses| b`),
+  with the action-lane order reflected by node ordering and a trailing note. Stable
+  output — no timestamps, everything emitted in a position-independent order.
+- **Mermaid import** (`applyingMermaid(_:)`). Parses a reasonable subset of
+  `graph`/`flowchart` (subgraphs, quoted/bare nodes, `-->`/`---` edges with `|label|`
+  or `-- label -->`, unmodeled directives ignored) and **merges onto** the current
+  model: nodes matched by token so renames / re-grouping / purpose edits update in
+  place, brand-new ids create nodes, and the edge set becomes exactly the text.
+  `export → import → export` is stable. On unparseable input it returns a specific
+  `OverlayMermaidError` and **never mutates** the model.
+- **"What I've learned" panel** (`LearnedGraphPanel`). Shows the graph BOTH as plain
+  statements (`learnedStatements`) AND as the editable mermaid text, with **Apply**
+  (commit edits) and **Refresh from graph**. The session (`OverlayCompositionSession`)
+  keeps `mermaidDraft` mirrored to the model and exposes `applyMermaid()`.
+- **PHI-free.** Edges carry only layer IDs and a content-free kind; the mermaid text
+  carries only labels, purposes, group names, and kinds. Persisted in the same
+  git-ignored JSON document (backward-compatible: a pre-relationships doc decodes
+  with an empty edge set).
 
 ## What's next
 
 - **Context toggle** — surface groups as first-class clinical-context switches in
   the overlay (show only the active context's layers).
-- **Mermaid graph** — export the authored layers + action lanes as the EHR-UI
-  knowledge graph.
 - **Agentic composition** — plan click-sequences over `actionLaneSequence` to
   accomplish untaught goals, behind a hard propose-confirm safety gate.
 - **Voice** — the architected correction layer above.


### PR DESCRIPTION
## Base = `master` (builds on the #72 layer model, which is now merged)

This slice was authored to **stack on #72** (`feat/screen-trainer-layers`). By the time
it was ready, **#72 had merged into `master`** and its branch was deleted, so there is no
longer a branch to stack on — this PR targets `master` and its single commit was rebased
onto master. The diff is exactly this slice's additive changes on top of the #72 layer/
group node model (now in master). Nothing from #72 is duplicated.

## Why

Owner's explicit ask: *"when it tells me what it's learning, that goes in a 'what I've
learned' area — originally as a statement and as `a tab -(houses)-> b button` or some
mermaid-metadata language I can quickly visualize and edit."* So the overlay/element
semantic model must be expressible **and editable** as mermaid.

The layer system (#72) gave us the **nodes** of the EHR-UI knowledge graph. This slice
adds the **edges** and the two-way mermaid bridge.

## What (all additive)

- **Typed relationships** — `OverlayRelationship {id, fromLayerID, toLayerID, kind}`.
  `OverlayRelationshipKind` is an **extensible** token (well-knowns: `houses`,
  `navigatesTo`, `opens`, `triggers`, `partOf`, `precedes`; new kinds may be coined by
  editing the mermaid text). Added to `OverlayComposition` as pure value functions:
  `addRelationship` (validates endpoints exist + differ, de-dupes identical edges),
  `removeRelationship`, `updateRelationship`, `pruneDanglingRelationships`; `removeLayer`
  now prunes any incident edge so the graph never dangles.
- **Mermaid export** (`mermaidExport()`) — deterministic `flowchart TD`: a `subgraph`
  per group, each overlay a node (`label` in the node; `purpose` + hidden state as
  structured `%%` metadata comments — mermaid has no native node metadata), each
  relationship a labeled edge (`a -->|houses| b`), action-lane order reflected by node
  ordering plus a trailing note. Stable output (no timestamps, position-independent
  ordering).
- **Mermaid import / round-trip** (`applyingMermaid(_:)`) — parses a reasonable subset
  of `graph`/`flowchart` (subgraphs, quoted/bare nodes, `-->`/`---` edges with `|label|`
  or `-- label -->`, unmodeled directives like `classDef`/`style`/`click` ignored) and
  **merges onto** the current model: nodes matched by token so renames / re-grouping /
  purpose edits update in place, brand-new ids create nodes, and the edge set becomes
  exactly the text. `export → import → export` is stable. On unparseable input it returns
  a specific `OverlayMermaidError` and **never mutates** the model (fail-safe).
- **"What I've learned" panel** (`LearnedGraphPanel`) — shows the graph BOTH as plain
  statements (`Open orders tab navigates to Admission order set`) AND as the editable
  mermaid text, with **Apply** (commit edits) and **Refresh from graph**. Reuses the
  Layers panel styling; wired into the live overlay and the headless demo.
- **PHI-free** — edges carry only layer IDs + a content-free kind; the mermaid text
  carries only labels, purposes, group names, and kinds. Persisted in the same
  git-ignored JSON document, **backward-compatible** (a pre-relationships doc from #72
  decodes with an empty edge set). Synthetic fixtures only in tests.

## Example exported mermaid (the `.starter` graph)

```mermaid
flowchart TD
%% Screen Trainer knowledge graph — PHI-free: labels, purposes & relations only.
%% Node = authored overlay · subgraph = clinical-context group · edge label = relationship kind.
subgraph group_inpatient["inpatient"]
  layer_open_orders["Open orders tab"]
  layer_order_set["Admission order set"]
  layer_sign["Sign & hold"]
end
subgraph group_outpatient["outpatient"]
  layer_visit_dx["Visit diagnosis"]
end
%% purpose layer_open_orders: Start the order-entry workflow from the chart toolbar.
%% purpose layer_order_set: Apply the standard inpatient admission bundle.
%% purpose layer_sign: Sign the orders; a propose-confirm gate stops here before execution.
%% purpose layer_visit_dx: Attach the outpatient visit diagnosis before checkout.
layer_open_orders -->|navigatesTo| layer_order_set
layer_order_set -->|precedes| layer_sign
%% action-lane order: layer_open_orders -> layer_visit_dx -> layer_order_set -> layer_sign
```

## Verify

- `swift build` clean.
- `swift test` green — **210 tests, 25 new**. New coverage: relationship
  add/remove/validate + prune, extensible-kind normalization, export determinism +
  expected shape, grouped-subgraph output, round-trip stability
  (`export→import→export` + merge-onto-self identity), import into empty, edit /
  rename / regroup / add-remove edges, visibility round-trip, malformed-input
  fail-safe (no corruption), backward-compatible decode, PHI-free serialized shape,
  and the session mermaid bridge.

## Files

- `Sources/OperationsFloater/ScreenTrainerMermaid.swift` (new) — relationship model,
  extensible kind, mermaid export + import, plain-statement narration.
- `Sources/OperationsFloater/ScreenTrainerLayers.swift` — `relationships` field +
  backward-compatible Codable, `removeLayer` prune, starter edges, session bridge
  (`mermaidDraft`, `applyMermaid`, `refreshMermaidFromModel`, relationship passthroughs).
- `Sources/OperationsFloater/ScreenTrainerLayersPanel.swift` — `LearnedGraphPanel`.
- `Sources/OperationsFloater/ScreenTrainerOverlay.swift` — panel wired into live overlay
  + demo.
- `Tests/OperationsFloaterTests/ScreenTrainerMermaidTests.swift` (new).
- `docs/SCREEN_TRAINER.md`, `CHANGELOG.md` — documented; mermaid moved out of roadmap.

Ad-hoc/local only; no Developer-ID signing, `/Applications` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
