### PR TITLE
chore(examples): genericize sample project tagline

### DIFF
--- a/examples/fastapi-next.answers.json
+++ b/examples/fastapi-next.answers.json
@@ -1,7 +1,7 @@
 {
   "project_name": "Acme (FastAPI)",
   "project_slug": "acmefn",
-  "project_tagline": "Deterministic clinical simulation operating system.",
+  "project_tagline": "Deterministic workflow simulation operating system.",
   "github_owner": "pulkitsinghal",
   "github_repo": "example-fastapi-next",
   "stack": "fastapi-next",


### PR DESCRIPTION
## Summary

- replace the domain-specific FastAPI sample tagline with a domain-neutral workflow simulation tagline
- preserve the existing example schema and every other sample value

## Why

The public example should demonstrate the `project_tagline` token without carrying a vertical-specific clinical hint.

## Test plan

- stamped all four declared example stacks in Docker with `python:3.12-slim`
- verified the new FastAPI tagline appears in 9 generated files and the old clinical tagline appears in 0
- verified no unexpected `{{ token }}` leaks and GitHub `${{ ... }}` expressions remain
- parsed generated migration/version scripts and all generated git hooks
- compiled `bin/generate.py` and parsed `bin/firestart.sh`
- `git diff --check master...6887cf7b09db7c88aa135e5c99a92193dfdea082`

## Review and merge gate

Exact diff review found one intended JSON string replacement, no secret/private material, no private names, and no unrelated scope.

This PR is intentionally a draft. The repository publishes GitHub Pages from `master:/docs`, and every default-branch push triggers a Pages deployment even when `docs/` is unchanged. Merge therefore remains owner-gated; do not mark ready or merge until that deployment side effect is explicitly authorized.
