### PR TITLE
fix(template): verify stopped ORC host PIDs

### DIFF
--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/scripts/federation_transfer.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/scripts/federation_transfer.py
@@ -143,12 +143,22 @@ def disarmed_host(value: str) -> dict[str, Any]:
     if not isinstance(session, dict) or session.get("armed") is not False:
         raise TransferError("source-host-still-armed")
     for field in ("desktop_pid", "proxy_pid", "app_server_pid"):
-        if session.get(field) is not None:
-            raise TransferError("source-host-process-not-cleared")
+        pid = session.get(field)
+        if pid is None:
+            continue
+        if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 1:
+            raise TransferError("source-host-session-invalid")
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            continue
+        except (PermissionError, OSError) as exc:
+            raise TransferError("source-host-process-unverifiable") from exc
+        raise TransferError("source-host-process-still-running")
     instance_id = session.get("instance_id")
     if not isinstance(instance_id, str) or OPAQUE.fullmatch(instance_id) is None:
         raise TransferError("source-host-session-invalid")
-    return {"instance_id": instance_id, "armed": False, "processes_cleared": True}
+    return {"instance_id": instance_id, "armed": False, "processes_absent": True}
 
 
 def current_authority(current: dict[str, Any]) -> dict[str, Any]:

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_federation_transfer.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_federation_transfer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -11,6 +12,10 @@ from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = PLUGIN_ROOT / "scripts" / "federation_transfer.py"
+SPEC = importlib.util.spec_from_file_location("federation_transfer", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
 REPO_ROOT = PLUGIN_ROOT.parents[4]
 CLI = (
     REPO_ROOT
@@ -64,7 +69,13 @@ class FederationTransferTest(unittest.TestCase):
             raise AssertionError(completed.stderr)
 
     @staticmethod
-    def write_host(host: Path, instance_id: str, *, armed: bool = False) -> None:
+    def write_host(
+        host: Path,
+        instance_id: str,
+        *,
+        armed: bool = False,
+        desktop_pid: int | None = None,
+    ) -> None:
         private(host)
         session = host / "session.json"
         session.write_text(
@@ -72,7 +83,7 @@ class FederationTransferTest(unittest.TestCase):
                 {
                     "instance_id": instance_id,
                     "armed": armed,
-                    "desktop_pid": None,
+                    "desktop_pid": desktop_pid,
                     "proxy_pid": None,
                     "app_server_pid": None,
                 },
@@ -128,7 +139,7 @@ class FederationTransferTest(unittest.TestCase):
             [4, 4], [source["configured_capacity"] for source in result["sources"]]
         )
         self.assertTrue(
-            all(item["processes_cleared"] for item in result["source_host_evidence"])
+            all(item["processes_absent"] for item in result["source_host_evidence"])
         )
 
         replay = subprocess.run(
@@ -139,6 +150,21 @@ class FederationTransferTest(unittest.TestCase):
         )
         self.assertEqual(0, replay.returncode, replay.stderr)
         self.assertTrue(json.loads(replay.stdout)["single_active_root"])
+
+    def test_disarmed_host_accepts_historical_dead_pid_and_rejects_live_pid(
+        self,
+    ) -> None:
+        dead_host = self.root / "dead-host"
+        self.write_host(dead_host, "dead-host", desktop_pid=2_147_483_647)
+        evidence = MODULE.disarmed_host(str(dead_host))
+        self.assertTrue(evidence["processes_absent"])
+
+        live_host = self.root / "live-host"
+        self.write_host(live_host, "live-host", desktop_pid=os.getpid())
+        with self.assertRaisesRegex(
+            MODULE.TransferError, "source-host-process-still-running"
+        ):
+            MODULE.disarmed_host(str(live_host))
 
     def test_armed_source_host_fails_before_authority_mutation(self) -> None:
         self.write_host(self.hosts[0], "source-host-1", armed=True)


### PR DESCRIPTION
## Summary

- accept a safely disarmed Desktop host that retains historical recorded PIDs
- prove each non-null recorded PID is absent before authority transfer
- fail closed if a PID is alive, malformed, or unverifiable

## Evidence

- synthetic dead historical PID accepted
- current live PID rejected
- stopped 0.3.6 primary-root record passes and reports processes absent
- federation apply/replay suite passes

This is a required live-integration correction discovered after PR #90 auto-merged. Plugin 0.4.0 remains uninstalled until this follow-up merges and exact-master validation passes.