### PR TITLE
feat(prototypes): notebook-crypto — cloud-blind envelope encryption

### DIFF
--- a/prototypes/notebook-crypto/.gitignore
+++ b/prototypes/notebook-crypto/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/prototypes/notebook-crypto/README.md
+++ b/prototypes/notebook-crypto/README.md
@@ -1,0 +1,53 @@
+# notebook-crypto
+
+Cloud-blind envelope encryption for a per-user notebook. The store holds only
+ciphertext; neither the operator, the server, nor the cloud provider can read a
+user's content — including in backups.
+
+**This is public on purpose.** Its security rests only on the keys, never on the
+code being secret (Kerckhoffs's principle) — so publishing it doesn't help an
+attacker, and open, auditable crypto is how you *earn* the "even we can't see it"
+claim instead of just asserting it.
+
+## What it guarantees (all proven, not assumed)
+- **Round-trip fidelity** — byte-exact for every field/type.
+- **Server-blind at rest** — stored bytes (and DB dumps) contain no plaintext.
+- **Dual-key** — a user share AND a system share are BOTH required, for the field
+  encryption AND the blind index; either alone is useless. Shares are validated
+  (exactly 32 bytes) so an empty/short share fails closed, never silently
+  collapsing the 2-of-2. The two combine only on the user's device.
+- **Recovery** — a user recovery code re-derives the user share on a new device;
+  the operator still cannot decrypt. A malformed code is rejected, not
+  mis-derived into a lockout.
+- **Per-user blind index** — the server dedups by canonical name without reading
+  it, and the same name in two notebooks produces *different* tags (no linkage).
+- **Tamper-evident, no substitution** — a modified byte, or a ciphertext moved to
+  another (tenant, field, row), fails closed, bound by an injective
+  per-(tenant, field, row, version) AAD folded into both layers.
+- **Rollback resistance is conditional** (read this): the AAD gives integrity of
+  *association*, not *freshness*. A rolled-back version fails closed **only when
+  the `version` (and full `RecordContext`) passed at open time comes from a
+  trusted, monotonic source** — a server-side row counter under RLS, or a
+  client-held monotonic clock — **never** the version stored beside the ciphertext
+  and handed back by the untrusted store (that design silently rolls back). The
+  library does not enforce monotonicity and cannot detect a reused/forgotten
+  version bump; that is the caller's invariant.
+
+## Primitives (standard, vetted — nothing invented)
+AES-256-GCM, HKDF-SHA256, HMAC-SHA256 via `pyca/cryptography`. The same primitives
+exist in Apple CryptoKit and the WebCrypto API. Known-answer vectors for the
+deterministic layers (KEK, blind-index key + tag, recovery-share, canonicalize)
+are committed in `tests/test_vectors.py`; the CryptoKit/WebCrypto ports (not yet
+written) must reproduce them byte-for-byte before they are trusted.
+
+## Not in here (stays private, by design)
+Keys and secrets; how the system share is protected/released server-side; and the
+notebook/clinical domain wiring. This library is only the reusable crypto glue.
+
+## Test
+```
+python -m venv .venv && ./.venv/bin/pip install cryptography pytest 'psycopg[binary]'
+./.venv/bin/python -m pytest -q          # in-memory property matrix
+./scripts/mutation_check.sh              # 7 mutations prove the core guarantees are load-bearing
+```
+Set `NOTEBOOK_CRYPTO_PG_DSN` to also run the real-Postgres sample-DB harness.

--- a/prototypes/notebook-crypto/notebook_crypto/__init__.py
+++ b/prototypes/notebook-crypto/notebook_crypto/__init__.py
@@ -1,0 +1,51 @@
+"""notebook-crypto — cloud-blind envelope encryption for a per-user notebook.
+
+Standard primitives (AES-256-GCM, HKDF-SHA256, HMAC-SHA256), composed into a
+dual-key envelope where a user share and a system share are BOTH required to
+decrypt, plus a per-user blind index that lets the server dedup without reading.
+
+Security rests only on the keys, never on this code being secret (Kerckhoffs) —
+which is why it can be public and auditable.
+"""
+
+from .blind_index import blind_index, canonicalize, derive_bi_key
+from .envelope import (
+    RecordContext,
+    SealedRecord,
+    derive_kek,
+    open_record,
+    seal,
+)
+from .primitives import (
+    aead_decrypt,
+    aead_encrypt,
+    ct_equal,
+    hkdf_sha256,
+    hmac_sha256,
+    random_bytes,
+)
+from .recovery import (
+    MalformedRecoveryCode,
+    generate_recovery_code,
+    user_share_from_recovery_code,
+)
+
+__all__ = [
+    "RecordContext",
+    "SealedRecord",
+    "seal",
+    "open_record",
+    "derive_kek",
+    "blind_index",
+    "derive_bi_key",
+    "canonicalize",
+    "generate_recovery_code",
+    "user_share_from_recovery_code",
+    "MalformedRecoveryCode",
+    "aead_encrypt",
+    "aead_decrypt",
+    "hkdf_sha256",
+    "hmac_sha256",
+    "ct_equal",
+    "random_bytes",
+]

--- a/prototypes/notebook-crypto/notebook_crypto/blind_index.py
+++ b/prototypes/notebook-crypto/notebook_crypto/blind_index.py
@@ -1,0 +1,56 @@
+"""Per-user deterministic blind index for server-side MERGE/dedup.
+
+The server dedups entities by canonical name WITHOUT reading the name: the client
+computes HMAC-SHA256(bi_key, canonical(name)) and the server matches on the tag.
+
+Hardening after adversarial review:
+  * The blind-index key now derives from BOTH shares (like the KEK), not the user
+    share alone. Previously a single-share holder could recover the whole name
+    column by offline dictionary attack; now a tag cannot be computed or attacked
+    without both shares, and the server (system share only) still cannot compute
+    one. The client holds both shares at seal time, so no new exposure.
+  * Canonicalization is NFKC + casefold + Unicode format-character stripping, so
+    compatibility/fullwidth/ligature/ß/zero-width/soft-hyphen spellings of the
+    same name dedup instead of silently fragmenting. Pinned by known-answer
+    vectors for cross-client parity.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from . import primitives as P
+from .envelope import _lp, _require_share
+
+_BI_INFO = b"notebook/blind-index-key/v1"
+_BI_SALT = b"notebook/blind-index/salt/v1"
+
+
+def derive_bi_key(user_share: bytes, system_share: bytes) -> bytes:
+    """Blind-index key from BOTH shares. The server (system share only) cannot
+    derive it; a lone user share cannot either."""
+    _require_share(user_share, "user_share")
+    _require_share(system_share, "system_share")
+    return P.hkdf_sha256(ikm=_lp(user_share) + _lp(system_share), salt=_BI_SALT, info=_BI_INFO)
+
+
+def _strip_format(text: str) -> str:
+    # Drop Unicode default-ignorable / format (category Cf) characters:
+    # zero-width joiners/spaces (200B–200D), BOM (FEFF), soft hyphen (00AD), etc.
+    return "".join(ch for ch in text if unicodedata.category(ch) != "Cf")
+
+
+def canonicalize(text: str) -> str:
+    """The canonical form the MERGE identity keys on. NFKC folds compatibility and
+    width variants; casefold is stronger than lower() for non-ASCII; format chars
+    are removed; whitespace is collapsed. Any drift here silently breaks dedup, so
+    it is pinned by tests and known-answer vectors."""
+    t = unicodedata.normalize("NFKC", text)
+    t = _strip_format(t).casefold()
+    return " ".join(t.split())
+
+
+def blind_index(bi_key: bytes, text: str) -> str:
+    """Opaque, deterministic tag for `text`. Hex so it drops straight into a text
+    column and an equality index."""
+    return P.hmac_sha256(bi_key, canonicalize(text).encode("utf-8")).hex()

--- a/prototypes/notebook-crypto/notebook_crypto/envelope.py
+++ b/prototypes/notebook-crypto/notebook_crypto/envelope.py
@@ -1,0 +1,131 @@
+"""The dual-key envelope: user + system shares BOTH required to decrypt.
+
+Content is sealed under a random per-record DEK; the DEK is wrapped under a KEK
+derived from BOTH shares. Missing/wrong either share → wrong KEK → the DEK
+unwrap fails (AES-GCM auth error) → unreadable.
+
+Two integrity properties the AAD enforces, both bound into the DEK wrap AND the
+field encrypt so a whole-record swap cannot bypass them:
+  * substitution — a sealed blob only opens against its own (tenant, field, row)
+  * rollback — ...and only at its own version.
+
+Hardening after adversarial review:
+  * Shares are validated to be exactly 32 bytes and fail closed — an empty or
+    short share never silently collapses the 2-of-2 (was a fail-open break).
+  * The AAD is a length-prefixed, injective encoding of the record identity,
+    including a version, so ciphertexts cannot be swapped between rows or rolled
+    back (was substitutable/rollbackable within a (tenant, field)).
+  * from_bytes is fully bounds-checked and fails closed on malformed input.
+
+The load-bearing key-combination invariant still lives at the call sites:
+`derive_kek` must run only on the user's device, where both shares are present.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+from . import primitives as P
+
+_KEK_INFO = b"notebook/dek-kek/v1"
+_KEK_SALT = b"notebook/dek-kek/salt/v1"
+_WRAP_LAYER = b"notebook/dek-wrap/v1"
+_FIELD_LAYER = b"notebook/field/v1"
+
+
+def _require_share(value: bytes, name: str) -> None:
+    if not isinstance(value, (bytes, bytearray)) or len(value) != P.KEY_LEN:
+        raise ValueError(f"{name} must be exactly {P.KEY_LEN} bytes (got {len(value) if hasattr(value, '__len__') else type(value).__name__})")
+
+
+def _lp(part: bytes) -> bytes:
+    """Length-prefixed encoding — makes any concatenation of parts injective, so
+    no two distinct tuples of parts can produce the same byte string."""
+    return struct.pack(">I", len(part)) + bytes(part)
+
+
+def derive_kek(user_share: bytes, system_share: bytes) -> bytes:
+    """KEK = HKDF-SHA256 over BOTH validated shares. 2-of-2: neither alone derives
+    it, and an empty/short share is rejected rather than silently degrading."""
+    _require_share(user_share, "user_share")
+    _require_share(system_share, "system_share")
+    # length-prefixed so (user||system) is unambiguous even if lengths ever vary
+    return P.hkdf_sha256(ikm=_lp(user_share) + _lp(system_share), salt=_KEK_SALT, info=_KEK_INFO)
+
+
+@dataclass(frozen=True)
+class RecordContext:
+    """The identity a sealed record is bound to. `row_id` is a stable per-entity
+    identifier (a row UUID, or the entity's blind index); `version` is a
+    caller-supplied monotonic value so a superseded ciphertext cannot be replayed.
+    All are authenticated (as AAD), none are encrypted — they are already known to
+    the server and carry no plaintext content."""
+
+    tenant: bytes
+    field: bytes
+    row_id: bytes
+    version: bytes
+
+    def aad(self, layer: bytes) -> bytes:
+        return _lp(layer) + _lp(self.tenant) + _lp(self.field) + _lp(self.row_id) + _lp(self.version)
+
+
+@dataclass(frozen=True)
+class SealedRecord:
+    """Everything the server stores for one encrypted field: ciphertext, nonces,
+    and the twice-wrapped DEK. No plaintext, no key material."""
+
+    wrapped_dek_nonce: bytes
+    wrapped_dek: bytes
+    field_nonce: bytes
+    field_ct: bytes
+
+    def to_bytes(self) -> bytes:
+        return b"".join(_lp(p) for p in (self.wrapped_dek_nonce, self.wrapped_dek, self.field_nonce, self.field_ct))
+
+    @classmethod
+    def from_bytes(cls, blob: bytes) -> "SealedRecord":
+        if not isinstance(blob, (bytes, bytearray)):
+            raise ValueError("SealedRecord.from_bytes expects bytes")
+        blob = bytes(blob)
+        vals, off, n = [], 0, len(blob)
+        for _ in range(4):
+            if off + 4 > n:
+                raise ValueError("malformed SealedRecord: truncated length prefix")
+            (ln,) = struct.unpack(">I", blob[off : off + 4])
+            off += 4
+            # `off + ln > n` already bounds every slice to the actual input the
+            # caller is holding, so no allocation-amplification window exists —
+            # and there is no arbitrary size cap, so any field that seals also
+            # round-trips (no silent write/read asymmetry).
+            if off + ln > n:
+                raise ValueError("malformed SealedRecord: part length out of range")
+            vals.append(blob[off : off + ln])
+            off += ln
+        if off != n:
+            raise ValueError("malformed SealedRecord: trailing bytes")
+        return cls(*vals)
+
+
+def seal(
+    plaintext: bytes, user_share: bytes, system_share: bytes, ctx: RecordContext
+) -> SealedRecord:
+    """Encrypt `plaintext` bound to `ctx`. The record only ever opens against the
+    same (tenant, field, row_id, version)."""
+    kek = derive_kek(user_share, system_share)
+    dek = P.random_bytes(P.KEY_LEN)
+    wnonce, wdek = P.aead_encrypt(kek, dek, aad=ctx.aad(_WRAP_LAYER))
+    fnonce, fct = P.aead_encrypt(dek, plaintext, aad=ctx.aad(_FIELD_LAYER))
+    return SealedRecord(wnonce, wdek, fnonce, fct)
+
+
+def open_record(
+    rec: SealedRecord, user_share: bytes, system_share: bytes, ctx: RecordContext
+) -> bytes:
+    """Decrypt a SealedRecord. Raises InvalidTag if either share is wrong/missing,
+    if the record was moved to a different row, rolled back to an old version, or
+    tampered."""
+    kek = derive_kek(user_share, system_share)
+    dek = P.aead_decrypt(kek, rec.wrapped_dek_nonce, rec.wrapped_dek, aad=ctx.aad(_WRAP_LAYER))
+    return P.aead_decrypt(dek, rec.field_nonce, rec.field_ct, aad=ctx.aad(_FIELD_LAYER))

--- a/prototypes/notebook-crypto/notebook_crypto/primitives.py
+++ b/prototypes/notebook-crypto/notebook_crypto/primitives.py
@@ -1,0 +1,57 @@
+"""Thin wrappers over vetted primitives (pyca/cryptography → OpenSSL).
+
+Nothing here is invented crypto. Every function is a standard primitive that
+Apple CryptoKit and the browser WebCrypto API also implement, so the same inputs
+produce the same bytes on every client — which the cross-client test vectors then
+prove. Keep this file small and boring: the moment it stops being an obvious
+wrapper, it needs the same scrutiny as a primitive, which is exactly what we are
+avoiding.
+"""
+
+from __future__ import annotations
+
+import hmac as _stdlib_hmac
+import os
+
+from cryptography.hazmat.primitives import hashes, hmac
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+NONCE_LEN = 12  # AES-GCM standard nonce
+KEY_LEN = 32    # AES-256
+
+
+def random_bytes(n: int) -> bytes:
+    return os.urandom(n)
+
+
+def aead_encrypt(key: bytes, plaintext: bytes, aad: bytes = b"") -> tuple[bytes, bytes]:
+    """AES-256-GCM. Returns (nonce, ciphertext||tag). Fresh random nonce each call."""
+    if len(key) != KEY_LEN:
+        raise ValueError("key must be 32 bytes")
+    nonce = os.urandom(NONCE_LEN)
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
+    return nonce, ciphertext
+
+
+def aead_decrypt(key: bytes, nonce: bytes, ciphertext: bytes, aad: bytes = b"") -> bytes:
+    """AES-256-GCM open. Raises cryptography.exceptions.InvalidTag on a wrong key,
+    wrong AAD, or any tampering — it never returns garbage."""
+    if len(key) != KEY_LEN:
+        raise ValueError("key must be 32 bytes")
+    return AESGCM(key).decrypt(nonce, ciphertext, aad)
+
+
+def hkdf_sha256(ikm: bytes, salt: bytes, info: bytes, length: int = KEY_LEN) -> bytes:
+    return HKDF(algorithm=hashes.SHA256(), length=length, salt=salt, info=info).derive(ikm)
+
+
+def hmac_sha256(key: bytes, msg: bytes) -> bytes:
+    h = hmac.HMAC(key, hashes.SHA256())
+    h.update(msg)
+    return h.finalize()
+
+
+def ct_equal(a: bytes, b: bytes) -> bool:
+    """Constant-time comparison."""
+    return _stdlib_hmac.compare_digest(a, b)

--- a/prototypes/notebook-crypto/notebook_crypto/recovery.py
+++ b/prototypes/notebook-crypto/notebook_crypto/recovery.py
@@ -1,0 +1,59 @@
+"""User share ⟷ recovery code.
+
+The user share is the root of a user's access. Everyday it lives in the device
+keychain; to restore on a new device it is re-derived from a high-entropy
+recovery code the user saved at setup (the single "keep this safe" moment).
+Because the code is high-entropy, deriving the share from it is a plain KDF.
+
+Recovery model (b): the system share plus the user's recovery code re-establish
+access on a new device; neither the operator nor a lone system-share holder can.
+
+Hardening after adversarial review: the code is stripped of ALL Unicode
+whitespace and validated against its exact alphabet/length before use, so a
+copy-paste artifact (trailing newline, non-breaking space) is reported as a
+malformed code rather than silently deriving a wrong share and locking the user
+out of their own data.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import secrets
+
+from . import primitives as P
+
+_RC_INFO = b"notebook/user-share-from-recovery/v1"
+_RECOVERY_ENTROPY_BYTES = 20  # 160 bits → 32 base32 chars
+_CODE_RE = re.compile(r"^[A-Z2-7]{32}$")  # RFC 4648 base32 alphabet, unpadded
+
+
+class MalformedRecoveryCode(ValueError):
+    """The recovery code is not a well-formed code (wrong alphabet/length). Raised
+    distinctly so a formatting artifact is never confused with a valid-but-wrong
+    code that would derive a usable-looking but incorrect share."""
+
+
+def generate_recovery_code() -> str:
+    """A high-entropy code, grouped for legibility like a wallet seed phrase."""
+    raw = secrets.token_bytes(_RECOVERY_ENTROPY_BYTES)
+    b32 = base64.b32encode(raw).decode("ascii").rstrip("=")
+    return "-".join(b32[i : i + 5] for i in range(0, len(b32), 5))
+
+
+def _normalize_code(code: str) -> bytes:
+    if not isinstance(code, str):
+        raise MalformedRecoveryCode("recovery code must be a string")
+    # Strip ALL Unicode whitespace and grouping dashes, then uppercase.
+    compact = re.sub(r"[\s-]+", "", code, flags=re.UNICODE).upper()
+    if not _CODE_RE.match(compact):
+        raise MalformedRecoveryCode("recovery code is malformed")
+    return compact.encode("ascii")
+
+
+def user_share_from_recovery_code(code: str, user_salt: bytes) -> bytes:
+    """Deterministically derive the user share from a validated recovery code.
+    `user_salt` is a per-user, non-secret value that only separates users so
+    identical codes never collide. A wrong (but well-formed) code yields a wrong
+    share, so every later decrypt fails closed."""
+    return P.hkdf_sha256(ikm=_normalize_code(code), salt=user_salt, info=_RC_INFO)

--- a/prototypes/notebook-crypto/pyproject.toml
+++ b/prototypes/notebook-crypto/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "notebook-crypto"
+version = "0.1.0"
+description = "Cloud-blind envelope encryption: dual-key sealing + per-user blind index."
+requires-python = ">=3.11"
+dependencies = ["cryptography>=42"]
+
+[project.optional-dependencies]
+test = ["pytest>=8", "psycopg[binary]>=3.1"]
+
+[tool.setuptools.packages.find]
+include = ["notebook_crypto*"]

--- a/prototypes/notebook-crypto/scripts/mutation_check.sh
+++ b/prototypes/notebook-crypto/scripts/mutation_check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Mutation proof: every crypto guarantee is load-bearing. For each mutation we
+# break one behavior, prove a NAMED property test turns red, then restore the
+# source byte-identically (sha256 verified). Restore is cp-from-copy, never a
+# VCS checkout.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+PY=./.venv/bin/python
+
+fail=0
+mutate() {  # <file> <perl-expr> <target-test> <label>
+  local file="$1" expr="$2" test="$3" label="$4" before after
+  before="$(shasum -a 256 "$file" | awk '{print $1}')"
+  cp "$file" "$file.bak"
+  perl -0pi -e "$expr" "$file"
+  if [ "$(shasum -a 256 "$file" | awk '{print $1}')" = "$before" ]; then
+    echo "  ✗ $label — mutation did not change the file (pattern drift)"; fail=1
+    rm -f "$file.bak"; return
+  fi
+  if $PY -m pytest -q -k "$test" tests/test_properties.py tests/test_vectors.py >/dev/null 2>&1; then
+    echo "  ✗ $label — '$test' still PASSED under mutation (guarantee not load-bearing!)"; fail=1
+  else
+    echo "  ✓ $label — '$test' correctly died"
+  fi
+  cp "$file.bak" "$file"; rm -f "$file.bak"
+  after="$(shasum -a 256 "$file" | awk '{print $1}')"
+  [ "$before" = "$after" ] || { echo "  ✗ $label — restore not byte-identical"; fail=1; }
+}
+
+echo "mutation proofs:"
+mutate notebook_crypto/primitives.py \
+  's/ciphertext = AESGCM\(key\)\.encrypt\(nonce, plaintext, aad\)/ciphertext = plaintext/' \
+  test_sealed_bytes_contain_no_plaintext "M1 AEAD no-op → server-blind"
+mutate notebook_crypto/envelope.py \
+  's/ikm=_lp\(user_share\) \+ _lp\(system_share\), salt=_KEK_SALT/ikm=_lp(user_share), salt=_KEK_SALT/' \
+  test_open_fails_with_only_user_share "M2 KEK ignores system share → dual-key"
+mutate notebook_crypto/blind_index.py \
+  's/return P\.hkdf_sha256\(ikm=_lp\(user_share\) \+ _lp\(system_share\), salt=_BI_SALT, info=_BI_INFO\)/return b"\\x00" * 32/' \
+  test_same_name_across_users_yields_different_index "M3 constant blind-index key → per-user isolation"
+mutate notebook_crypto/envelope.py \
+  's/_lp\(self\.field\) \+ _lp\(self\.row_id\) \+ _lp\(self\.version\)/_lp(self.field) + _lp(self.version)/' \
+  test_ciphertext_cannot_be_substituted_into_another_row "M4 AAD drops row id → substitution"
+mutate notebook_crypto/envelope.py \
+  's/if not isinstance\(value, \(bytes, bytearray\)\) or len\(value\) != P\.KEY_LEN:/if False:/' \
+  test_derive_kek_rejects_empty_shares "M5 share validation off → fail-open"
+mutate notebook_crypto/blind_index.py \
+  's/t = unicodedata\.normalize\("NFKC", text\)/t = text/' \
+  test_canonicalization_folds_unicode_variants "M6 NFKC dropped → dedup fragments"
+mutate notebook_crypto/blind_index.py \
+  's/ikm=_lp\(user_share\) \+ _lp\(system_share\), salt=_BI_SALT/ikm=_lp(user_share), salt=_BI_SALT/' \
+  test_blind_index_key_vector "M7 blind-index single-share → KAT vector"
+mutate notebook_crypto/envelope.py \
+  's/_lp\(layer\) \+ _lp\(self\.tenant\) \+ _lp\(self\.field\)/_lp(layer) + _lp(self.field)/' \
+  test_ciphertext_cannot_be_substituted_across_tenants "M8 AAD drops tenant → cross-notebook substitution"
+mutate notebook_crypto/envelope.py \
+  's/_lp\(self\.tenant\) \+ _lp\(self\.field\) \+ _lp\(self\.row_id\)/_lp(self.tenant) + _lp(self.row_id)/' \
+  test_ciphertext_cannot_be_moved_between_fields "M9 AAD drops field → cross-field substitution"
+mutate notebook_crypto/envelope.py \
+  's/_lp\(self\.row_id\) \+ _lp\(self\.version\)/_lp(self.row_id)/' \
+  test_ciphertext_cannot_be_rolled_back_to_an_old_version "M10 AAD drops version → rollback"
+mutate notebook_crypto/envelope.py \
+  's/return _lp\(layer\) \+ _lp\(self\.tenant\)/return _lp(self.tenant)/' \
+  test_aad_wire_format_vector "M11 AAD drops layer label → wire-format vector"
+
+echo
+if [ "$fail" = 0 ]; then echo "ALL MUTATIONS KILLED ✓"; else echo "MUTATION CHECK FAILED ✗"; fi
+exit $fail

--- a/prototypes/notebook-crypto/tests/test_postgres_harness.py
+++ b/prototypes/notebook-crypto/tests/test_postgres_harness.py
@@ -1,0 +1,109 @@
+"""End-to-end against a REAL seeded Postgres (the shadow instance), not in memory.
+
+The "test with sample DBs, don't assume it just works" gate. Stores sealed
+records + dual-share blind indexes in a real table and proves, against actual
+storage: nothing plaintext at rest, dedup within a tenant, no cross-tenant
+linkage, a full round-trip, and that a row-substituted ciphertext fails to open.
+
+Skips if NOTEBOOK_CRYPTO_PG_DSN is unset. The runner points it at the shadow.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+import notebook_crypto as nc
+
+DSN = os.environ.get("NOTEBOOK_CRYPTO_PG_DSN")
+pytestmark = pytest.mark.skipif(not DSN, reason="NOTEBOOK_CRYPTO_PG_DSN not set")
+
+psycopg = pytest.importorskip("psycopg")
+
+
+@pytest.fixture
+def conn():
+    c = psycopg.connect(DSN, connect_timeout=8)
+    c.execute("CREATE SCHEMA IF NOT EXISTS crypto_harness")
+    c.execute("DROP TABLE IF EXISTS crypto_harness.entities")
+    c.execute(
+        "CREATE TABLE crypto_harness.entities ("
+        " tenant_key text NOT NULL,"
+        " name_bidx  text NOT NULL,"
+        " name_sealed bytea NOT NULL,"
+        " UNIQUE (tenant_key, name_bidx))"
+    )
+    c.commit()
+    try:
+        yield c
+    finally:
+        c.execute("DROP SCHEMA IF EXISTS crypto_harness CASCADE")
+        c.commit()
+        c.close()
+
+
+def _ctx(tenant, bidx):
+    return nc.RecordContext(tenant.encode(), b"name", bidx.encode(), b"1")
+
+
+def _store(conn, tenant, user_share, system_share, name):
+    bidx = nc.blind_index(nc.derive_bi_key(user_share, system_share), name)
+    sealed = nc.seal(name.encode(), user_share, system_share, _ctx(tenant, bidx)).to_bytes()
+    conn.execute(
+        "INSERT INTO crypto_harness.entities VALUES (%s,%s,%s) ON CONFLICT DO NOTHING",
+        (tenant, bidx, sealed),
+    )
+    conn.commit()
+    return bidx
+
+
+def test_server_blind_at_rest(conn):
+    ua, sa = nc.random_bytes(32), nc.random_bytes(32)
+    _store(conn, "tenantA", ua, sa, "WARFARIN_SENTINEL")
+    raw = bytes(conn.execute("SELECT name_sealed FROM crypto_harness.entities").fetchone()[0])
+    assert b"WARFARIN_SENTINEL" not in raw
+    dump = conn.execute(
+        "SELECT string_agg(encode(name_sealed,'escape'),'') FROM crypto_harness.entities"
+    ).fetchone()[0]
+    assert "WARFARIN" not in (dump or "")
+
+
+def test_dedup_within_tenant(conn):
+    ua, sa = nc.random_bytes(32), nc.random_bytes(32)
+    b1 = _store(conn, "tenantA", ua, sa, "Metoprolol")
+    b2 = _store(conn, "tenantA", ua, sa, "  metoprolol ")
+    assert b1 == b2
+    n = conn.execute(
+        "SELECT count(*) FROM crypto_harness.entities WHERE tenant_key='tenantA'"
+    ).fetchone()[0]
+    assert n == 1
+
+
+def test_no_cross_tenant_linkage(conn):
+    ua, sa = nc.random_bytes(32), nc.random_bytes(32)
+    ub, sb = nc.random_bytes(32), nc.random_bytes(32)
+    ba = _store(conn, "tenantA", ua, sa, "metoprolol")
+    bb = _store(conn, "tenantB", ub, sb, "metoprolol")
+    assert ba != bb
+
+
+def test_full_round_trip_through_db(conn):
+    ua, sa = nc.random_bytes(32), nc.random_bytes(32)
+    bidx = _store(conn, "tenantA", ua, sa, "lisinopril")
+    row = conn.execute(
+        "SELECT name_sealed FROM crypto_harness.entities WHERE tenant_key='tenantA'"
+    ).fetchone()
+    rec = nc.SealedRecord.from_bytes(bytes(row[0]))
+    assert nc.open_record(rec, ua, sa, _ctx("tenantA", bidx)) == b"lisinopril"
+
+
+def test_stored_blob_cannot_be_replayed_to_another_row(conn):
+    # pull a real stored blob and try to open it as if it were a different entity
+    ua, sa = nc.random_bytes(32), nc.random_bytes(32)
+    _store(conn, "tenantA", ua, sa, "warfarin")
+    row = conn.execute("SELECT name_sealed FROM crypto_harness.entities").fetchone()
+    rec = nc.SealedRecord.from_bytes(bytes(row[0]))
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, ua, sa, _ctx("tenantA", "some-other-row-bidx"))

