### PR TITLE
chore(gitignore): ignore scratchpad/ — origin is PUBLIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 /tmp/
 *.local.json
 answers.json
+
+# Local working notes. This repo's origin is PUBLIC — scratchpad/ accumulates
+# untracked working files (ops notes naming live infra, personal working sets)
+# that must never be swept in by a stray `git add -A`.
+scratchpad/


### PR DESCRIPTION
`scratchpad/` had **no ignore rule** in this repo while accumulating ~327 untracked working files — ops notes naming live GCP services and an exploitable URL, plus personal working sets.

**Nothing has leaked.** Verified zero `scratchpad/` paths are tracked locally and zero exist on `origin/master` or any pushed branch. The risk was prospective: the directory sat one stray `git add -A` away from publication to a public repo — the shared-clone hazard this setup is most exposed to.

Found while auditing Cloud Run traffic tags; the ops notes that prompted the check were themselves sitting unignored in the public tree.

**Verification**
- `git check-ignore -v scratchpad/_probe.txt` → matches at `.gitignore:16`
- `git add -A --dry-run` → captures zero `scratchpad/` paths
- Diff is one file, five lines

Supersedes #101, which was cut from a stale base and showed 100 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)