### PR TITLE
fix(template): repair terminal refill replay

### DIFF
--- a/addons/orchestrator_session/common/orchestrator-control/docs/PHASE2_PLUGIN_INTEGRATION.md
+++ b/addons/orchestrator_session/common/orchestrator-control/docs/PHASE2_PLUGIN_INTEGRATION.md
@@ -269,10 +269,20 @@ output.
    fences immediately lose heartbeat, mutation, and handback authority.
 9. Treat closure and refill as one saga. Normalize `completed`, `archived`, and
    observed `interrupted/notLoaded` with a valid clean handback as terminal.
-   Before `record-handback`, reconcile live external state and call
-   `recycle-queue`. Select the highest-value eligible successor, if any, and
-   include its exact `prepare-launch` request plus the configured capacity,
-   runnable queue count, terminal observation, and bounded evidence refs.
+   Before `record-handback`, reconcile live external state, select the
+   highest-value eligible successor, if any, and include its exact
+   `prepare-launch` request plus the configured capacity, runnable queue count,
+   terminal observation, bounded evidence refs, and blocked-work audits.
+   Do not release claims through a standalone pre-handback recycle; the control
+   plane applies those audits in the atomic handback transaction.
+   An expired committed receipt remains stale except for
+   `completed_local_only` / `completed_local_artifact` backed by the exact
+   authoritative task, launch receipt, external thread, policy, lease, fence,
+   and active claim plus terminal lifecycle evidence: either its matching
+   `CONTROL_SCHEMA_HOLD`, or a non-empty `COMPLETION_CANDIDATE` /
+   `INTERRUPT_REQUIRED` signal set with the matching `REQUEST_HANDBACK` /
+   `TERMINALIZE` action. The wrapper only admits this replay; the control plane
+   still validates all completion evidence and commits release atomically.
 10. `record-handback` performs the exact ordered transition
     **handback → capacity release → blocked-work re-audit** before it reserves
     the successor and create outbox, records `EMPTY`/`OWNER_GATED` with evidence

--- a/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
+++ b/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
@@ -6490,10 +6490,31 @@ class Plane:
                     "SELECT * FROM lifecycle_watchdog WHERE task_id=?",
                     (row["task_id"],),
                 ).fetchone()
