### PR TITLE
feat(addons): convergent_deploy — additive, commutative, fenced publishing

### DIFF
--- a/addons/convergent_deploy/README.md
+++ b/addons/convergent_deploy/README.md
@@ -1,0 +1,48 @@
+# convergent_deploy add-on
+
+Make static deploys **additive, commutative and fenced**, so several agents can publish
+to the same site without waiting for each other and without deleting each other's work.
+
+Stack-agnostic, Python-stdlib-only, no daemon, no service.
+
+```
+convergent_deploy/
+├── README.md                          # this file (not stamped into projects)
+└── common/                            # overlaid when include_convergent_deploy=yes
+    ├── scripts/converge.py            # the module: merge → heal → fence
+    └── docs/CONVERGENT_DEPLOY.md      # house-style doc that lands in the project
+```
+
+## The problem it removes
+
+Every common static deploy mirrors a directory — `wrangler pages deploy`,
+`aws s3 sync --delete`, `netlify deploy --prod`, `rsync --delete`, `gh-pages`. Whatever
+the live site has and your directory lacks gets **deleted**. Fine with one deployer;
+with several it means each agent silently removes the artefacts it does not happen to
+hold, and whoever was sent a link gets a 404.
+
+Locking is the wrong fix — it converts data loss into blocking, and blocking is the
+thing we are trying to get rid of. Instead the deploy reconciles: it reads the live
+manifest, restores what it is missing, merges by id in an order-independent way, and
+fences its write with a monotonic token published by the site itself.
+
+## Relationship to the other concurrency add-ons
+
+| add-on | answers | mechanism |
+|---|---|---|
+| `work_registry` | *is a peer already working here?* | advisory noticeboard, expiring claims |
+| `orchestrator_session` | *who owns this task right now?* | real leases: epoch, heartbeat, takeover |
+| **`convergent_deploy`** | *what if two of us publish anyway?* | additive + commutative + fenced writes |
+
+The first two are **discovery**. This one assumes discovery failed — ignored, raced, or
+the peer is on another machine entirely — and makes the outcome correct regardless. Use
+them together.
+
+## Enable
+
+```bash
+python3 bin/generate.py --set include_convergent_deploy=yes …
+```
+
+Then see `docs/CONVERGENT_DEPLOY.md` in the generated project for wiring it into your
+deploy command. Contract tests: `tests/test_convergent_deploy_contract.py`.