--- a/prototypes/notebook-crypto/tests/test_properties.py
+++ b/prototypes/notebook-crypto/tests/test_properties.py
@@ -1,0 +1,232 @@
+"""The property matrix. Prove every combination; assume nothing.
+
+Covers the guarantees AND the classes the first adversarial review found
+untested: empty/short shares, cross-row substitution + rollback, dual-share
+blind index, NFKC canonicalization, and malformed-input handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+import notebook_crypto as nc
+
+USER_A = nc.random_bytes(32)
+SYS_A = nc.random_bytes(32)
+USER_B = nc.random_bytes(32)
+SYS_B = nc.random_bytes(32)
+
+
+def ctx(tenant="tenantA", field="name", row_id="row1", version=1):
+    return nc.RecordContext(
+        tenant.encode(), field.encode(), row_id.encode(), str(version).encode()
+    )
+
+
+SAMPLE_FIELDS = [
+    b"",
+    b"metoprolol",
+    "café / naïve — résumé".encode(),
+    b'{"dose":"25mg","route":"PO"}',
+    b"x" * 100_000,
+    bytes(range(256)),
+]
+
+
+# ---- 1. round-trip fidelity --------------------------------------------------
+
+@pytest.mark.parametrize("plaintext", SAMPLE_FIELDS)
+def test_round_trip_is_byte_exact(plaintext):
+    rec = nc.seal(plaintext, USER_A, SYS_A, ctx())
+    assert nc.open_record(rec, USER_A, SYS_A, ctx()) == plaintext
+
+
+# ---- 2. server-blind at rest -------------------------------------------------
+
+def test_sealed_bytes_contain_no_plaintext():
+    secret = b"WARFARIN-5MG-DAILY-SENTINEL"
+    rec = nc.seal(secret, USER_A, SYS_A, ctx())
+    blob = rec.to_bytes()
+    assert secret not in blob
+    assert nc.open_record(nc.SealedRecord.from_bytes(blob), USER_A, SYS_A, ctx()) == secret
+
+
+# ---- 3. dual-key enforcement: BOTH shares required ---------------------------
+
+def test_open_fails_with_only_user_share():
+    rec = nc.seal(b"secret", USER_A, SYS_A, ctx())
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, USER_A, nc.random_bytes(32), ctx())
+
+
+def test_open_fails_with_only_system_share():
+    rec = nc.seal(b"secret", USER_A, SYS_A, ctx())
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, nc.random_bytes(32), SYS_A, ctx())
+
+
+def test_open_succeeds_only_with_both():
+    rec = nc.seal(b"secret", USER_A, SYS_A, ctx())
+    assert nc.open_record(rec, USER_A, SYS_A, ctx()) == b"secret"
+
+
+# ---- 3b. empty/short shares fail closed (the fail-open break) -----------------
+
+@pytest.mark.parametrize("bad", [b"", b"short", bytes(31), bytes(33), None])
+def test_seal_rejects_bad_user_share(bad):
+    with pytest.raises(ValueError):
+        nc.seal(b"x", bad, SYS_A, ctx())
+
+
+@pytest.mark.parametrize("bad", [b"", b"short", bytes(31)])
+def test_seal_rejects_bad_system_share(bad):
+    with pytest.raises(ValueError):
+        nc.seal(b"x", USER_A, bad, ctx())
+
+
+def test_derive_kek_rejects_empty_shares():
+    with pytest.raises(ValueError):
+        nc.derive_kek(b"", b"")
+
+
+# ---- 4. recovery -------------------------------------------------------------
+
+def test_recovery_code_reconstructs_access():
+    salt = nc.random_bytes(16)
+    code = nc.generate_recovery_code()
+    us = nc.user_share_from_recovery_code(code, salt)
+    rec = nc.seal(b"my notebook", us, SYS_A, ctx())
+    again = nc.user_share_from_recovery_code(code, salt)
+    assert nc.open_record(rec, again, SYS_A, ctx()) == b"my notebook"
+
+
+def test_wrong_recovery_code_fails_closed():
+    salt = nc.random_bytes(16)
+    us = nc.user_share_from_recovery_code(nc.generate_recovery_code(), salt)
+    rec = nc.seal(b"my notebook", us, SYS_A, ctx())
+    wrong = nc.user_share_from_recovery_code(nc.generate_recovery_code(), salt)
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, wrong, SYS_A, ctx())
+
+
+def test_recovery_code_whitespace_artifact_is_rejected_not_silently_wrong():
+    salt = nc.random_bytes(16)
+    code = nc.generate_recovery_code()
+    clean = nc.user_share_from_recovery_code(code, salt)
+    # trailing newline / spaces must be tolerated (same share), not mis-derived
+    assert nc.user_share_from_recovery_code(code + "\n", salt) == clean
+    assert nc.user_share_from_recovery_code("  " + code + " ", salt) == clean
+    # a truly malformed code raises distinctly
+    with pytest.raises(nc.MalformedRecoveryCode):
+        nc.user_share_from_recovery_code("not-a-valid-code!!", salt)
+
+
+# ---- 5. blind index: dual-share, deterministic, isolated ---------------------
+
+def test_blind_index_is_deterministic_within_a_user():
+    k = nc.derive_bi_key(USER_A, SYS_A)
+    assert nc.blind_index(k, "Metoprolol") == nc.blind_index(k, "  metoprolol ")
+
+
+def test_blind_index_differs_for_different_names():
+    k = nc.derive_bi_key(USER_A, SYS_A)
+    assert nc.blind_index(k, "metoprolol") != nc.blind_index(k, "metformin")
+
+
+def test_same_name_across_users_yields_different_index():
+    ka = nc.derive_bi_key(USER_A, SYS_A)
+    kb = nc.derive_bi_key(USER_B, SYS_B)
+    assert nc.blind_index(ka, "metoprolol") != nc.blind_index(kb, "metoprolol")
+
+
+def test_blind_index_needs_both_shares():
+    with pytest.raises(ValueError):
+        nc.derive_bi_key(b"", SYS_A)
+    with pytest.raises(ValueError):
+        nc.derive_bi_key(USER_A, b"")
+
+
+def test_canonicalization_folds_unicode_variants():
+    k = nc.derive_bi_key(USER_A, SYS_A)
+    # NFC vs NFD spelling of the same accented name
+    assert nc.blind_index(k, "café") == nc.blind_index(k, "café")
+    # fullwidth + zero-width joiner + casefold
+    assert nc.blind_index(k, "Ｍｅ‍toprolol") == nc.blind_index(k, "metoprolol")
+
+
+# ---- 6. tamper + substitution + rollback -------------------------------------
+
+def test_tampered_ciphertext_is_rejected():
+    rec = nc.seal(b"secret", USER_A, SYS_A, ctx())
+    flipped = bytearray(rec.field_ct)
+    flipped[0] ^= 0x01
+    bad = nc.SealedRecord(rec.wrapped_dek_nonce, rec.wrapped_dek, rec.field_nonce, bytes(flipped))
+    with pytest.raises(InvalidTag):
+        nc.open_record(bad, USER_A, SYS_A, ctx())
+
+
+def test_ciphertext_cannot_be_substituted_into_another_row():
+    # THE clinical-safety break: swap a whole sealed blob onto a different row.
+    rec_x = nc.seal(b"warfarin", USER_A, SYS_A, ctx(row_id="rowX"))
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec_x, USER_A, SYS_A, ctx(row_id="rowY"))  # opened at another row → fails
+
+
+def test_ciphertext_cannot_be_rolled_back_to_an_old_version():
+    old = nc.seal(b"50mg", USER_A, SYS_A, ctx(field="dose", version=1))
+    with pytest.raises(InvalidTag):
+        nc.open_record(old, USER_A, SYS_A, ctx(field="dose", version=2))  # stale version → fails
+
+
+def test_ciphertext_cannot_be_moved_between_fields():
+    rec = nc.seal(b"secret", USER_A, SYS_A, ctx(field="name"))
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, USER_A, SYS_A, ctx(field="synonyms"))
+
+
+def test_ciphertext_cannot_be_substituted_across_tenants():
+    # `tenant` is the sole barrier against cross-notebook substitution for one
+    # user's two tenants under the SAME shares — so it must be load-bearing.
+    rec = nc.seal(b"warfarin", USER_A, SYS_A, ctx(tenant="tenantA"))
+    with pytest.raises(InvalidTag):
+        nc.open_record(rec, USER_A, SYS_A, ctx(tenant="tenantB"))
+
+
+def test_large_field_round_trips_no_silent_loss():
+    # A field larger than any past internal size cap must still round-trip — a
+    # write/read asymmetry would silently lose data (long clinical note, base64
+    # image). Exercises just past the old 1 MiB boundary.
+    for size in (1_048_560, 1_048_561, 2_000_000):
+        big = b"z" * size
+        rec = nc.seal(big, USER_A, SYS_A, ctx())
+        blob = rec.to_bytes()
+        assert nc.open_record(nc.SealedRecord.from_bytes(blob), USER_A, SYS_A, ctx()) == big
+
+
+# ---- 7. cross-tenant ---------------------------------------------------------
+
+def test_identical_plaintext_two_users_unequal_everything():
+    rec_a = nc.seal(b"metoprolol", USER_A, SYS_A, ctx())
+    rec_b = nc.seal(b"metoprolol", USER_B, SYS_B, ctx(tenant="tenantB"))
+    assert rec_a.field_ct != rec_b.field_ct
+    ka = nc.derive_bi_key(USER_A, SYS_A)
+    kb = nc.derive_bi_key(USER_B, SYS_B)
+    assert nc.blind_index(ka, "metoprolol") != nc.blind_index(kb, "metoprolol")
+
+
+# ---- 8. malformed serialized input fails closed (no struct.error / DoS) -------
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        b"",
+        b"\x00\x00\x00",              # truncated length prefix
+        b"\x00\x00\x00\x05ab",         # length exceeds remaining
+        b"\xff\xff\xff\xff",           # absurd length
+        b"\x00\x00\x00\x01a" + b"\x00\x00\x00\x01b",  # too few parts + trailing shape
+    ],
+)
+def test_from_bytes_rejects_malformed_input(blob):
+    with pytest.raises(ValueError):
+        nc.SealedRecord.from_bytes(blob)

--- a/prototypes/notebook-crypto/tests/test_vectors.py
+++ b/prototypes/notebook-crypto/tests/test_vectors.py
@@ -1,0 +1,74 @@
+"""Known-answer vectors — pinned inputs → exact outputs.
+
+These are the cross-client vectors the CryptoKit and WebCrypto ports MUST also
+reproduce byte-for-byte; if any client's primitives differ, its output diverges
+from these literals and the parity is caught. They also lock the deterministic
+functions against silent drift (a canonicalization or KDF change turns these red).
+
+Vectors are published so a port can verify itself before it is trusted. Sealing
+uses a fresh random nonce per call, so the full seal has no single fixed output —
+but AES-256-GCM IS a known-answer function under a pinned nonce, and the AAD wire
+format and record layout are fully deterministic, so both are pinned below. A
+port that reproduces every deterministic vector AND the pinned-nonce AEAD output
+matches this reference byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+import notebook_crypto as nc
+from notebook_crypto.envelope import _FIELD_LAYER, _WRAP_LAYER, RecordContext
+
+U = bytes.fromhex("00" * 32)
+S = bytes.fromhex("11" * 32)
+SALT = bytes.fromhex("22" * 16)
+CODE = "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE-FFFFF-GG"
+CTX = RecordContext(b"tenantA", b"name", b"row1", b"1")
+
+
+def test_kek_vector():
+    assert nc.derive_kek(U, S).hex() == "a2792a3f4511b37c65c658d0269bb0e7510f54849eedd7c511ed28f6fef4c2d4"
+
+
+def test_blind_index_key_vector():
+    assert nc.derive_bi_key(U, S).hex() == "7b774086c1294af3c472ba3c6271e64e664e3dc0601b950a7fc4e167d537a6e3"
+
+
+def test_blind_index_vector():
+    bik = nc.derive_bi_key(U, S)
+    assert nc.blind_index(bik, "Metoprolol") == "029f06282a8f1977150a0be02b8b2cd1c3c04d1081c98295f59c5020f2dee815"
+
+
+def test_user_share_from_recovery_code_vector():
+    assert (
+        nc.user_share_from_recovery_code(CODE, SALT).hex()
+        == "3e1668f15744696d2cc1c769d32a1c41e6d20a400997371cb708e783d4cbe0c1"
+    )
+
+
+def test_canonicalize_vector():
+    # fullwidth + zero-width joiner + case + surrounding whitespace all fold away
+    assert nc.canonicalize("  Ｍｅ‍TOPROLOL  ") == "metoprolol"
+
+
+def test_aad_wire_format_vector():
+    # The exact AAD bytes for both layers — a port MUST reproduce these or its
+    # ciphertexts are incompatible / its context binding differs.
+    assert CTX.aad(_WRAP_LAYER).hex() == (
+        "000000146e6f7465626f6f6b2f64656b2d777261702f7631"
+        "0000000774656e616e7441000000046e616d6500000004726f77310000000131"
+    )
+    assert CTX.aad(_FIELD_LAYER).hex() == (
+        "000000116e6f7465626f6f6b2f6669656c642f7631"
+        "0000000774656e616e7441000000046e616d6500000004726f77310000000131"
+    )
+
+
+def test_aead_pinned_nonce_vector():
+    # AES-256-GCM is a known-answer function under a pinned nonce. This pins the
+    # field-layer wire format end to end (a port's GCM + AAD must match).
+    key = bytes.fromhex("00" * 32)
+    nonce = bytes.fromhex("00" * 12)
+    ct = AESGCM(key).encrypt(nonce, b"metoprolol", CTX.aad(_FIELD_LAYER))
+    assert ct.hex() == "a3c234523d12040268226b55492495592b0b7aa458c61cb3d051"


### PR DESCRIPTION
Adds `prototypes/notebook-crypto/` — the reusable, **public** crypto glue behind an 'even we can't see your data' claim. Dual-key envelope + per-user blind index + recovery code; standard primitives only (AES-256-GCM/HKDF/HMAC), no invented crypto. Public on purpose (Kerckhoffs: security is in the keys). Self-contained: 51 tests + 11-mutation proof; survived two adversarial review rounds. Closes the extraction tracked in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)