+                control_schema_hold = connection.execute(
+                    """SELECT ticket_id,replay_target
+                       FROM control_schema_holds
+                       WHERE task_id=? AND released_at IS NULL""",
+                    (row["task_id"],),
+                ).fetchone()
+                launch = connection.execute(
+                    "SELECT receipt_json FROM launches WHERE task_id=?",
+                    (row["task_id"],),
+                ).fetchone()
+                launch_receipt = (
+                    None
+                    if launch is None or launch["receipt_json"] is None
+                    else json.loads(launch["receipt_json"])
+                )
                 claim = connection.execute(
                     """SELECT status,expires_at FROM owner_claims
                        WHERE task_id=? ORDER BY acquired_at DESC LIMIT 1""",
                     (row["task_id"],),
+                ).fetchone()
+                receipt_claim = connection.execute(
+                    """SELECT claim_id,lease_epoch,fencing_token,status,expires_at
+                       FROM owner_claims WHERE task_id=? AND fencing_token=?
+                       ORDER BY acquired_at DESC LIMIT 1""",
+                    (row["task_id"], row["fencing_token"]),
                 ).fetchone()
                 stale = (
                     None
@@ -6523,6 +6544,48 @@ class Plane:
                             None
                             if lifecycle is None
                             else self.lifecycle_result(lifecycle)
+                        ),
+                        "control_schema_hold": (
+                            None
+                            if control_schema_hold is None
+                            else {
+                                "hold_state": "CONTROL_SCHEMA_HOLD",
+                                "ticket_id": control_schema_hold["ticket_id"],
+                                "task_id": row["task_id"],
+                                "external_thread_id": row["external_thread_id"],
+                                "policy_snapshot_revision": row[
+                                    "policy_revision"
+                                ],
+                                "lease_epoch": row["lease_epoch"],
+                                "fencing_token": row["fencing_token"],
+                                "replay_target": control_schema_hold[
+                                    "replay_target"
+                                ],
+                            }
+                        ),
+                        "receipt_fence": (
+                            None
+                            if receipt_claim is None or launch_receipt is None
+                            else {
+                                "task_id": row["task_id"],
+                                "receipt_external_thread_id": launch_receipt[
+                                    "external_thread_id"
+                                ],
+                                "policy_snapshot_revision": row[
+                                    "policy_revision"
+                                ],
+                                "lease_epoch": row["lease_epoch"],
+                                "lease_expires_at": receipt_claim["expires_at"],
+                                "fencing_token": row["fencing_token"],
+                                "owner_claim_id": receipt_claim["claim_id"],
+                                "owner_claim_status": receipt_claim["status"],
+                                "claim_lease_epoch": receipt_claim[
+                                    "lease_epoch"
+                                ],
+                                "claim_fencing_token": receipt_claim[
+                                    "fencing_token"
+                                ],
+                            }
                         ),
                         "freshness": {
                             "evaluated_at": now,

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/CHANGELOG.md
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Allow only exact authoritative terminal evidence to carry an expired
+  committed receipt through `close-and-refill`: either an active matching
+  `CONTROL_SCHEMA_HOLD`, or a completion-signalled `COMPLETION_CANDIDATE` /
+  `INTERRUPT_REQUIRED` lifecycle with its matching required action. Admit both
+  local completion dispositions to authoritative control validation, and keep
+  recycle/release effects behind the atomic handback commit.
+
 ## 0.4.2 - 2026-08-04
 
 - Add truthful `completed_local_only` and `completed_local_artifact` closure

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/skills/pm-proxy-orchestrator/scripts/refill_saga.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/skills/pm-proxy-orchestrator/scripts/refill_saga.py
@@ -20,6 +20,14 @@ LOCK_NAME = ".pm-proxy-refill.lock"
 TERMINAL_OBSERVATIONS = {"completed", "archived", "interrupted/notLoaded"}
 SATISFIED_OUTCOMES = {"REFILL_SATISFIED", "EMPTY", "OWNER_GATED", "CAPACITY_FULL"}
 ACTIVE_OR_RESERVED = {"RUNNING", "LAUNCH_PENDING"}
+TERMINAL_DISPOSITIONS = {
+    "completed",
+    "completed_local_only",
+    "completed_local_artifact",
+    "failed",
+    "superseded",
+    "duplicate",
+}
 
 
 class SagaLedger:
@@ -147,6 +155,82 @@ def slot_truth(
         "deficit": deficit,
         "failure_state": "CAPACITY_DEFICIT" if failure else None,
     }
+
+
+def exact_terminal_evidence_replay(
+    status: dict[str, Any],
+    ticket: dict[str, Any],
+    handback: dict[str, Any],
+) -> bool:
+    """Authorize an expired local completion only from exact terminal evidence."""
+
+    receipt = bridge.require_committed_receipt(ticket)
+    disposition = handback.get("disposition")
+    if disposition not in {"completed_local_only", "completed_local_artifact"}:
+        return False
+    matching = [
+        task
+        for task in status.get("tasks", [])
+        if isinstance(task, dict) and task.get("task_id") == ticket["task_id"]
+    ]
+    if len(matching) != 1:
+        return False
+    task = matching[0]
+    lifecycle = task.get("lifecycle")
+    hold = task.get("control_schema_hold")
+    expected_receipt_fence = {
+        "task_id": ticket["task_id"],
+        "receipt_external_thread_id": receipt["external_thread_id"],
+        "policy_snapshot_revision": ticket["policy_snapshot_revision"],
+        "lease_epoch": ticket["lease_epoch"],
+        "lease_expires_at": ticket["lease_expires_at"],
+        "fencing_token": ticket["fencing_token"],
+        "owner_claim_id": ticket["owner_claim_id"],
+        "owner_claim_status": "active",
+        "claim_lease_epoch": ticket["lease_epoch"],
+        "claim_fencing_token": ticket["fencing_token"],
+    }
+    expected_hold = {
+        "hold_state": "CONTROL_SCHEMA_HOLD",
+        "ticket_id": ticket["source_event_key"],
+        "task_id": ticket["task_id"],
+        "external_thread_id": receipt["external_thread_id"],
+        "policy_snapshot_revision": ticket["policy_snapshot_revision"],
+        "lease_epoch": ticket["lease_epoch"],
+        "fencing_token": ticket["fencing_token"],
+        "replay_target": disposition,
+    }
+    exact_identity = (
+        task.get("state") == "RUNNING"
+        and task.get("canonical_external_thread_id")
+        == receipt["external_thread_id"]
+        and isinstance(task.get("receipt_fence"), dict)
+        and set(task["receipt_fence"]) == set(expected_receipt_fence)
+        and task["receipt_fence"] == expected_receipt_fence
+        and isinstance(lifecycle, dict)
+        and lifecycle.get("task_id") == ticket["task_id"]
+    )
+    if not exact_identity:
+        return False
+    if lifecycle.get("lifecycle_state") == "CONTROL_SCHEMA_HOLD":
+        return (
+            isinstance(hold, dict)
+            and set(hold) == set(expected_hold)
+            and hold == expected_hold
+        )
+    expected_action = {
+        "COMPLETION_CANDIDATE": "REQUEST_HANDBACK",
+        "INTERRUPT_REQUIRED": "TERMINALIZE",
+    }.get(lifecycle.get("lifecycle_state"))
+    completion_signals = lifecycle.get("completion_signals")
+    return (
+        expected_action is not None
+        and lifecycle.get("required_action") == expected_action
+        and isinstance(completion_signals, list)
+        and bool(completion_signals)
+        and all(isinstance(item, str) and item for item in completion_signals)
+        and hold is None
+    )
 
 
 def create_ticket(
@@ -358,12 +442,10 @@ def execute(args: argparse.Namespace) -> dict[str, Any]:
                 handback = bridge.load_json_file(args.handback_request, "handback request")
                 bridge.validate_handback_request(handback)
                 predecessor_path, predecessor = bridge.load_ticket(args.predecessor_ticket)
-                bridge.require_active_receipt(predecessor, handback["now"])
+                receipt = bridge.require_committed_receipt(predecessor)
                 bridge.inject_ticket_fields(handback, predecessor)
                 if bridge.schema_at_least(health["schema_version"], (1, 1)):
-                    handback["external_thread_id"] = predecessor["receipt"][
-                        "external_thread_id"
-                    ]
+                    handback["external_thread_id"] = receipt["external_thread_id"]
                 if handback.get("successor_request") is not None:
                     raise bridge.BridgeError(
                         "SCHEMA_INVALID",
@@ -371,26 +453,23 @@ def execute(args: argparse.Namespace) -> dict[str, Any]:
                         exit_status=2,
                     )
                 terminal_results = {item["result"] for item in handback.get("checks", [])}
-                if handback.get("disposition") not in {"completed", "failed", "superseded", "duplicate"}:
+                if handback.get("disposition") not in TERMINAL_DISPOSITIONS:
                     raise bridge.BridgeError("TERMINAL_EVIDENCE_INVALID", "handback is not terminal", exit_status=2)
                 if terminal_results & {"fail", "pending", "blocked"}:
                     raise bridge.BridgeError("TERMINAL_EVIDENCE_INVALID", "handback checks are not clean", exit_status=2)
-                pre_recycle = bridge.run_cli(
-                    cli,
-                    state_dir,
-                    "recycle-queue",
-                    request=refill["recycle_request"],
-                )
-                saga["events"].append(
-                    event(
-                        "QUEUE_RECYCLED",
-                        handback["now"],
-                        refill["terminal_observation"]["evidence_refs"],
-                        phase="pre-closure",
-                        selected_task_id=pre_recycle.get("selected_task_id"),
-                    )
-                )
-                firestarter_status = bridge.run_cli(cli, state_dir, "status")
+                try:
+                    bridge.require_active_receipt(predecessor, handback["now"])
+                    firestarter_status = bridge.run_cli(cli, state_dir, "status")
+                except bridge.BridgeError as error:
+                    if error.code != "RECEIPT_STALE":
+                        raise
+                    firestarter_status = bridge.run_cli(cli, state_dir, "status")
+                    if not exact_terminal_evidence_replay(
+                        firestarter_status,
+                        predecessor,
+                        handback,
+                    ):
+                        raise error
                 before = slot_truth(firestarter_status, refill)
                 projected_active = max(0, before["active_or_reserved_count"] - 1)
                 candidates = sorted(

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/fake_firestarter_cli.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/fake_firestarter_cli.py
@@ -148,8 +148,31 @@ def status_result(state: dict[str, Any]) -> dict[str, Any]:
             "priority": task["priority"],
             "repo_alias": task["target"]["remote"].split("/", 1)[-1],
             "path": task["target"]["path"],
+            "canonical_external_thread_id": task.get("external_thread_id"),
             "updated_at": task["updated_at"],
             "block": task.get("block"),
+            "lifecycle": task.get("lifecycle"),
+            "control_schema_hold": task.get("control_schema_hold"),
+            "receipt_fence": (
+                None
+                if task.get("receipt_external_thread_id") is None
+                else {
+                    "task_id": task["task_id"],
+                    "receipt_external_thread_id": task[
+                        "receipt_external_thread_id"
+                    ],
+                    "policy_snapshot_revision": task[
+                        "policy_snapshot_revision"
+                    ],
+                    "lease_epoch": task["lease_epoch"],
+                    "lease_expires_at": task["lease_expires_at"],
+                    "fencing_token": task["fencing_token"],
+                    "owner_claim_id": task["owner_claim_id"],
+                    "owner_claim_status": task["owner_claim_status"],
+                    "claim_lease_epoch": task["claim_lease_epoch"],
+                    "claim_fencing_token": task["claim_fencing_token"],
+                }
+            ),
         }
         for task in state["tasks"].values()
     ]
@@ -270,6 +293,11 @@ def main() -> int:
                     "lease_expires_at": request["lease_expires_at"],
                     "updated_at": request["now"],
                     "external_thread_id": None,
+                    "receipt_external_thread_id": None,
+                    "owner_claim_id": "claim-" + task["task_id"],
+                    "owner_claim_status": "active",
+                    "claim_lease_epoch": 1,
+                    "claim_fencing_token": fence,
                     "block": None,
                 }
             )