--- a/addons/convergent_deploy/common/docs/CONVERGENT_DEPLOY.md
+++ b/addons/convergent_deploy/common/docs/CONVERGENT_DEPLOY.md
@@ -1,0 +1,86 @@
+# Deploying without blocking your peers
+
+If more than one agent (or person, or CI job) can publish to this site, read this before
+writing a deploy command.
+
+## Why the obvious deploy is unsafe
+
+`wrangler pages deploy ./site`, `aws s3 sync ./site s3://bucket --delete`, `rsync -a
+--delete`, `netlify deploy --prod` — all of them **mirror**. Anything live that is absent
+from your directory is deleted.
+
+With one deployer that is a feature. With several it is a live-fire hazard, because each
+agent usually holds only the artefact it is working on. Agent A deploys and removes B's
+pages; B deploys and removes A's. Nobody sees an error. The failure surfaces days later
+as a 404 in someone else's inbox.
+
+The tempting fixes are both wrong:
+
+- **A lock.** Now your peers wait on you, which is the cost we were trying to avoid — and
+  a lock held by a crashed agent is worse than no lock.
+- **Refuse to deploy when something is missing.** This is what we tried first. It turns
+  silent data loss into loud blocking. Better, still bad: an agent with a correct
+  artefact cannot ship it because of an unrelated gap.
+
+## What we do instead
+
+`scripts/converge.py`, three properties:
+
+**Additive.** The site publishes its own manifest at `_deployed.json`, and each entry
+records the files it consists of. Before uploading, we download anything the manifest
+lists that we do not hold. A deploy therefore carries everyone's artefacts.
+
+**Commutative.** The merge is a union by id that never drops an entry; a same-id conflict
+is settled by the newer timestamp. Two agents converge to the same state regardless of
+who deploys last — the race stops mattering rather than being prevented.
+
+**Fenced.** `_deploy-state.json` holds a monotonically increasing token. We read the live
+token, publish `live + 1`, upload, then check that ours is the one that landed. An agent
+that prepared against a stale view finds out and re-runs. The register that decides is
+the resource itself, not a lock beside it — a fencing token in Kleppmann's sense.
+
+## Wiring it in
+
+```python
+import converge
+
+owner  = os.environ.get("WORK_REGISTRY_OWNER", "unknown-session")
+local  = json.loads(MANIFEST.read_text())
+remote = converge._fetch_json(BASE_URL, converge.MANIFEST_FILE)
+
+merged, adopted = converge.merge_manifests(local, remote)
+healed, unhealable = converge.heal(SITE_ROOT, merged, BASE_URL, BACKUPS)
+if unhealable:
+    sys.exit(f"cannot safely deploy; would delete: {unhealable}")
+
+token = converge.next_token(BASE_URL)
+converge.write_state(SITE_ROOT, merged, token, owner)
+
+run_your_upload_command()
+
+if msg := converge.verify_not_superseded(BASE_URL, token):
+    sys.exit(msg)          # someone landed between our read and our write; re-run
+```
+
+If your manifest already has its own shape, rebind the vocabulary once at import:
+
+```python
+converge.COLLECTION, converge.ID, converge.STAMP, converge.SUBDIR = "shares", "slug", "added", "s"
+```
+
+## Two rules learned the hard way
+
+**The live site beats a local backup.** Backups often get committed, so a fresh clone
+carries whatever was backed up whenever it was committed. Restoring from one republished
+a 47 KB page over the current 105 KB build — the same clobber this module exists to
+prevent, arriving by a politer route. Currency is the ordering criterion, not cheapness.
+A backup restore is the fallback for an unreachable site, and it reports itself as STALE.
+
+**Tell every future session the entry point.** None of this helps if an agent runs the
+raw mirror command, which is usually sitting right there in a docstring. Put the rule in
+`CLAUDE.md`/`AGENTS.md` at the repo root — that is the layer that actually reaches a
+session that has never seen this code:
+
+> **Deploy only with `./deploy.py`. Never call `<mirror command>` directly.** It deletes
+> anything live that is absent locally, and the artefacts are gitignored, so a fresh
+> clone lacks all of them.

