### PR TITLE
chore(template): package PM proxy plugin 0.4.3

### DIFF
--- a/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
+++ b/addons/orchestrator_session/common/orchestrator-control/orchestrator_control.py
@@ -7237,7 +7237,7 @@ def validate_dispatcher_adoption(value: Any) -> dict[str, Any]:
     )
     if (
         re.fullmatch(
-            r"(?:0\.3\.(?:0|1|2|3|4|5|6)|0\.4\.(?:0|1|2))(?:\+codex\.\d{14})?",
+            r"(?:0\.3\.(?:0|1|2|3|4|5|6)|0\.4\.(?:0|1|2|3))(?:\+codex\.\d{14})?",
             plugin_version,
         )
         is None

--- a/addons/orchestrator_session/common/orchestrator-control/schemas/dispatcher-adoption.request.schema.json
+++ b/addons/orchestrator_session/common/orchestrator-control/schemas/dispatcher-adoption.request.schema.json
@@ -15,7 +15,7 @@
     "interface_version": {"const": "1.0"},
     "request_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"},
     "adoption_mode": {"const": "COVERED_PATH_GUARDRAIL"},
-    "plugin_version": {"type": "string", "pattern": "^(?:0\\.3\\.(?:0|1|2|3|4|5|6)|0\\.4\\.(?:0|1|2))(?:\\+codex\\.[0-9]{14})?$"},
+    "plugin_version": {"type": "string", "pattern": "^(?:0\\.3\\.(?:0|1|2|3|4|5|6)|0\\.4\\.(?:0|1|2|3))(?:\\+codex\\.[0-9]{14})?$"},
     "proofs": {
       "type": "object",
       "additionalProperties": false,

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/.codex-plugin/plugin.json
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-proxy-orchestrator",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Fail-closed agent-CLI wrapper for the Firestarter cross-task control plane.",
   "author": {
     "name": "Firestarter contributors"

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/CHANGELOG.md
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## Unreleased
 
-- Allow only exact authoritative terminal evidence to carry an expired
-  committed receipt through `close-and-refill`: either an active matching
-  `CONTROL_SCHEMA_HOLD`, or a completion-signalled `COMPLETION_CANDIDATE` /
-  `INTERRUPT_REQUIRED` lifecycle with its matching required action. Admit both
-  local completion dispositions to authoritative control validation, and keep
-  recycle/release effects behind the atomic handback commit.
+## 0.4.3 - 2026-08-04
+
+- Fix stale receipt-fenced local-completion replay by accepting only matching
+  authoritative terminal evidence and keeping handback, release, and recycle
+  effects atomic.
 
 ## 0.4.2 - 2026-08-04
 

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/README.md
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/README.md
@@ -1,6 +1,6 @@
 # PM Proxy Orchestrator
 
-Version `0.4.2` is a source-only agent-CLI plugin for Firestarter control-plane
+Version `0.4.3` is a source-only agent-CLI plugin for Firestarter control-plane
 interface `1.0` and control bundle `1.4.2`. It makes typed configured-capacity
 compare-and-set, task reservation, policy receipts, approval routing, fenced
 handback, successor creation, and queue recycling operational without installing
@@ -21,7 +21,7 @@ lifecycle action. Hosted paths, opt-outs, reauthorization gaps, and universal
 non-spoofable caller identity remain unresolved. See
 `docs/DISPATCHER_ENFORCEMENT.md`.
 
-Version `0.4.2` also includes an opt-in Desktop app-server proxy. An
+Version `0.4.3` also includes an opt-in Desktop app-server proxy. An
 owner-selected exact task ID is attested as root through a private local socket;
 other task IDs remain workers, so visible workers do not inherit a process-wide
 root role. The adapter requires current pin/doctor state and a fresh native-hook

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/docs/DESKTOP_HOST_ADAPTER.md
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/docs/DESKTOP_HOST_ADAPTER.md
@@ -1,6 +1,6 @@
 # Codex Desktop host adapter
 
-Version `0.4.2` includes an opt-in desktop host adapter for one exact root task.
+Version `0.4.3` includes an opt-in desktop host adapter for one exact root task.
 It does not export `ROOT_ORCHESTRATOR_ROLE` to the normal desktop process and it
 does not infer root identity from a prompt, working directory, project, or
 model-visible field.
@@ -89,7 +89,7 @@ non-secret instance ID.
 ## Operator workflow
 
 Run these commands from an owner-controlled terminal, outside an enforced root
-task. First install the complete `0.4.2` plugin, recreate the runtime pin for the
+task. First install the complete `0.4.3` plugin, recreate the runtime pin for the
 reviewed clean Firestarter runtime, and run doctor. Keep any global
 `ROOT_ORCHESTRATOR_ROLE` export unset.
 

--- a/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/scripts/mcp_server.py
+++ b/addons/orchestrator_session/common/plugins/pm-proxy-orchestrator/scripts/mcp_server.py
@@ -41,7 +41,7 @@ BRIDGE = (
     / "pm_proxy_bridge.py"
 )
 REFILL = BRIDGE.with_name("refill_saga.py")
-SERVER_VERSION = "0.4.2"
+SERVER_VERSION = "0.4.3"
 MAX_MESSAGE_BYTES = 2_000_000
 OPAQUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 UTC = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$")

--- a/tests/test_orchestrator_session_contract.py
+++ b/tests/test_orchestrator_session_contract.py
@@ -276,7 +276,7 @@ class OrchestratorSessionContractTests(unittest.TestCase):
         self.assertEqual(entry["name"], manifest["name"])
         self.assertRegex(
             manifest["version"],
-            r"^0\.4\.2(?:\+codex\.\d{14})?$",
+            r"^0\.4\.3(?:\+codex\.\d{14})?$",
         )
         self.assertEqual("./skills/", manifest["skills"])
         self.assertEqual("./.mcp.json", manifest["mcpServers"])


### PR DESCRIPTION
## Summary

- package PM proxy orchestrator plugin 0.4.3 on control bundle 1.4.2 / interface 1.0
- admit 0.4.3 in both dispatcher-adoption schema and executable validation while preserving older compatibility
- update the root marketplace/session contract to expect current plugin 0.4.3

## Verification

- plugin suite: 97 tests, 3 expected skips, privacy/source scan pass
- root session contract: 2 tests pass
- required orchestrator regression group: 107 tests pass
- 8 Docker stamps: four default plus four orchestrator add-on outputs
- no token leaks; GitHub expressions preserved; generated shell parse and generator compile pass
- manifest/marketplace validation and exact-diff gitleaks scan pass

## Boundaries

Source packaging only. No plugin install/adoption, runtime pin, live ORC state, host, capacity, federation, product repository, deployment, or release mutation.