@@ -334,6 +362,7 @@ def main() -> int:
             if sorted(request.get("applicable_rule_ids", [])) != sorted(task["applicable_rule_ids"]):
                 return deny("RECEIPT_MISMATCH", "rule receipt mismatch", 2)
             task["external_thread_id"] = request.get("external_thread_id")
+            task["receipt_external_thread_id"] = request.get("external_thread_id")
             task["state"] = "RUNNING"
             task["updated_at"] = request["now"]
             for outbox in state["outbox"].values():
@@ -465,12 +494,28 @@ def main() -> int:
             return emit(command, {"rule_id": rule["id"], "policy_revision": state["policy_revision"]})
 
         if command == "record-handback":
+            if mode == "fail-before-handback-commit":
+                return deny(
+                    "SYNTHETIC_HANDBACK_NOT_COMMITTED",
+                    "synthetic failure before authoritative handback commit",
+                    2,
+                )
             handback_id = request["handback_id"]
             if handback_id in state["handbacks"]:
                 return emit(command, state["handbacks"][handback_id])
             task = state["tasks"].get(request.get("task_id"))
             if not task or task["state"] != "RUNNING" or not receipt_matches(task, request):
                 return deny("FENCE_STALE", "current exact receipt is required", 2)
+            hold = task.get("control_schema_hold")
+            if hold is not None and (
+                hold.get("hold_state") != "CONTROL_SCHEMA_HOLD"
+                or hold.get("replay_target") != request.get("disposition")
+            ):
+                return deny(
+                    "CONTROL_SCHEMA_HOLD_REPLAY_MISMATCH",
+                    "control-schema hold requires its exact typed replay",
+                    3,
+                )
             archive_id = "archive-" + task["task_id"]
             state["outbox"][archive_id] = {
                 "outbox_id": archive_id,
@@ -500,6 +545,11 @@ def main() -> int:
                     "lease_expires_at": successor["lease_expires_at"],
                     "updated_at": request["now"],
                     "external_thread_id": None,
+                    "receipt_external_thread_id": None,
+                    "owner_claim_id": "claim-" + successor_id,
+                    "owner_claim_status": "active",
+                    "claim_lease_epoch": 1,
+                    "claim_fencing_token": task["fencing_token"] + 1,
                     "block": None,
                 }
                 state["outbox"][create_id] = {
@@ -562,7 +612,11 @@ def main() -> int:
                     "outbox": {"outbox_id": create_id, "kind": "CREATE_THREAD"},
                 }
             task["state"] = "ARCHIVE_PENDING"
+            task["owner_claim_status"] = "released"
             task["updated_at"] = request["now"]