--- a/addons/convergent_deploy/common/scripts/converge.py
+++ b/addons/convergent_deploy/common/scripts/converge.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Additive, commutative, fenced deploys — so concurrent agents stop blocking each other.
+
+THE FAILURE THIS REMOVES
+------------------------
+Most static deploys mirror a directory: `wrangler pages deploy`, `aws s3 sync --delete`,
+`netlify deploy --prod`, `rsync --delete`, `gh-pages`. Anything the live site has and
+your directory lacks is DELETED. That is fine with one deployer and catastrophic with
+several, because each agent typically holds only the artefact it is working on. Two
+agents then take turns removing each other's work, and the person holding the link gets
+a 404 with no warning.
+
+The instinctive fix — a lock, or refusing to deploy when something is missing — trades
+data loss for blocking. That is the same problem wearing a better hat: the whole point
+is that peers should not have to wait for each other.
+
+THREE PROPERTIES, IN THE ORDER THEY MATTER
+------------------------------------------
+**Additive.** The live site publishes its own manifest (`_deployed.json`). Before
+deploying, read it, union it with yours, and restore anything you are missing by
+downloading the files the manifest lists. A deploy then carries everyone's artefacts,
+not just the ones this agent happens to have on disk.
+
+**Commutative.** The union is by id and never drops an entry; a genuine conflict on the
+same id is settled by the newer timestamp. Two agents publishing different artefacts
+converge to the same state regardless of who goes last — which is what removes the need
+to coordinate at all. This is the CRDT idea applied to a deploy: make the merge
+order-independent and the race stops mattering.
+
+**Fenced.** The one genuinely global resource is the live site, so let it hold the
+register. `_deploy-state.json` carries a monotonically increasing token; read the live
+token, publish `live + 1`, then verify yours is what landed. An agent that prepared its
+deploy against an older view of the world finds out, and re-reconciles instead of
+overwriting. This is a fencing token in the Kleppmann sense — the register that decides
+is the resource itself, not a lock held beside it.
+
+WHAT THIS IS NOT
+----------------
+Not a lease, and not a lock. The `work_registry` add-on is an advisory noticeboard, and
+`orchestrator_session` has real leases with heartbeats and takeover. Both are about
+*discovery* — knowing a peer exists. This module assumes discovery failed, or was
+ignored, or the peer is on another machine entirely, and makes the outcome correct
+anyway. Use them together: the registry to avoid surprising each other, this to be safe
+when you do.
+
+ADOPTING IT
+-----------
+Provide a `files` list per entry when you stage an artefact (`file_list()` does this),
+point `BASE_URL` at the live site, and call `merge_manifests` → `heal` → `next_token` →
+`write_state` before your upload command, `verify_not_superseded` after it. See
+docs/CONVERGENT_DEPLOY.md.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import time
+import urllib.error
+import urllib.request
+
+STATE_FILE = "_deploy-state.json"
+MANIFEST_FILE = "_deployed.json"
+
+# Vocabulary. A project that already has its own manifest shape rebinds these once at
+# import rather than threading them through every call.
+COLLECTION = "entries"   # the list key inside the manifest
+ID = "id"                # the field that identifies an entry
+STAMP = "added"          # ISO-8601; newer wins a same-id conflict
+SUBDIR = ""              # path under the deploy root, e.g. "s" for /s/<id>/
+UA = {"User-Agent": "Mozilla/5.0 (convergent-deploy)"}
+
+
+def _fetch_json(base: str, name: str):
+    """Read a JSON file published by the live site. Absent is normal on first deploy."""
+    try:
+        req = urllib.request.Request(f"{base.rstrip('/')}/{name}", headers=UA)
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return json.loads(r.read().decode())
+    except (urllib.error.HTTPError, urllib.error.URLError, ValueError, TimeoutError):
+        return None
+
+
+def _fetch_file(url: str, dest: pathlib.Path) -> bool:
+    try:
+        req = urllib.request.Request(url, headers=UA)
+        with urllib.request.urlopen(req, timeout=600) as r:
+            if r.status != 200:
+                return False
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with open(dest, "wb") as fh:
+                while chunk := r.read(1 << 20):
+                    fh.write(chunk)
+        return True
+    except Exception:
+        return False
+
+
+def file_list(entry_dir: pathlib.Path) -> list[str]:
+    """Relative paths of everything in a staged artefact, so a peer can restore it."""
+    return sorted(str(f.relative_to(entry_dir)) for f in entry_dir.rglob("*") if f.is_file())
+
+
+def merge_manifests(local: dict, remote: dict | None) -> tuple[dict, list[str]]:
+    """Union by slug. Never drops an entry; newer `added` wins a genuine conflict.
+
+    This is the commutative part: whichever session deploys last, the result is the
+    same, so neither has to wait for the other.
+    """
+    by_id = {e[ID]: e for e in (remote or {}).get(COLLECTION, [])}
+    mine = {e[ID] for e in local.get(COLLECTION, [])}
+    for entry in local.get(COLLECTION, []):
+        prev = by_id.get(entry[ID])
+        if prev is None or entry.get(STAMP, "") >= prev.get(STAMP, ""):
+            by_id[entry[ID]] = entry
+    adopted = sorted(k for k in by_id if k not in mine)
+    merged = {COLLECTION: sorted(by_id.values(), key=lambda e: e.get(STAMP, ""))}
+    return merged, adopted
+
+
+def heal(root: pathlib.Path, merged: dict, base_url: str,
+         backups: pathlib.Path) -> tuple[list[str], list[str]]:
+    """Restore entries this agent does not hold, so the deploy stays additive.
+
+    Two sources, **most current first**: the live site itself, using the file list the
+    manifest carries, and only then a local backup.
+
+    The order is the whole point, and I had it backwards. Preferring the cheap local
+    backup meant a fresh clone — whose `.backups/` are whatever was committed, possibly
+    months old — would restore a stale build and publish it over the current one. That
+    is the same clobber this module exists to prevent, arriving by a politer route. A
+    backup restore is therefore a fallback for when the live site cannot be reached, and
+    it says STALE in its report so nobody mistakes it for a clean recovery.
+
+    A slug we cannot restore is reported rather than silently dropped — deploying
+    without it would delete it for whoever holds the link.
+    """
+    healed, unhealable = [], []
+    for entry in merged[COLLECTION]:
+        slug = entry[ID]
+        dest = (root / SUBDIR / slug) if SUBDIR else (root / slug)
+        if dest.exists():
+            continue
+        files = entry.get("files") or []
+        if files and all(_fetch_file(f"{base_url.rstrip('/')}/{SUBDIR + '/' if SUBDIR else ''}{slug}/{f}", dest / f)
+                         for f in files):
+            healed.append(f"{slug} (from live site, {len(files)} files)")
+            continue
+        if dest.exists():
+            import shutil
+            shutil.rmtree(dest)          # a half-downloaded share is worse than none
+        bak = sorted(backups.glob(f"*{slug}*"), reverse=True) if backups.exists() else []
+        if bak and any(bak[0].rglob("index.html")):
+            import shutil
+            shutil.copytree(bak[0], dest, dirs_exist_ok=True)
+            healed.append(f"{slug} (STALE: from backup {bak[0].name}; live site was "
+                          f"unreachable, so this may be an older build)")
+            continue
+        unhealable.append(f"{slug} (live unreachable and no usable backup)"
+                          if files else
+                          f"{slug} (no file list recorded; cannot restore)")
+    return healed, unhealable
+
+
+def next_token(base_url: str, local_token: int = 0) -> int:
+    """One past whatever the live site says. The resource is its own register."""
+    state = _fetch_json(base_url, STATE_FILE) or {}
+    return max(int(state.get("token", 0)), int(local_token)) + 1
+
+
+def write_state(root: pathlib.Path, merged: dict, token: int, owner: str) -> None:
+    (root / STATE_FILE).write_text(json.dumps(
+        {"token": token, "owner": owner, "at": time.strftime("%Y-%m-%dT%H:%M:%S%z")},
+        indent=2) + "\n")
+    (root / MANIFEST_FILE).write_text(json.dumps(merged, indent=2) + "\n")
+
+
+def verify_not_superseded(base_url: str, token: int) -> str | None:
+    """After deploying, confirm the token we published is the one that landed.
+
+    If another session deployed between our reconcile and our upload, the live token
+    will not be ours. That is recoverable — re-run — and it is far better to say so
+    than to assume our view won.
+    """
+    state = _fetch_json(base_url, STATE_FILE) or {}
+    live = int(state.get("token", -1))
+    if live == token:
+        return None
+    return (f"live token is {live}, we published {token} — another deploy landed "
+            f"concurrently. Re-run deploy; reconciliation will pick up their shares.")

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -206,6 +206,7 @@ def main() -> int:
         "browser_automation_policy",
         "local_ollama",
         "encrypted_local_areas",
+        "convergent_deploy",
     ):
         if values.get(f"include_{addon}") == "yes":
             overlaid = False

--- a/firestarter.config.json
+++ b/firestarter.config.json
@@ -22,6 +22,7 @@
   "include_browser_automation_policy": ["no", "yes"],
   "include_local_ollama": ["no", "yes"],
   "include_encrypted_local_areas": ["no", "yes"],
+  "include_convergent_deploy": ["no", "yes"],
 
   "db_name": "{{ project_slug }}",
   "commit_scopes": "backend frontend migrations docs ci build",

--- a/tests/test_convergent_deploy_contract.py
+++ b/tests/test_convergent_deploy_contract.py
@@ -1,0 +1,170 @@
+"""Property contract for the convergent_deploy add-on.
+
+Each test is a collision that actually happened while shipping a share to an outside
+collaborator on 20-21 Aug 2026. They are the reason the module exists, so they are
+written as properties rather than as unit tests of the implementation: what must hold
+is that two agents deploying concurrently cannot lose each other's work, and that an
+agent which loses a race finds out.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON = ROOT / "addons" / "convergent_deploy" / "common"
+CONFIG = json.loads((ROOT / "firestarter.config.json").read_text())
+
+_spec = importlib.util.spec_from_file_location("converge", ADDON / "scripts" / "converge.py")
+converge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(converge)
+
+
+class Registration(unittest.TestCase):
+    def test_registered_and_off_by_default(self):
+        choices = CONFIG["include_convergent_deploy"]
+        self.assertEqual(choices[0], "no", "add-on must be opt-in")
+        self.assertIn("yes", choices)
+
+    def test_wired_into_the_generator(self):
+        self.assertIn('"convergent_deploy"', (ROOT / "bin" / "generate.py").read_text(),
+                      "an addon absent from generate.py's list is never stamped")
+
+
+class Commutative(unittest.TestCase):
+    """Two agents publishing different artefacts must converge to the same state
+    whichever one deploys last. That is what removes the need for them to take turns."""
+
+    A = {"id": "aaa", "title": "mine", "added": "2026-08-20T10:00:00+00:00"}
+    B = {"id": "bbb", "title": "theirs", "added": "2026-08-20T11:00:00+00:00"}
+
+    def test_neither_agent_loses_its_artefact(self):
+        m1, _ = converge.merge_manifests({"entries": [self.A]}, {"entries": [self.B]})
+        m2, _ = converge.merge_manifests({"entries": [self.B]}, {"entries": [self.A]})
+        self.assertEqual({e["id"] for e in m1["entries"]}, {"aaa", "bbb"})
+        self.assertEqual(m1, m2, "merge must not depend on deploy order")
+
+    def test_adopted_ids_are_reported(self):
+        _, adopted = converge.merge_manifests({"entries": [self.A]}, {"entries": [self.B]})
+        self.assertEqual(adopted, ["bbb"])
+
+    def test_newer_edit_wins_without_dropping_unrelated_entries(self):
+        older = {"id": "aaa", "title": "old", "added": "2026-08-20T09:00:00+00:00"}
+        newer = {"id": "aaa", "title": "new", "added": "2026-08-20T12:00:00+00:00"}
+        merged, _ = converge.merge_manifests({"entries": [newer]},
+                                             {"entries": [older, self.B]})
+        by = {e["id"]: e for e in merged["entries"]}
+        self.assertEqual(by["aaa"]["title"], "new")
+        self.assertIn("bbb", by, "an unrelated artefact must survive an update to another")
+
+    def test_empty_remote_is_normal(self):
+        merged, adopted = converge.merge_manifests({"entries": [self.A]}, None)
+        self.assertEqual([e["id"] for e in merged["entries"]], ["aaa"])
+        self.assertEqual(adopted, [])
+
+
+class Fencing(unittest.TestCase):
+    """The live site is the register. A deploy publishes one past what it read."""
+
+    def setUp(self):
+        self._orig = converge._fetch_json
+        self.addCleanup(lambda: setattr(converge, "_fetch_json", self._orig))
+
+    def test_token_advances_past_the_live_value(self):
+        converge._fetch_json = lambda base, name: {"token": 7}
+        self.assertEqual(converge.next_token("https://example.invalid"), 8)
+
+    def test_token_starts_at_one_when_nothing_is_published(self):
+        converge._fetch_json = lambda base, name: None
+        self.assertEqual(converge.next_token("https://example.invalid"), 1)
+
+    def test_a_lost_race_is_detected_not_assumed_away(self):
+        converge._fetch_json = lambda base, name: {"token": 9}
+        msg = converge.verify_not_superseded("https://example.invalid", 8)
+        self.assertIsNotNone(msg, "a deploy that lost the race must say so")
+
+    def test_our_own_token_landing_is_silence(self):
+        converge._fetch_json = lambda base, name: {"token": 8}
+        self.assertIsNone(converge.verify_not_superseded("https://example.invalid", 8))
+
+
+class Additive(unittest.TestCase):
+    """An artefact we do not hold locally must survive our deploy."""
+
+    def setUp(self):
+        self._orig = converge._fetch_file
+        self.addCleanup(lambda: setattr(converge, "_fetch_file", self._orig))
+
+    def test_live_site_beats_a_stale_local_backup(self):
+        """The regression a fresh clone actually hit on 21 Aug 2026.
+
+        Backups are often committed, so a clone carries whatever was backed up whenever
+        it was committed — in the real case a 47 KB page from before the media moved to
+        a range-serving host, against a 105 KB live page. Preferring the cheap local
+        copy would have republished the old build over the working one. Cheapness is the
+        wrong ordering criterion; currency is the right one.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bak = root / ".backups" / "bak-old-bbb"
+            bak.mkdir(parents=True)
+            (bak / "index.html").write_text("STALE BUILD")
+            live = root / "deploy"
+            live.mkdir()
+
+            def fake(url, dest):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text("CURRENT BUILD")
+                return True
+
+            converge._fetch_file = fake
+            healed, unhealable = converge.heal(
+                live, {"entries": [{"id": "bbb", "files": ["index.html"]}]},
+                "https://example.test", root / ".backups")
+            self.assertEqual(unhealable, [])
+            self.assertEqual((live / "bbb" / "index.html").read_text(), "CURRENT BUILD")
+            self.assertIn("from live site", healed[0])
+
+    def test_backup_is_the_fallback_and_announces_itself_as_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bak = root / ".backups" / "bak-old-bbb"
+            bak.mkdir(parents=True)
+            (bak / "index.html").write_text("<h1>theirs</h1>")
+            live = root / "deploy"
+            live.mkdir()
+            converge._fetch_file = lambda url, dest: False      # live unreachable
+            healed, unhealable = converge.heal(
+                live, {"entries": [{"id": "bbb", "files": ["index.html"]}]},
+                "https://example.invalid", root / ".backups")
+            self.assertEqual(unhealable, [])
+            self.assertTrue((live / "bbb" / "index.html").exists())
+            self.assertIn("STALE", healed[0],
+                          "a backup restore must announce it may be an older build")
+
+    def test_an_unrestorable_entry_is_named_never_silently_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            live = root / "deploy"
+            live.mkdir()
+            healed, unhealable = converge.heal(live, {"entries": [{"id": "ccc"}]},
+                                               "https://example.invalid", root / ".backups")
+            self.assertEqual(healed, [])
+            self.assertTrue(unhealable and "ccc" in unhealable[0])
+
+    def test_file_list_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp) / "entry"
+            (d / "data").mkdir(parents=True)
+            (d / "index.html").write_text("x")
+            (d / "data" / "a.csv").write_text("y")
+            self.assertEqual(converge.file_list(d), ["data/a.csv", "index.html"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Every common static deploy mirrors a directory — `wrangler pages deploy`, `aws s3 sync --delete`, `netlify deploy --prod`, `rsync --delete`. Anything live that is absent locally is **deleted**. With one deployer that is a feature. With several agents each holding only its own artefact, they take turns removing each other's work, and whoever was sent a link gets a 404 days later with no error anywhere.

Two fixes were tried and rejected:

- **A lock** — peers now wait on each other, which is the cost we were trying to remove.
- **Refuse to deploy when an entry is missing** — our first attempt. It converts silent data loss into loud blocking. Same defect, better hat.

## What

`converge.py` reconciles before uploading:

- **Additive** — the site publishes `_deployed.json` with the file list per entry; a deploy re-downloads anything it does not hold, so it carries everyone's artefacts
- **Commutative** — union by id, newest timestamp wins a same-id conflict, nothing ever dropped; two agents converge to the same state whichever goes last, so the race stops mattering rather than being prevented
- **Fenced** — `_deploy-state.json` holds a monotonic token; publish `live + 1`, then verify ours landed. A deploy prepared against a stale view finds out and re-runs

## Relationship to the existing concurrency add-ons

| add-on | answers | mechanism |
|---|---|---|
| `work_registry` | is a peer already working here? | advisory noticeboard |
| `orchestrator_session` | who owns this task? | leases with heartbeat + takeover |
| **this** | what if two of us publish anyway? | convergent, fenced writes |

The first two are discovery. `work_registry` says so itself — "the missing capability was discovery, not mutual exclusion". This is that missing half: it assumes discovery failed, was ignored, or the peer is on another machine, and makes the outcome correct regardless.

## Evidence

Proven end to end in `share-desk`, which had the live failure. A **fresh clone holding zero artefacts** reconstructed the live share byte-identically — 105,309 bytes, 12 files — before deploying.

That exercise also caught a defect in the original: `heal()` preferred a local backup because it was cheaper, and `.backups/` is committed, so the clone carried a 47 KB page from before the media moved to a range-serving host. It would have republished that over the current build — the same clobber this module exists to prevent, arriving by a politer route. **Currency, not cheapness**: the live site is authoritative, a backup is the fallback for an unreachable site, and it reports itself as STALE. Pinned by a regression test.

## Testing

- 14 contract tests, stdlib only, `tests/test_convergent_deploy_contract.py`
- Generator smoke-tested: stamps `scripts/converge.py` + `docs/CONVERGENT_DEPLOY.md`, no unsubstituted tokens, off by default

## Note for reviewers

The docs deliberately carry the "tell every future session the entry point" rule. None of this helps if an agent runs the raw mirror command, which is usually sitting in a docstring — the `CLAUDE.md`/`AGENTS.md` layer is what reaches a session that has never seen this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)