+            task["control_schema_hold"] = None
+            if isinstance(task.get("lifecycle"), dict):
+                task["lifecycle"]["lifecycle_state"] = "COMPLETED"
             result = {
                 "task_id": task["task_id"],
                 "state": "ARCHIVE_PENDING",
@@ -570,6 +624,7 @@ def main() -> int:
                 "successor": successor_result,
                 "evidence_count": len(request["checks"]),
                 "resource_count": len(request["resources"]),
+                "control_schema_hold_released": hold is not None,
                 "reclaimed_bytes": sum(
                     resource.get("bytes", 0)
                     for resource in request["resources"]

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_mcp_server.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_mcp_server.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import unittest
+from contextlib import closing
 from pathlib import Path
 
 from tests.support import (
     BRIDGE,
     classify_request,
     config_verified_runtime_attestation,
+    handback_request,
     iso,
     launch_request,
     private_temp,
@@ -132,6 +136,118 @@ class McpServerTest(unittest.TestCase):
             "project_root": str(self.project),
             "state_dir": str(self.state),
         }
+
+    def adopt_current_plugin(self, request_id: str) -> None:
+        plugin_version = json.loads(
+            (PLUGIN_ROOT / ".codex-plugin" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )["version"]
+        self.record_owner_adoption(
+            {
+                "interface_version": "1.0",
+                "request_id": request_id,
+                "adoption_mode": "COVERED_PATH_GUARDRAIL",
+                "plugin_version": plugin_version,
+                "proofs": {
+                    "pre_tool_denial_verified": True,
+                    "typed_mcp_control_verified": True,
+                    "reserved_create_admission_verified": True,
+                    "lifecycle_debt_clear_verified": True,
+                    "archive_refill_fence_verified": True,
+                    "no_side_effect_canary_verified": True,
+                    "hosted_paths_uncovered": True,
+                    "universal_coverage_claimed": False,
+                },
+                "now": iso(),
+            }
+        )
+
+    def prepare_receipted_task(
+        self,
+        *,
+        ticket_id: str,
+        task_id: str,
+        fence: int,
+        path: str = "/",
+    ) -> dict:
+        with closing(
+            sqlite3.connect(self.state / "orchestrator.sqlite3")
+        ) as connection, connection:
+            connection.execute("UPDATE metadata SET value=? WHERE key='next_fence'", (str(fence),))
+        launch = launch_request(
+            task_id=task_id,
+            source_event_key=ticket_id,
+            outcome_key=f"outcome-{task_id}",
+            idempotency_key=f"idem-{task_id}",
+            repo_root=str(self.target),
+            remote="https://github.com/example/project.git",
+        )
+        launch["target"]["path"] = path
+        launch["target"]["resource_mode"] = "repo-wide" if path == "/" else "path"
+        launch["context"]["repo"] = "github.com/example/project"
+        launch["context"]["path"] = path
+        prepared = self.call(
+            "pm_proxy_prepare_launch",
+            {
+                **self.common(),
+                "ticket_id": ticket_id,
+                "recycle_request": recycle_request(request_id=f"recycle-{task_id}"),
+                "launch_request": launch,
+            },
+        )["result"]
+        self.assertIsNot(prepared.get("isError"), True, prepared)
+        receipted = self.call(
+            "pm_proxy_record_launch_receipt",
+            {
+                **self.common(),
+                "ticket_id": ticket_id,
+                "external_thread_id": f"thread-{task_id}",
+                "runtime_attestation": config_verified_runtime_attestation(),
+                "request_id": f"receipt-{task_id}",
+                "now": iso(minutes=1),
+            },
+        )["result"]
+        self.assertIsNot(receipted.get("isError"), True, receipted)
+        ticket = json.loads(
+            (self.state / f"{ticket_id}.ticket.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(fence, ticket["fencing_token"])
+        return ticket
+
+    def set_expired_terminal_evidence(
+        self,
+        *,
+        task_id: str,
+        worker_status: str,
+        signal: str,
+    ) -> None:
+        with closing(
+            sqlite3.connect(self.state / "orchestrator.sqlite3")
+        ) as connection, connection:
+            connection.execute(
+                """INSERT OR REPLACE INTO lifecycle_watchdog(
+                   task_id,lifecycle_state,worker_status,completion_signals_json,
+                   evidence_refs_json,remaining_work_json,progress_ref,
+                   progress_observed_at,handback_deadline_checks,
+                   handback_deadline_limit,required_action,interrupt_receipt_id,
+                   updated_at
+                ) VALUES(?,'INTERRUPT_REQUIRED',?,?,?,NULL,?,?,2,2,
+                         'TERMINALIZE',NULL,?)""",
+                (
+                    task_id,
+                    worker_status,
+                    json.dumps([signal]),
+                    json.dumps([f"evidence:{task_id}"]),
+                    f"progress:{task_id}",
+                    iso(minutes=20),
+                    iso(minutes=20),
+                ),
+            )
+            connection.execute(
+                "UPDATE owner_claims SET expires_at=? WHERE task_id=?",
+                (iso(minutes=30), task_id),
+            )
 
     def record_owner_adoption(self, request: dict) -> dict:
         request_path = self.state / ".owner-dispatcher-adoption.json"
@@ -486,6 +602,257 @@ class McpServerTest(unittest.TestCase):
             "credential_url",
         ):
             self.assertNotIn(forbidden, serialized)
+
+    def test_screen_sanitizer_fence_41_local_artifact_uses_control_validation(self) -> None:
+        self.adopt_current_plugin("screen-sanitizer-fence-41-adoption")
+        (self.target / "docs").mkdir()
+        relative_path = "docs/screen-sanitizer-report.json"
+        artifact_path = self.target / relative_path
+        artifact_path.write_text("synthetic sanitized artifact\n", encoding="utf-8")
+        after = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+        ticket = self.prepare_receipted_task(
+            ticket_id="screen-sanitizer-ticket-41",
+            task_id="screen-sanitizer-fence-41",
+            fence=41,
+            path="/docs",
+        )
+        self.set_expired_terminal_evidence(
+            task_id="screen-sanitizer-fence-41",
+            worker_status="completed",
+            signal="worker-final",
+        )
+        body = {
+            "algorithm": "sha256",
+            "entries": [
+                {
+                    "relative_path": relative_path,
+                    "transition": "created",
+                    "before_sha256": None,
+                    "after_sha256": after,
+                }
+            ],
+        }
+        manifest = {
+            **body,
+            "manifest_sha256": hashlib.sha256(
+                (
+                    json.dumps(body, sort_keys=True, separators=(",", ":"))
+                    + "\n"
+                ).encode()
+            ).hexdigest(),
+            "rollback": {
+                "strategy": "restore_base",
+                "evidence_ref": "rollback-screen-sanitizer-fence-41",
+            },
+        }
+        handback = handback_request(
+            task_id="screen-sanitizer-fence-41",
+            handback_id="screen-sanitizer-fence-41",
+            now=iso(minutes=32),
+        )
+        for key in ("policy_snapshot_revision", "lease_epoch", "fencing_token"):
+            handback[key] = ticket[key]
+        handback.update(
+            {
+                "disposition": "completed_local_artifact",
+                "exact_refs": {
+                    "base_sha": "a" * 40,
+                    "candidate_sha": None,
+                    "pr_url": None,
+                    "merge_sha": None,
+                    "default_sha": None,
+                },
+                "external_delivery": "not_performed",
+                "artifacts": [relative_path],
+                "local_artifact": manifest,
+                "resources": [
+                    {
+                        "id": ticket["owner_claim_id"],
+                        "disposition": "removed",
+                        "reason": "synthetic owner claim released",
+                        "bytes": 0,
+                    },
+                    {
+                        "id": relative_path,
+                        "disposition": "retain",
+                        "reason": "bounded synthetic local artifact",
+                        "bytes": artifact_path.stat().st_size,
+                    },
+                ],
+            }
+        )
+        refill = refill_request(
+            request_id="screen-sanitizer-fence-41",
+            capacity=4,
+            now=iso(minutes=32),
+        )
+        invalid = json.loads(json.dumps(handback))
+        invalid["local_artifact"]["entries"][0]["after_sha256"] = "f" * 64
+        invalid_body = {
+            "algorithm": invalid["local_artifact"]["algorithm"],
+            "entries": invalid["local_artifact"]["entries"],
+        }
+        invalid["local_artifact"]["manifest_sha256"] = hashlib.sha256(
+            (
+                json.dumps(invalid_body, sort_keys=True, separators=(",", ":"))
+                + "\n"
+            ).encode()
+        ).hexdigest()
+        rejected = self.call(
+            "pm_proxy_close_and_refill",
+            {
+                **self.common(),
+                "predecessor_ticket_id": "screen-sanitizer-ticket-41",
+                "handback_request": invalid,
+                "refill_request": refill,
+            },
+        )["result"]
+        self.assertTrue(rejected["isError"])
+        self.assertEqual(
+            "artifact-content-mismatch",
+            rejected["structuredContent"]["error"]["code"],
+        )
+        self.assertFalse((self.state / "pm-proxy-refill-ledger.json").exists())
+
+        closed = self.call(
+            "pm_proxy_close_and_refill",
+            {
+                **self.common(),
+                "predecessor_ticket_id": "screen-sanitizer-ticket-41",
+                "handback_request": handback,
+                "refill_request": refill,
+            },
+        )["result"]
+        self.assertIsNot(closed.get("isError"), True, closed)
+        result = closed["structuredContent"]["result"]
+        self.assertEqual("EMPTY", result["outcome"])
+        with closing(
+            sqlite3.connect(self.state / "orchestrator.sqlite3")
+        ) as connection:
+            stored = json.loads(
+                connection.execute(
+                    "SELECT result_json FROM handbacks WHERE handback_id=?",
+                    ("screen-sanitizer-fence-41",),
+                ).fetchone()[0]
+            )
+        self.assertEqual(
+            manifest["manifest_sha256"],
+            stored["local_artifact_manifest_sha256"],
+        )
+
+    def test_screenbench_fence_42_mcp_replays_stale_terminal_evidence_atomically(self) -> None:
+        self.adopt_current_plugin("screenbench-fence-42-adoption")
+        ticket = self.prepare_receipted_task(
+            ticket_id="screenbench-ticket-42",
+            task_id="screenbench-fence-42",
+            fence=42,
+        )
+        database = self.state / "orchestrator.sqlite3"
+        self.set_expired_terminal_evidence(
+            task_id="screenbench-fence-42",
+            worker_status="waiting",
+            signal="accepted-schema-defect-replay",
+        )
+        terminal_status = self.call(
+            "pm_proxy_status",
+            {**self.common(), "now": iso(minutes=32)},
+        )["result"]["structuredContent"]["result"]
+        terminal_task = next(
+            item
+            for item in terminal_status["tasks"]
+            if item["task_id"] == "screenbench-fence-42"
+        )
+        self.assertEqual(
+            "INTERRUPT_REQUIRED",
+            terminal_task["lifecycle"]["lifecycle_state"],
+        )
+        self.assertEqual("waiting", terminal_task["lifecycle"]["worker_status"])
+        self.assertEqual("TERMINALIZE", terminal_task["lifecycle"]["required_action"])
+        self.assertIsNone(terminal_task["control_schema_hold"])
+        self.assertEqual(
+            ticket["owner_claim_id"],
+            terminal_task["receipt_fence"]["owner_claim_id"],
+        )
+
+        handback = handback_request(
+            task_id="screenbench-fence-42",
+            handback_id="screenbench-fence-42",
+            now=iso(minutes=32),
+        )
+        for key in ("policy_snapshot_revision", "lease_epoch", "fencing_token"):
+            handback[key] = ticket[key]
+        handback.update(
+            {
+                "disposition": "completed_local_only",
+                "exact_refs": {
+                    "base_sha": "a" * 40,
+                    "candidate_sha": "b" * 40,
+                    "pr_url": None,
+                    "merge_sha": None,
+                    "default_sha": None,
+                },
+                "external_delivery": "not_performed",
+                "dependencies": ["accepted-schema-defect-replay"],
+                "resources": [
+                    {
+                        "id": ticket["owner_claim_id"],
+                        "disposition": "removed",
+                        "reason": "exact synthetic owner claim released",
+                        "bytes": 0,
+                    }
+                ],
+            }
+        )
+        closed = self.call(
+            "pm_proxy_close_and_refill",
+            {
+                **self.common(),
+                "predecessor_ticket_id": "screenbench-ticket-42",
+                "handback_request": handback,
+                "refill_request": refill_request(
+                    request_id="screenbench-fence-42",
+                    capacity=4,
+                    now=iso(minutes=32),
+                ),
+            },
+        )["result"]
+        self.assertIsNot(closed.get("isError"), True, closed)
+        result = closed["structuredContent"]["result"]
+        self.assertEqual("EMPTY", result["outcome"])
+        self.assertTrue(result["capacity_released"])
+        self.assertEqual([], result["launches"])
+        with closing(sqlite3.connect(database)) as connection:
+            connection.row_factory = sqlite3.Row
+            task = connection.execute(
+                "SELECT state FROM tasks WHERE task_id=?",
+                ("screenbench-fence-42",),
+            ).fetchone()
+            claim = connection.execute(
+                "SELECT status FROM owner_claims WHERE task_id=?",
+                ("screenbench-fence-42",),
+            ).fetchone()
+            hold_count = connection.execute(
+                "SELECT COUNT(*) FROM control_schema_holds WHERE task_id=?",
+                ("screenbench-fence-42",),
+            ).fetchone()[0]
+            handback_count = connection.execute(
+                "SELECT COUNT(*) FROM handbacks WHERE handback_id=?",
+                ("screenbench-fence-42",),
+            ).fetchone()[0]
+            archive = connection.execute(
+                "SELECT state FROM outbox WHERE task_id=? AND kind='ARCHIVE_THREAD'",
+                ("screenbench-fence-42",),
+            ).fetchone()
+            capacity = connection.execute(
+                "SELECT outcome FROM capacity_sagas WHERE saga_id=?",
+                ("screenbench-fence-42",),
+            ).fetchone()
+        self.assertEqual("ARCHIVE_PENDING", task["state"])
+        self.assertEqual("released", claim["status"])
+        self.assertEqual(0, hold_count)
+        self.assertEqual(1, handback_count)
+        self.assertEqual("pending", archive["state"])
+        self.assertEqual("EMPTY", capacity["outcome"])
 
     def test_runtime_pin_rejects_mismatch_and_bundle_drift(self) -> None:
         mismatched = self.call(

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_refill_saga.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/tests/test_refill_saga.py
@@ -37,7 +37,10 @@ class RefillSagaTestCase(unittest.TestCase):
             config_verified_runtime_attestation(),
         )
 
-    def run_script(self, script: Path, *args: str):
+    def run_script(self, script: Path, *args: str, mode: str | None = None):
+        environment = os.environ.copy()
+        if mode is not None:
+            environment["FAKE_CLI_MODE"] = mode
         return subprocess.run(
             [
                 sys.executable,
@@ -50,6 +53,7 @@ class RefillSagaTestCase(unittest.TestCase):
             ],
             text=True,
             capture_output=True,
+            env=environment,
             check=False,
         )
 
@@ -96,6 +100,128 @@ class RefillSagaTestCase(unittest.TestCase):
         )
         self.assertEqual(receipt.returncode, 0, receipt.stderr)
         return ticket
+
+    def set_control_schema_hold(
+        self,
+        ticket_path: Path,
+        *,
+        fence: int,
+        replay_target: str = "completed_local_only",
+        hold_fence: int | None = None,
+    ) -> None:
+        ticket = json.loads(ticket_path.read_text(encoding="utf-8"))
+        ticket["fencing_token"] = fence
+        ticket_path.write_text(json.dumps(ticket, sort_keys=True) + "\n", encoding="utf-8")
+        state_path = self.state / "fake-state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        task = state["tasks"][ticket["task_id"]]
+        task["fencing_token"] = fence
+        task["claim_fencing_token"] = fence
+        task["lifecycle"] = {
+            "task_id": ticket["task_id"],
+            "lifecycle_state": "CONTROL_SCHEMA_HOLD",
+        }
+        task["control_schema_hold"] = {
+            "hold_state": "CONTROL_SCHEMA_HOLD",
+            "ticket_id": ticket["source_event_key"],
+            "task_id": ticket["task_id"],
+            "external_thread_id": ticket["receipt"]["external_thread_id"],
+            "policy_snapshot_revision": ticket["policy_snapshot_revision"],
+            "lease_epoch": ticket["lease_epoch"],
+            "fencing_token": fence if hold_fence is None else hold_fence,
+            "replay_target": replay_target,
+        }
+        state_path.write_text(json.dumps(state, sort_keys=True) + "\n", encoding="utf-8")
+
+    def set_terminal_evidence(
+        self,
+        ticket_path: Path,
+        *,
+        fence: int,
+        lifecycle_state: str = "INTERRUPT_REQUIRED",
+        worker_status: str,
+        completion_signals: list[str] | None = None,
+        required_action: str = "TERMINALIZE",
+    ) -> None:
+        ticket = json.loads(ticket_path.read_text(encoding="utf-8"))
+        ticket["fencing_token"] = fence
+        ticket_path.write_text(json.dumps(ticket, sort_keys=True) + "\n", encoding="utf-8")
+        state_path = self.state / "fake-state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        task = state["tasks"][ticket["task_id"]]
+        task["fencing_token"] = fence
+        task["claim_fencing_token"] = fence
+        task["lifecycle"] = {
+            "task_id": ticket["task_id"],
+            "lifecycle_state": lifecycle_state,
+            "worker_status": worker_status,
+            "completion_signals": (
+                ["worker-final"]
+                if completion_signals is None
+                else completion_signals
+            ),
+            "required_action": required_action,
+        }
+        task["control_schema_hold"] = None
+        state_path.write_text(json.dumps(state, sort_keys=True) + "\n", encoding="utf-8")
+
+    def local_only_handback(
+        self,
+        ticket_path: Path,
+        *,
+        handback_id: str,
+        now: str,
+        disposition: str = "completed_local_only",
+    ) -> Path:
+        ticket = json.loads(ticket_path.read_text(encoding="utf-8"))
+        value = handback_request(
+            task_id=ticket["task_id"],
+            handback_id=handback_id,
+            now=now,
+        )
+        for key in (
+            "policy_snapshot_revision",
+            "lease_epoch",
+            "fencing_token",
+        ):
+            value[key] = ticket[key]
+        value["disposition"] = disposition
+        value["exact_refs"] = {
+            "base_sha": "a" * 40,
+            "candidate_sha": (
+                None if disposition == "completed_local_artifact" else "b" * 40
+            ),
+            "pr_url": None,
+            "merge_sha": None,
+            "default_sha": None,
+        }
+        value["external_delivery"] = "not_performed"
+        if disposition == "completed_local_artifact":
+            value["local_artifact"] = {
+                "algorithm": "sha256",
+                "entries": [
+                    {
+                        "relative_path": "synthetic/report.json",
+                        "transition": "created",
+                        "before_sha256": None,
+                        "after_sha256": "c" * 64,
+                    }
+                ],
+                "manifest_sha256": "d" * 64,
+                "rollback": {
+                    "strategy": "restore_base",
+                    "evidence_ref": "synthetic-rollback",
+                },
+            }
+        value["resources"] = [
+            {
+                "id": ticket["owner_claim_id"],
+                "disposition": "removed",
+                "reason": "synthetic fenced owner claim released",
+                "bytes": 0,
+            }
+        ]
+        return write_json(self.root / f"{handback_id}.json", value)
 
     def test_interrupted_notloaded_clean_handback_refills_once_without_owner_prompt(self):
         predecessor = self.start_predecessor()
@@ -224,6 +350,414 @@ class RefillSagaTestCase(unittest.TestCase):
             iso(minutes=4),
         )
         self.assertEqual(archived.returncode, 0, archived.stderr)
+
+    def test_stream_recorder_fence_38_expired_hold_replays_local_only_to_empty(self):
+        predecessor = self.start_predecessor()
+        self.set_control_schema_hold(predecessor, fence=38)
+        handback = self.local_only_handback(
+            predecessor,
+            handback_id="stream-recorder-fence-38",
+            now=iso(minutes=31),
+        )
+        refill = write_json(
+            self.root / "stream-recorder-refill.json",
+            refill_request(
+                request_id="stream-recorder-fence-38",
+                now=iso(minutes=31),
+            ),
+        )
+
+        closed = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(0, closed.returncode, closed.stderr)
+        result = json.loads(closed.stdout)["result"]
+        self.assertEqual("EMPTY", result["outcome"])
+        self.assertTrue(result["capacity_released"])
+        self.assertEqual([], result["launches"])
+        state = json.loads((self.state / "fake-state.json").read_text(encoding="utf-8"))
+        task = state["tasks"]["task-predecessor"]
+        self.assertEqual("ARCHIVE_PENDING", task["state"])
+        self.assertIsNone(task["control_schema_hold"])
+        self.assertEqual("COMPLETED", task["lifecycle"]["lifecycle_state"])
+        saga = json.loads(
+            (self.state / "pm-proxy-refill-ledger.json").read_text(encoding="utf-8")
+        )["sagas"]["stream-recorder-fence-38"]
+        events = [item["event"] for item in saga["events"]]
+        self.assertEqual("CAPACITY_RELEASED", events[0])
+        self.assertIn("EMPTY", events)
+
+    def test_screen_sanitizer_fence_41_expired_terminal_evidence_replays_artifact(self):
+        predecessor = self.start_predecessor("-screen-sanitizer")
+        self.set_terminal_evidence(
+            predecessor,
+            fence=41,
+            worker_status="completed",
+        )
+        handback = self.local_only_handback(
+            predecessor,
+            handback_id="screen-sanitizer-fence-41",
+            now=iso(minutes=31),
+            disposition="completed_local_artifact",
+        )
+        refill = write_json(
+            self.root / "screen-sanitizer-fence-41-refill.json",
+            refill_request(
+                request_id="screen-sanitizer-fence-41",
+                now=iso(minutes=31),
+            ),
+        )
+
+        closed = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(0, closed.returncode, closed.stderr)
+        self.assertEqual("EMPTY", json.loads(closed.stdout)["result"]["outcome"])
+        state = json.loads((self.state / "fake-state.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            "ARCHIVE_PENDING",
+            state["tasks"]["task-predecessor-screen-sanitizer"]["state"],
+        )
+
+    def test_screenbench_fence_42_expired_waiting_terminal_evidence_closes_empty(self):
+        predecessor = self.start_predecessor("-screenbench")
+        self.set_terminal_evidence(
+            predecessor,
+            fence=42,
+            worker_status="waiting",
+        )
+        handback = self.local_only_handback(
+            predecessor,
+            handback_id="screenbench-fence-42",
+            now=iso(minutes=31),
+        )
+        refill = write_json(
+            self.root / "screenbench-fence-42-refill.json",
+            refill_request(
+                request_id="screenbench-fence-42",
+                now=iso(minutes=31),
+            ),
+        )
+
+        closed = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(0, closed.returncode, closed.stderr)
+        result = json.loads(closed.stdout)["result"]
+        self.assertEqual("EMPTY", result["outcome"])
+        self.assertTrue(result["capacity_released"])
+        self.assertEqual([], result["launches"])
+
+    def test_expired_completion_candidate_request_handback_replays_local_only(self):
+        predecessor = self.start_predecessor("-completion-candidate")
+        self.set_terminal_evidence(
+            predecessor,
+            fence=43,
+            lifecycle_state="COMPLETION_CANDIDATE",
+            worker_status="completed",
+            required_action="REQUEST_HANDBACK",
+        )
+        handback = self.local_only_handback(
+            predecessor,
+            handback_id="completion-candidate-fence-43",
+            now=iso(minutes=31),
+        )
+        refill = write_json(
+            self.root / "completion-candidate-fence-43-refill.json",
+            refill_request(
+                request_id="completion-candidate-fence-43",
+                now=iso(minutes=31),
+            ),
+        )
+
+        closed = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(0, closed.returncode, closed.stderr)
+        self.assertEqual("EMPTY", json.loads(closed.stdout)["result"]["outcome"])
+
+    def test_expired_hold_mismatch_and_ordinary_expiry_remain_stale(self):
+        predecessor = self.start_predecessor()
+        handback = self.local_only_handback(
+            predecessor,
+            handback_id="stream-recorder-mismatch",
+            now=iso(minutes=31),
+        )
+        refill = write_json(
+            self.root / "stream-recorder-mismatch-refill.json",
+            refill_request(
+                request_id="stream-recorder-mismatch",
+                now=iso(minutes=31),
+            ),
+        )
+
+        ordinary = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(2, ordinary.returncode)
+        self.assertEqual("RECEIPT_STALE", json.loads(ordinary.stderr)["error"]["code"])
+
+        for label, replay_target, hold_fence in (
+            ("target", "completed_local_artifact", 38),
+            ("fence", "completed_local_only", 39),
+        ):
+            with self.subTest(label=label):
+                self.set_control_schema_hold(
+                    predecessor,
+                    fence=38,
+                    replay_target=replay_target,
+                    hold_fence=hold_fence,
+                )
+                handback = self.local_only_handback(
+                    predecessor,
+                    handback_id="stream-recorder-mismatch",
+                    now=iso(minutes=31),
+                )
+                rejected = self.run_script(
+                    REFILL,
+                    "close-and-refill",
+                    "--predecessor-ticket",
+                    str(predecessor),
+                    "--handback-request",
+                    str(handback),
+                    "--refill-request",
+                    str(refill),
+                )
+                self.assertEqual(2, rejected.returncode)
+                self.assertEqual(
+                    "RECEIPT_STALE",
+                    json.loads(rejected.stderr)["error"]["code"],
+                )
+                state = json.loads(
+                    (self.state / "fake-state.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(
+                    "RUNNING",
+                    state["tasks"]["task-predecessor"]["state"],
+                )
+                self.assertFalse(
+                    any(row["kind"] == "ARCHIVE_THREAD" for row in state["outbox"].values())
+                )
+
+    def test_close_and_refill_still_requires_a_committed_receipt(self):
+        predecessor = self.start_predecessor("-missing-receipt")
+        ticket = json.loads(predecessor.read_text(encoding="utf-8"))
+        ticket["receipt"] = None
+        predecessor.write_text(
+            json.dumps(ticket, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        handback = write_json(
+            self.root / "missing-receipt-handback.json",
+            handback_request(
+                task_id="task-predecessor-missing-receipt",
+                handback_id="missing-receipt",
+                now=iso(minutes=2),
+            ),
+        )
+        refill = write_json(
+            self.root / "missing-receipt-refill.json",
+            refill_request(request_id="missing-receipt"),
+        )
+
+        rejected = self.run_script(
+            REFILL,
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        self.assertEqual(2, rejected.returncode)
+        self.assertEqual(
+            "RECEIPT_MISSING",
+            json.loads(rejected.stderr)["error"]["code"],
+        )
+
+    def test_expired_terminal_evidence_identity_and_lifecycle_mismatches_stay_stale(self):
+        predecessor = self.start_predecessor("-terminal-mismatch")
+        self.set_terminal_evidence(
+            predecessor,
+            fence=41,
+            worker_status="completed",
+        )
+        state_path = self.state / "fake-state.json"
+        baseline = json.loads(state_path.read_text(encoding="utf-8"))
+        refill = write_json(
+            self.root / "terminal-mismatch-refill.json",
+            refill_request(
+                request_id="terminal-mismatch",
+                now=iso(minutes=31),
+            ),
+        )
+
+        for label in (
+            "task",
+            "policy",
+            "lease",
+            "fence",
+            "thread",
+            "claim",
+            "missing-signals",
+            "wrong-action",
+            "running",
+            "nonlocal-disposition",
+        ):
+            with self.subTest(label=label):
+                state = json.loads(json.dumps(baseline))
+                task = state["tasks"]["task-predecessor-terminal-mismatch"]
+                if label == "task":
+                    task["task_id"] = "different-task"
+                elif label == "policy":
+                    task["policy_snapshot_revision"] += 1
+                elif label == "lease":
+                    task["lease_expires_at"] = iso(minutes=29)
+                elif label == "fence":
+                    task["claim_fencing_token"] += 1
+                elif label == "thread":
+                    task["receipt_external_thread_id"] = "different-thread"
+                elif label == "claim":
+                    task["owner_claim_id"] = "different-claim"
+                elif label == "missing-signals":
+                    task["lifecycle"]["completion_signals"] = []
+                elif label == "wrong-action":
+                    task["lifecycle"]["required_action"] = "CONTINUE"
+                elif label == "running":
+                    task["lifecycle"]["lifecycle_state"] = "RUNNING"
+                state_path.write_text(
+                    json.dumps(state, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                handback = self.local_only_handback(
+                    predecessor,
+                    handback_id=f"terminal-mismatch-{label}",
+                    now=iso(minutes=31),
+                )
+                if label == "nonlocal-disposition":
+                    value = json.loads(handback.read_text(encoding="utf-8"))
+                    value["disposition"] = "completed"
+                    handback.write_text(
+                        json.dumps(value, sort_keys=True) + "\n",
+                        encoding="utf-8",
+                    )
+                rejected = self.run_script(
+                    REFILL,
+                    "close-and-refill",
+                    "--predecessor-ticket",
+                    str(predecessor),
+                    "--handback-request",
+                    str(handback),
+                    "--refill-request",
+                    str(refill),
+                )
+                self.assertEqual(2, rejected.returncode)
+                self.assertEqual(
+                    "RECEIPT_STALE",
+                    json.loads(rejected.stderr)["error"]["code"],
+                )
+                unchanged = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    "RUNNING",
+                    unchanged["tasks"]["task-predecessor-terminal-mismatch"][
+                        "state"
+                    ],
+                )
+                self.assertFalse(
+                    any(
+                        row["kind"] == "ARCHIVE_THREAD"
+                        for row in unchanged["outbox"].values()
+                    )
+                )
+
+    def test_no_commit_retry_is_idempotent_and_releases_nothing_early(self):
+        predecessor = self.start_predecessor()
+        handback = write_json(
+            self.root / "screenbench-fence-42-no-commit.json",
+            handback_request(
+                task_id="task-predecessor",
+                handback_id="screenbench-fence-42-no-commit",
+                now=iso(minutes=2),
+            ),
+        )
+        refill = write_json(
+            self.root / "screenbench-fence-42-no-commit-refill.json",
+            refill_request(request_id="screenbench-fence-42-no-commit"),
+        )
+        command = (
+            "close-and-refill",
+            "--predecessor-ticket",
+            str(predecessor),
+            "--handback-request",
+            str(handback),
+            "--refill-request",
+            str(refill),
+        )
+        before = json.loads((self.state / "fake-state.json").read_text(encoding="utf-8"))
+        failed = self.run_script(REFILL, *command, mode="fail-before-handback-commit")
+        self.assertEqual(2, failed.returncode)
+        self.assertEqual(
+            "SYNTHETIC_HANDBACK_NOT_COMMITTED",
+            json.loads(failed.stderr)["error"]["code"],
+        )
+        after_failure = json.loads(
+            (self.state / "fake-state.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(before["recycle_revision"], after_failure["recycle_revision"])
+        self.assertEqual(
+            "RUNNING",
+            after_failure["tasks"]["task-predecessor"]["state"],
+        )
+        self.assertEqual({}, after_failure["handbacks"])
+        self.assertFalse(
+            any(row["kind"] == "ARCHIVE_THREAD" for row in after_failure["outbox"].values())
+        )
+        self.assertFalse((self.state / "pm-proxy-refill-ledger.json").exists())
+
+        closed = self.run_script(REFILL, *command)
+        self.assertEqual(0, closed.returncode, closed.stderr)
+        replayed = self.run_script(REFILL, *command)
+        self.assertEqual(0, replayed.returncode, replayed.stderr)
+        self.assertTrue(json.loads(replayed.stdout)["result"]["replayed"])
+        state = json.loads((self.state / "fake-state.json").read_text(encoding="utf-8"))
+        archives = [row for row in state["outbox"].values() if row["kind"] == "ARCHIVE_THREAD"]
+        self.assertEqual(1, len(archives))
 
     def test_under_capacity_exact_replacement_is_not_still_runnable(self):
         predecessor = self.start_predecessor("-target")


### PR DESCRIPTION
## Summary

- admit expired committed receipts only for exact local-completion terminal evidence
- prove current task, launch receipt, external thread, policy, lease, fence, and active claim before stale replay
- keep cleanup, claim release, archive, and refill behind authoritative handback commit
- cover Stream Recorder fence 38, Screen Sanitizer fence 41, and ScreenBench fence 42 with synthetic saga and MCP regressions

## Candidate evidence

- exact base: 1fae1e12bd69e6ae16f60ffaccb3e08a86a1fe5c
- focused corrected regressions: pass
- full plugin suite: 97 tests pass, 3 skipped
- repository control regression: 107 tests pass
- all four stacks stamp cleanly with base answers and orchestrator-session enabled
- token, GitHub expression, shell syntax, generated Python compile, privacy, secret, scope, and diff checks: pass

## Boundaries

Synthetic temporary ledgers only. No live control state, installed plugin cache, runtime pin, adoption, Desktop host, product repository, release, or deployment mutation.

## Rollback

Revert the squash merge commit.