### PR TITLE
feat(addons): version_changelog — build stamp, curated changelog, rollback

### DIFF
--- a/addons/version_changelog/README.md
+++ b/addons/version_changelog/README.md
@@ -1,0 +1,76 @@
+# `version_changelog` add-on (contributor notes)
+
+> Maintainer notes. This file sits above `common/`, so the generator does **not**
+> stamp it into projects. The user-facing doc is `common/docs/VERSION_CHANGELOG.md`,
+> which *does* stamp into `<project>/docs/`.
+
+## What it is
+
+A **stack-agnostic** add-on that turns the build stamp every project already prints
+into a changelog and a rollback control. One custom element, no dependencies, no build
+step, Shadow DOM so it survives contact with any host stylesheet — including a Claude
+artifact under strict CSP, where it can be fed an inline manifest instead of fetching one.
+
+## Layout (all under `common/`, stamped to `<project>/`)
+
+```
+common/assets/version-changelog.js   the <version-changelog> element (~330 lines, no deps)
+common/scripts/changelog-gen.py      draft → review → publish pipeline
+common/docs/VERSION_CHANGELOG.md     concept, manifest shape, wiring, a11y
+```
+
+## The two design decisions worth defending
+
+**1. Publication fails closed.** The generator's `include` heuristic is a proposal.
+On its first real run against `cervical-cord-video` it proposed *"Audio drifted from its
+beat when a beat was inserted"* for publication — a true and completely internal
+sentence. So `publish` refuses any release whose `reviewed` flag is still false, and
+refuses outright if `_`-prefixed internal fields would reach the output. The heuristic
+saves typing; it is not the gate.
+
+**2. The component never mutates.** It opens an immutable URL, or it emits a cancelable
+`changelog:rollback` event. Rollback availability is supplied by the project's rollback
+map, never inferred — because the component cannot know whether a version is separable
+from server state, and guessing wrong means offering a restore that silently half-works.
+Disabled entries must carry a reason, and the reason is rendered as visible text, not
+just a tooltip.
+
+## Where the rollback URLs come from
+
+Most static hosts already mint an immutable per-deployment alias and simply do not
+advertise it:
+
+| Host | Immutable alias |
+|---|---|
+| Cloudflare Pages | `https://<deploy-hash>.<project>.pages.dev` |
+| Netlify | `https://<deploy-id>--<site>.netlify.app` |
+| Vercel | the per-deployment `*.vercel.app` URL |
+| S3 / R2 | object versioning (`?versionId=`) |
+
+These are the *same* URLs that are a hazard when shared by accident — a frozen build
+someone keeps opening forever. Enumerated deliberately, that hazard becomes the feature.
+
+## Gotchas
+
+- **Inline manifests need escaping discipline.** The element reads `textContent`, so a
+  `</script>`-like sequence inside a note will not bite, but unescaped user content in
+  notes would; everything rendered goes through `escapeHtml`.
+- **`document.addEventListener(..., true)`** — the outside-click handler uses the capture
+  phase deliberately. A host that calls `stopPropagation()` on its own clicks would
+  otherwise leave the panel stuck open.
+- **No `<dialog>`.** Native dialog's top-layer behaviour fights position-anchored panels
+  inside transformed ancestors, which several of our pages have.
+- The stamp inherits `font-family` from the host by default; pin `--changelog-sans` if the
+  host font is decorative.
+
+## Try it
+
+```
+python3 common/scripts/changelog-gen.py draft --repo /path/to/repo --out draft.json
+# edit draft.json: fix the wording, flip reviewed:true
+python3 common/scripts/changelog-gen.py publish --draft draft.json --out changelog.json \
+        --rollback-map rollback.json
+```
+
+`examples/version-changelog/` renders a page with both a fetched and an inline manifest,
+including a deliberately disabled release, for eyeballing the states.

--- a/addons/version_changelog/common/assets/version-changelog.js
+++ b/addons/version_changelog/common/assets/version-changelog.js
@@ -87,6 +87,50 @@ TEMPLATE.innerHTML = `
     padding: .25rem 0;
   }
   :host([drop="down"]) .panel { bottom: auto; top: calc(100% + .5rem); }
+
+  /* Placement. inline (default) sits wherever the host puts it; the rest pin
+     themselves so a page can carry the stamp without reserving layout for it. */
+  :host([placement="float"]),
+  :host([placement="header"]),
+  :host([placement="footer"]),
+  :host([placement="side"]) { position: fixed; z-index: 60; }
+
+  :host([placement="float"]) { bottom: 1.25rem; right: 1.25rem; }
+  :host([placement="float"][corner="bottom-left"])  { right: auto; left: 1.25rem; }
+  :host([placement="float"][corner="top-right"])    { bottom: auto; top: 1.25rem; }
+  :host([placement="float"][corner="top-left"])     { bottom: auto; top: 1.25rem; right: auto; left: 1.25rem; }
+  :host([placement="float"]) .stamp {
+    background: var(--vc-surface);
+    border: 1px solid var(--vc-rule);
+    border-bottom-color: var(--vc-rule);
+    border-radius: 999px;
+    padding: .45rem .85rem;
+    box-shadow: 0 4px 14px rgba(0,0,0,.16);
+    color: var(--vc-ink-2);
+  }
+  :host([placement="float"]) .stamp:hover { color: var(--vc-accent); border-color: var(--vc-accent); }
+
+  :host([placement="header"]) { top: .6rem; right: 1rem; }
+  :host([placement="footer"]) { bottom: .6rem; right: 1rem; }
+  :host([placement="side"])   { top: 50%; right: 0; transform: translateY(-50%); }
+  :host([placement="side"]) .stamp {
+    writing-mode: vertical-rl;
+    background: var(--vc-surface);
+    border: 1px solid var(--vc-rule);
+    border-radius: 6px 0 0 6px;
+    padding: .8rem .4rem;
+  }
+
+  /* A pinned stamp near the bottom must open upward, near the top downward. */
+  :host([placement="header"]) .panel { bottom: auto; top: calc(100% + .5rem); }
+  :host([placement="float"][corner^="top"]) .panel { bottom: auto; top: calc(100% + .5rem); }
+  /* Right-pinned placements would overflow the viewport if the panel grew rightward. */
+  :host([placement="float"]) .panel,
+  :host([placement="header"]) .panel,
+  :host([placement="footer"]) .panel { left: auto; right: 0; }
+  :host([placement="side"]) .panel { right: calc(100% + .5rem); top: 50%; bottom: auto; transform: translateY(-50%); }
+
+  @media (prefers-reduced-motion: reduce) { .stamp, .ch, .rel-top { transition: none; } }
   .panel[hidden] { display: none; }
 
   .head {
@@ -137,7 +181,7 @@ TEMPLATE.innerHTML = `
 `;
 
 class VersionChangelog extends HTMLElement {
-  static get observedAttributes() { return ["src", "current"]; }
+  static get observedAttributes() { return ["src", "current", "placement", "corner"]; }
 
   constructor() {
     super();
@@ -197,9 +241,13 @@ class VersionChangelog extends HTMLElement {
       this._stamp.textContent = "no versions";
       return;
     }
-    this._stamp.textContent = this._data.stampLabel
-      ? interpolate(this._data.stampLabel, cur)
-      : `build ${cur.id}${cur.runtime ? " · " + cur.runtime : ""}`;
+    const floating = this.getAttribute("placement") === "float";
+    const short = this._data.floatLabel || "What's new";
+    this._stamp.textContent = floating
+      ? short
+      : (this._data.stampLabel
+          ? interpolate(this._data.stampLabel, cur)
+          : `build ${cur.id}${cur.runtime ? " · " + cur.runtime : ""}`);
     this._stamp.title = "What changed, and how to go back";
 
     const head = `<div class="head"><b>${escapeHtml(this._data.title || "Version history")}</b>` +

--- a/addons/version_changelog/common/assets/version-changelog.js
+++ b/addons/version_changelog/common/assets/version-changelog.js
@@ -1,0 +1,302 @@
+/**
+ * <version-changelog> — the build stamp in the corner, made useful.
+ *
+ * Every project ends up printing a version somewhere. This turns that dead text
+ * into the answer to three questions a reader actually has: what am I looking at,
+ * what changed, and can I go back to the one that worked.
+ *
+ * Design constraints, learned the hard way:
+ *   - No dependencies and no build step. It has to run inside a Claude artifact
+ *     (strict CSP, no external hosts), a static page on Cloudflare Pages, and an
+ *     app shell, without changing shape.
+ *   - Shadow DOM. Host stylesheets vary wildly across projects; the panel must not
+ *     inherit them, and must not leak into them.
+ *   - It never performs a rollback itself. It navigates, or it emits an event and
+ *     lets the host decide. A component that can silently revert someone's data is
+ *     a component that will eventually revert someone's data.
+ *
+ * Usage:
+ *   <version-changelog src="changelog.json"></version-changelog>
+ *   <version-changelog>{ ...inline manifest... }</version-changelog>
+ *
+ * Manifest shape: see common/docs/VERSION_CHANGELOG.md and changelog.schema.json.
+ */
+
+const TEMPLATE = document.createElement("template");
+TEMPLATE.innerHTML = `
+<style>
+  :host {
+    --vc-ink: var(--changelog-ink, #1a1f1e);
+    --vc-ink-2: var(--changelog-ink-2, #5d6b68);
+    --vc-ink-3: var(--changelog-ink-3, #8a9693);
+    --vc-surface: var(--changelog-surface, #ffffff);
+    --vc-rule: var(--changelog-rule, #dde4e2);
+    --vc-accent: var(--changelog-accent, #0d6a62);
+    --vc-disabled: var(--changelog-disabled, #a5adab);
+    --vc-mono: var(--changelog-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    --vc-sans: var(--changelog-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    display: inline-block;
+    position: relative;
+    font-family: var(--vc-sans);
+  }
+  @media (prefers-color-scheme: dark) {
+    :host(:not([theme="light"])) {
+      --vc-ink: var(--changelog-ink, #e6edeb);
+      --vc-ink-2: var(--changelog-ink-2, #a3b0ad);
+      --vc-ink-3: var(--changelog-ink-3, #7d8a87);
+      --vc-surface: var(--changelog-surface, #161d1c);
+      --vc-rule: var(--changelog-rule, #2a3533);
+      --vc-accent: var(--changelog-accent, #57c2b2);
+      --vc-disabled: var(--changelog-disabled, #55605e);
+    }
+  }
+  :host([theme="dark"]) {
+    --vc-ink: #e6edeb; --vc-ink-2: #a3b0ad; --vc-ink-3: #7d8a87;
+    --vc-surface: #161d1c; --vc-rule: #2a3533; --vc-accent: #57c2b2;
+    --vc-disabled: #55605e;
+  }
+
+  .stamp {
+    font-family: var(--vc-mono);
+    font-size: .72rem;
+    letter-spacing: .06em;
+    color: var(--vc-ink-3);
+    background: none;
+    border: 0;
+    border-bottom: 1px dotted currentColor;
+    padding: 0 0 1px;
+    cursor: pointer;
+    line-height: 1.4;
+  }
+  .stamp:hover, .stamp:focus-visible { color: var(--vc-accent); }
+  .stamp:focus-visible { outline: 2px solid var(--vc-accent); outline-offset: 3px; }
+
+  .panel {
+    position: absolute;
+    bottom: calc(100% + .5rem);
+    left: 0;
+    z-index: 40;
+    width: min(26rem, calc(100vw - 2rem));
+    max-height: min(24rem, 70vh);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    background: var(--vc-surface);
+    border: 1px solid var(--vc-rule);
+    border-radius: 6px;
+    box-shadow: 0 10px 30px rgba(0,0,0,.18);
+    padding: .25rem 0;
+  }
+  :host([drop="down"]) .panel { bottom: auto; top: calc(100% + .5rem); }
+  .panel[hidden] { display: none; }
+
+  .head {
+    display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+    padding: .6rem .85rem; border-bottom: 1px solid var(--vc-rule);
+  }
+  .head b { font-size: .8rem; color: var(--vc-ink); font-weight: 600; }
+  .head span { font-family: var(--vc-mono); font-size: .66rem; color: var(--vc-ink-3); }
+
+  .rel { border-bottom: 1px solid var(--vc-rule); }
+  .rel:last-child { border-bottom: 0; }
+  .rel-top {
+    width: 100%; display: grid; grid-template-columns: 1fr auto; gap: .5rem;
+    align-items: baseline; padding: .55rem .85rem; background: none; border: 0;
+    text-align: left; cursor: pointer; color: var(--vc-ink); font-family: inherit;
+  }
+  .rel-top:hover { background: color-mix(in srgb, var(--vc-accent) 7%, transparent); }
+  .rel-top:focus-visible { outline: 2px solid var(--vc-accent); outline-offset: -2px; }
+  .rel-title { font-size: .82rem; font-weight: 500; }
+  .rel-meta { font-family: var(--vc-mono); font-size: .66rem; color: var(--vc-ink-3); white-space: nowrap; }
+  .current .rel-title::after {
+    content: "current"; margin-left: .45rem; font-family: var(--vc-mono);
+    font-size: .6rem; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--vc-accent); border: 1px solid currentColor; border-radius: 2px; padding: 0 .25rem;
+  }
+  .body { padding: 0 .85rem .7rem; }
+  .body[hidden] { display: none; }
+  .body ul { margin: 0 0 .55rem; padding-left: 1.05rem; }
+  .body li { font-size: .78rem; line-height: 1.5; color: var(--vc-ink-2); margin: .15rem 0; }
+
+  .roll {
+    font-family: var(--vc-mono); font-size: .68rem; letter-spacing: .04em;
+    padding: .3rem .6rem; border-radius: 3px; cursor: pointer;
+    border: 1px solid var(--vc-accent); color: var(--vc-accent); background: none;
+  }
+  .roll:hover { background: color-mix(in srgb, var(--vc-accent) 12%, transparent); }
+  .roll:focus-visible { outline: 2px solid var(--vc-accent); outline-offset: 2px; }
+  .roll[disabled] {
+    border-color: var(--vc-disabled); color: var(--vc-disabled);
+    cursor: not-allowed; background: none;
+  }
+  .why { font-size: .7rem; color: var(--vc-ink-3); margin-top: .35rem; line-height: 1.45; }
+  .err { padding: .7rem .85rem; font-size: .78rem; color: var(--vc-ink-2); }
+</style>
+
+<button class="stamp" part="stamp" aria-haspopup="dialog" aria-expanded="false"></button>
+<div class="panel" part="panel" role="dialog" aria-label="Version history" hidden></div>
+`;
+
+class VersionChangelog extends HTMLElement {
+  static get observedAttributes() { return ["src", "current"]; }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" }).appendChild(TEMPLATE.content.cloneNode(true));
+    this._stamp = this.shadowRoot.querySelector(".stamp");
+    this._panel = this.shadowRoot.querySelector(".panel");
+    this._open = false;
+    this._data = null;
+    this._onDocClick = (e) => { if (!this.contains(e.target) && e.target !== this) this.close(); };
+    this._onKey = (e) => { if (e.key === "Escape" && this._open) { this.close(); this._stamp.focus(); } };
+  }
+
+  connectedCallback() {
+    this._stamp.addEventListener("click", () => this.toggle());
+    this._load();
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener("click", this._onDocClick, true);
+    document.removeEventListener("keydown", this._onKey);
+  }
+
+  attributeChangedCallback(name, prev, next) {
+    if (prev !== next && this.isConnected) this._load();
+  }
+
+  async _load() {
+    const src = this.getAttribute("src");
+    try {
+      if (src) {
+        const res = await fetch(src, { cache: "no-cache" });
+        if (!res.ok) throw new Error(`${res.status} fetching ${src}`);
+        this._data = await res.json();
+      } else {
+        const inline = this.textContent.trim();
+        if (!inline) throw new Error("no src attribute and no inline manifest");
+        this._data = JSON.parse(inline);
+      }
+      this._render();
+    } catch (err) {
+      this._data = null;
+      this._stamp.textContent = "version unavailable";
+      this._panel.innerHTML = `<p class="err">Could not load the version history: ${escapeHtml(err.message)}</p>`;
+    }
+  }
+
+  get _current() {
+    const pinned = this.getAttribute("current");
+    const releases = (this._data && this._data.releases) || [];
+    return releases.find((r) => r.id === pinned) || releases[0] || null;
+  }
+
+  _render() {
+    const cur = this._current;
+    const releases = (this._data && this._data.releases) || [];
+    if (!cur) {
+      this._stamp.textContent = "no versions";
+      return;
+    }
+    this._stamp.textContent = this._data.stampLabel
+      ? interpolate(this._data.stampLabel, cur)
+      : `build ${cur.id}${cur.runtime ? " · " + cur.runtime : ""}`;
+    this._stamp.title = "What changed, and how to go back";
+
+    const head = `<div class="head"><b>${escapeHtml(this._data.title || "Version history")}</b>` +
+      `<span>${releases.length} release${releases.length === 1 ? "" : "s"}</span></div>`;
+
+    this._panel.innerHTML = head + releases.map((r, i) => {
+      const isCur = r.id === cur.id;
+      const bodyId = `vc-body-${i}`;
+      const notes = (r.highlights || []).map((h) => `<li>${escapeHtml(h)}</li>`).join("");
+      const roll = this._rollbackMarkup(r, isCur);
+      return `
+        <div class="rel ${isCur ? "current" : ""}">
+          <button class="rel-top" aria-expanded="${isCur}" aria-controls="${bodyId}">
+            <span class="rel-title">${escapeHtml(r.title || r.id)}</span>
+            <span class="rel-meta">${escapeHtml(r.date || "")} ${escapeHtml(r.id)}</span>
+          </button>
+          <div class="body" id="${bodyId}" ${isCur ? "" : "hidden"}>
+            ${notes ? `<ul>${notes}</ul>` : ""}
+            ${roll}
+          </div>
+        </div>`;
+    }).join("");
+
+    this._panel.querySelectorAll(".rel-top").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const body = this.shadowRoot.getElementById(btn.getAttribute("aria-controls"));
+        const nowHidden = !body.hasAttribute("hidden");
+        body.toggleAttribute("hidden", nowHidden);
+        btn.setAttribute("aria-expanded", String(!nowHidden));
+      });
+    });
+    this._panel.querySelectorAll(".roll:not([disabled])").forEach((btn) => {
+      btn.addEventListener("click", () => this._rollback(btn.dataset.id));
+    });
+  }
+
+  _rollbackMarkup(release, isCurrent) {
+    if (isCurrent) return `<p class="why">You are viewing this version.</p>`;
+    const rb = release.rollback || {};
+    if (rb.available) {
+      return `<button class="roll" data-id="${escapeHtml(release.id)}">Open this version</button>`;
+    }
+    const why = rb.reason || "This version cannot be restored from here.";
+    return `<button class="roll" disabled title="${escapeHtml(why)}">Open this version</button>` +
+           `<p class="why">${escapeHtml(why)}</p>`;
+  }
+
+  /**
+   * Navigate, or hand off. Never mutate. A host that wants to do something
+   * cleverer (restore a snapshot, warn about unsaved work) listens for the event
+   * and calls preventDefault().
+   */
+  _rollback(id) {
+    const release = (this._data.releases || []).find((r) => r.id === id);
+    if (!release) return;
+    const evt = new CustomEvent("changelog:rollback", {
+      detail: { release }, bubbles: true, composed: true, cancelable: true,
+    });
+    const proceed = this.dispatchEvent(evt);
+    if (proceed && release.rollback && release.rollback.url) {
+      window.open(release.rollback.url, this.getAttribute("target") || "_self");
+    }
+  }
+
+  toggle() { this._open ? this.close() : this.open(); }
+
+  open() {
+    this._open = true;
+    this._panel.hidden = false;
+    this._stamp.setAttribute("aria-expanded", "true");
+    // capture phase: a host that stops propagation on its own clicks should not
+    // trap the panel open forever
+    document.addEventListener("click", this._onDocClick, true);
+    document.addEventListener("keydown", this._onKey);
+  }
+
+  close() {
+    this._open = false;
+    this._panel.hidden = true;
+    this._stamp.setAttribute("aria-expanded", "false");
+    document.removeEventListener("click", this._onDocClick, true);
+    document.removeEventListener("keydown", this._onKey);
+  }
+}
+
+function escapeHtml(s) {
+  return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+  ));
+}
+
+function interpolate(tpl, release) {
+  return String(tpl).replace(/\{(\w+)\}/g, (_, k) => escapeHtml(release[k] ?? ""));
+}
+
+if (!customElements.get("version-changelog")) {
+  customElements.define("version-changelog", VersionChangelog);
+}
+
+export { VersionChangelog };

--- a/addons/version_changelog/common/docs/VERSION_CHANGELOG.md
+++ b/addons/version_changelog/common/docs/VERSION_CHANGELOG.md
@@ -1,0 +1,109 @@
+# Version stamp, changelog, and rollback
+
+Every project prints a version somewhere — a footer, an about box, a build hash in
+the corner. It is almost always dead text. This add-on makes it answer the three
+questions a reader actually has:
+
+1. **What am I looking at?** — the stamp itself.
+2. **What changed?** — click it; curated notes per release.
+3. **Can I go back to the one that worked?** — a restore control, enabled only when
+   that is genuinely possible, and disabled with a plain-language reason when it is not.
+
+## Why the curation is mandatory
+
+Commit subjects are written by engineers for engineers. Ours have included lines like
+*"audio drifted from its beat when a beat was inserted"* and *"render script screenshotted
+a stale slide"* — accurate, useful internally, and not what a collaborator or customer
+should be reading in a product changelog.
+
+So the pipeline **fails closed**:
+
+```
+changelog-gen.py draft    →  proposes entries from git, marks the obviously
+                             internal ones include:false with a reason
+        ↓  (a human or an agent reads them as an outsider would)
+changelog-gen.py publish  →  emits changelog.json, but ONLY for releases
+                             whose reviewed flag is true
+```
+
+The `include` heuristic (feat/fix/perf, non-internal scope, no self-flagellating
+phrases) is a **first pass, not a filter you trust**. It once proposed the audio-drift
+line above for publication. `publish` therefore refuses any release still marked
+`reviewed: false`, and refuses outright if internal `_`-prefixed fields would leak.
+
+## Rollback is never guessed
+
+A release is restorable **only** if the project supplies an immutable URL for it in the
+rollback map. The natural source is a per-deployment alias — Cloudflare Pages, Netlify,
+Vercel and S3 versioning all mint one, and it keeps serving that exact build forever.
+
+```json
+{
+  "_default_reason": "This version predates the deployment archive.",
+  "v1.2.0": { "url": "https://a1b2c3d4.my-project.pages.dev/" },
+  "v1.1.0": { "reason": "Restoring this would need the pre-migration database schema." }
+}
+```
+
+Anything backed by server state — a database migration, a changed API contract, a cloud
+function — stays **disabled with the reason shown to the reader**. A greyed button that
+explains itself is far better than one that half-works.
+
+The component itself never mutates anything. It navigates to the URL, or emits a
+cancelable `changelog:rollback` event and lets the host app decide:
+
+```js
+document.addEventListener("changelog:rollback", (e) => {
+  if (hasUnsavedWork()) { e.preventDefault(); confirmThenRestore(e.detail.release); }
+});
+```
+
+## Wiring it in
+
+```html
+<script type="module" src="assets/version-changelog.js"></script>
+
+<!-- fetches the manifest -->
+<version-changelog src="changelog.json"></version-changelog>
+
+<!-- or inline it, for a strict-CSP page that cannot fetch (e.g. a Claude artifact) -->
+<version-changelog>{"title":"Version history","releases":[…]}</version-changelog>
+```
+
+Attributes: `src`, `current` (pin which release is "current"; defaults to the first),
+`drop="down"` (panel opens downward), `theme="light|dark"`, `target` (window target for
+the restore link).
+
+Theming is via CSS custom properties on the host — `--changelog-ink`, `--changelog-surface`,
+`--changelog-rule`, `--changelog-accent`, `--changelog-mono`, `--changelog-sans`. The
+component uses Shadow DOM, so host stylesheets cannot bleed in and its styles cannot leak
+out; it follows `prefers-color-scheme` unless `theme` pins it.
+
+## Manifest
+
+```json
+{
+  "title": "Version history",
+  "stampLabel": "build {id} · {runtime}",
+  "releases": [
+    {
+      "id": "2c5aed27",
+      "title": "Age-specific rates",
+      "date": "2026-08-20",
+      "runtime": "7:04",
+      "highlights": ["Added age- and sex-specific rates", "Corrected the age-distribution claim"],
+      "rollback": { "available": false, "reason": "This is the version you are viewing." }
+    }
+  ]
+}
+```
+
+`stampLabel` interpolates any field of the current release. Order matters: the first
+release is treated as current unless `current` names another.
+
+## Accessibility
+
+The stamp is a real `<button>` with `aria-haspopup`/`aria-expanded`; the panel is a
+labelled dialog; each release header toggles `aria-expanded` on its notes. Escape closes
+and returns focus to the stamp. Disabled restore buttons carry their reason as a `title`
+*and* as visible text, because a tooltip alone is not an explanation.

--- a/addons/version_changelog/common/docs/VERSION_CHANGELOG.md
+++ b/addons/version_changelog/common/docs/VERSION_CHANGELOG.md
@@ -70,6 +70,31 @@ document.addEventListener("changelog:rollback", (e) => {
 <version-changelog>{"title":"Version history","releases":[…]}</version-changelog>
 ```
 
+### Placement
+
+The stamp can sit wherever the page wants it. `placement` decides whether the component
+positions itself or leaves that to the host:
+
+| `placement` | behaviour |
+|---|---|
+| `inline` *(default)* | sits in normal flow, wherever you mount it — a footer, a header, a sidebar |
+| `float` | pins itself like a support launcher; a rounded pill reading "What's new" (override with `floatLabel` in the manifest). `corner` takes `bottom-right` *(default)*, `bottom-left`, `top-right`, `top-left` |
+| `header` | pinned top-right |
+| `footer` | pinned bottom-right |
+| `side` | pinned to the right edge, vertically centred, text running vertically |
+
+Header **and** footer at once is just two mounts — the component is cheap and both read
+the same manifest:
+
+```html
+<header>… <version-changelog src="changelog.json"></version-changelog></header>
+<footer>… <version-changelog src="changelog.json"></version-changelog></footer>
+```
+
+Pinned placements open their panel away from the edge they are pinned to, so it never
+runs off-screen: bottom-pinned opens upward, top-pinned downward, right-pinned aligns
+its right edge, and `side` opens to the left.
+
 Attributes: `src`, `current` (pin which release is "current"; defaults to the first),
 `drop="down"` (panel opens downward), `theme="light|dark"`, `target` (window target for
 the restore link).

--- a/addons/version_changelog/common/scripts/changelog-gen.py
+++ b/addons/version_changelog/common/scripts/changelog-gen.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Turn git history into a *curated* changelog manifest.
+
+The rule this enforces: nothing reaches users by accident. Commit subjects are
+written for engineers and routinely say things like "fix the thing I broke in the
+last commit" — true, useful internally, and not what a collaborator should read.
+
+So generation is two-step and fails closed:
+
+  1. `draft`   scan commits between tags, propose entries, mark each `include`
+               true only if it is plausibly user-facing (feat/fix, user-facing
+               scope, not matching the internal patterns). Everything else lands
+               with include=false and the reason why.
+  2. `publish` read the (hand- or AI-edited) draft and emit changelog.json with
+               ONLY included entries and only user-facing fields. Internal notes,
+               commit hashes and rejection reasons never appear in the output.
+
+Rollback availability is not guessed. A version is restorable only if the project
+supplies an immutable URL for it in the rollback map — typically a per-deployment
+alias that will still serve that exact build years from now. Anything touching
+server state stays disabled with a reason the reader can understand.
+
+  ./changelog-gen.py draft   --repo . --out changelog.draft.json
+  ./changelog-gen.py publish --draft changelog.draft.json --out changelog.json \
+                             --rollback-map rollback.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+# Commit types that can ever be user-facing. Everything else is plumbing.
+USER_FACING_TYPES = {"feat", "fix", "perf"}
+# Scopes that are plumbing even when the type is feat/fix.
+INTERNAL_SCOPES = {"ci", "build", "test", "tests", "deps", "chore", "infra", "tooling"}
+# Subjects that describe our own mess rather than the user's experience.
+INTERNAL_PATTERNS = [
+    re.compile(p, re.I) for p in (
+        r"\brevert\b", r"\bwip\b", r"\btypo\b", r"\bbroke[n]?\b", r"\boops\b",
+        r"\bregression I\b", r"\bmy (own )?(bug|mistake|fault)\b",
+        r"\bstale\b.*\b(slide|build|artifact)\b", r"\bforgot\b", r"\bagain\b$",
+    )
+]
+SUBJECT_RE = re.compile(r"^(?P<type>\w+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!)?:\s*(?P<subject>.+)$")
+
+
+def git(repo: pathlib.Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def classify(subject: str) -> tuple[bool, str]:
+    """Should this line be shown to a user, and if not, why not."""
+    m = SUBJECT_RE.match(subject)
+    if not m:
+        return False, "not a conventional commit"
+    typ, scope = m.group("type").lower(), (m.group("scope") or "").lower()
+    if typ not in USER_FACING_TYPES:
+        return False, f"type '{typ}' is not user-facing"
+    if scope in INTERNAL_SCOPES:
+        return False, f"scope '{scope}' is internal"
+    for pat in INTERNAL_PATTERNS:
+        if pat.search(m.group("subject")):
+            return False, "reads as internal detail"
+    return True, ""
+
+
+def humanise(subject: str) -> str:
+    """Strip the conventional-commit prefix and start with a capital."""
+    m = SUBJECT_RE.match(subject)
+    text = m.group("subject") if m else subject
+    return text[:1].upper() + text[1:]
+
+
+def releases_from_git(repo: pathlib.Path) -> list[dict]:
+    tags = [t for t in git(repo, "tag", "--sort=-creatordate").splitlines() if t.strip()]
+    spans: list[tuple[str, str | None]] = []
+    if tags:
+        for i, tag in enumerate(tags):
+            spans.append((tag, tags[i + 1] if i + 1 < len(tags) else None))
+    else:
+        spans.append(("HEAD", None))
+
+    out = []
+    for tag, prev in spans:
+        rng = f"{prev}..{tag}" if prev else tag
+        log = git(repo, "log", "--no-merges", "--pretty=format:%h%x1f%s%x1f%cI", rng)
+        entries = []
+        for line in [l for l in log.splitlines() if l.strip()]:
+            sha, subject, date = line.split("\x1f")
+            include, why = classify(subject)
+            entries.append({
+                "include": include,
+                "text": humanise(subject),
+                "_commit": sha,
+                "_subject": subject,
+                **({"_excluded_because": why} if not include else {}),
+            })
+        date = git(repo, "log", "-1", "--pretty=format:%cI", tag)[:10] if tag != "HEAD" else ""
+        out.append({
+            "id": tag,
+            "title": tag,
+            "date": date,
+            "reviewed": False,
+            "notes": entries,
+        })
+    return out
+
+
+def cmd_draft(args) -> int:
+    repo = pathlib.Path(args.repo).resolve()
+    data = {
+        "_comment": "Draft. Edit titles and note text for a reader who does not work here; "
+                    "flip include:true/false as needed. Only included notes are published, and "
+                    "fields beginning with _ are never published.",
+        "title": args.title,
+        "releases": releases_from_git(repo),
+    }
+    pathlib.Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
+    total = sum(len(r["notes"]) for r in data["releases"])
+    kept = sum(1 for r in data["releases"] for n in r["notes"] if n["include"])
+    print(f"draft written to {args.out}: {len(data['releases'])} releases, "
+          f"{kept}/{total} notes proposed for publication")
+    return 0
+
+
+def cmd_publish(args) -> int:
+    draft = json.loads(pathlib.Path(args.draft).read_text())
+    rollback = json.loads(pathlib.Path(args.rollback_map).read_text()) if args.rollback_map else {}
+    default_reason = rollback.get(
+        "_default_reason",
+        "This version is not available to reopen — it predates the archive.",
+    )
+
+    releases, unreviewed = [], []
+    for rel in draft.get("releases", []):
+        # The include heuristic is a proposal, not a gate. Someone has to have read
+        # these lines as a stranger would before they ship.
+        if not rel.get("reviewed"):
+            unreviewed.append(rel["id"])
+            continue
+        highlights = [n["text"] for n in rel.get("notes", []) if n.get("include")]
+        if not highlights and not args.keep_empty:
+            continue
+        rb = rollback.get(rel["id"], {})
+        releases.append({
+            "id": rel["id"],
+            "title": rel.get("title") or rel["id"],
+            "date": rel.get("date", ""),
+            **({"runtime": rel["runtime"]} if rel.get("runtime") else {}),
+            "highlights": highlights,
+            "rollback": {
+                "available": bool(rb.get("url")),
+                **({"url": rb["url"]} if rb.get("url") else {}),
+                "reason": rb.get("reason", "" if rb.get("url") else default_reason),
+            },
+        })
+
+    out = {"title": draft.get("title", "Version history"), "releases": releases}
+    if draft.get("stampLabel"):
+        out["stampLabel"] = draft["stampLabel"]
+
+    leaked = [k for k in json.dumps(out) .split('"') if k.startswith("_")]
+    if leaked:
+        print(f"refusing to publish: internal fields leaked into output: {sorted(set(leaked))}",
+              file=sys.stderr)
+        return 1
+
+    if unreviewed:
+        print(f"skipped {len(unreviewed)} unreviewed release(s): {', '.join(unreviewed)}\n"
+              f"  read their notes as an outsider would, then set reviewed: true",
+              file=sys.stderr)
+    if not releases:
+        print("nothing to publish — no release has been reviewed yet", file=sys.stderr)
+        return 1
+
+    pathlib.Path(args.out).write_text(json.dumps(out, indent=2) + "\n")
+    restorable = sum(1 for r in releases if r["rollback"]["available"])
+    print(f"published {args.out}: {len(releases)} releases, {restorable} restorable")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    d = sub.add_parser("draft", help="propose entries from git history")
+    d.add_argument("--repo", default=".")
+    d.add_argument("--out", default="changelog.draft.json")
+    d.add_argument("--title", default="Version history")
+    d.set_defaults(fn=cmd_draft)
+
+    q = sub.add_parser("publish", help="emit the user-facing manifest")
+    q.add_argument("--draft", default="changelog.draft.json")
+    q.add_argument("--out", default="changelog.json")
+    q.add_argument("--rollback-map", default=None)
+    q.add_argument("--keep-empty", action="store_true",
+                   help="keep releases whose notes were all excluded")
+    q.set_defaults(fn=cmd_publish)
+
+    args = p.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -207,6 +207,7 @@ def main() -> int:
         "local_ollama",
         "encrypted_local_areas",
         "convergent_deploy",
+        "version_changelog",
     ):
         if values.get(f"include_{addon}") == "yes":
             overlaid = False

--- a/examples/version-changelog/changelog.json
+++ b/examples/version-changelog/changelog.json
@@ -1,0 +1,23 @@
+{
+  "title": "Firestarter demo",
+  "stampLabel": "build {id} · {date}",
+  "releases": [
+    {
+      "id": "a1b2c3d4",
+      "title": "Rollback control",
+      "date": "2026-08-20",
+      "highlights": [
+        "Click the build stamp to see what changed",
+        "Reopen an earlier version when one is archived"
+      ],
+      "rollback": { "available": false, "reason": "This is the version you are viewing." }
+    },
+    {
+      "id": "9f8e7d6c",
+      "title": "First release",
+      "date": "2026-08-14",
+      "highlights": ["Initial public build"],
+      "rollback": { "available": true, "url": "https://example.com/deploy/9f8e7d6c/" }
+    }
+  ]
+}

--- a/examples/version-changelog/index.html
+++ b/examples/version-changelog/index.html
@@ -77,7 +77,14 @@
       ]
     }</version-changelog>
   </div>
+
+  <div class="case">
+    <h2>4 — placement: float (a support-launcher pill, bottom-right)</h2>
+    <p>Pins itself to the viewport. Look at the bottom-right corner of this page.</p>
+  </div>
 </div>
+
+<version-changelog placement="float" src="changelog.json"></version-changelog>
 
 <script type="module" src="../../addons/version_changelog/common/assets/version-changelog.js"></script>
 <script>

--- a/examples/version-changelog/index.html
+++ b/examples/version-changelog/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>version-changelog — states</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; padding: 3rem 1.5rem 12rem; background: #f4f6f5; color: #131b1a;
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  @media (prefers-color-scheme: dark) { body { background: #0e1413; color: #e3eae8; } }
+  .wrap { max-width: 42rem; margin: 0 auto; display: flex; flex-direction: column; gap: 2rem; }
+  h1 { font-size: 1.5rem; margin: 0; }
+  p { margin: 0; color: #5d6b68; }
+  @media (prefers-color-scheme: dark) { p { color: #a3b0ad; } }
+  .case {
+    border: 1px solid #dde4e2; border-radius: 6px; padding: 1rem 1.15rem;
+    display: flex; flex-direction: column; gap: .6rem; background: #fff;
+  }
+  @media (prefers-color-scheme: dark) { .case { background: #161d1c; border-color: #2a3533; } }
+  .case h2 { font-size: .95rem; margin: 0; }
+  code { font-family: ui-monospace, Menlo, monospace; font-size: .85em; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>version-changelog</h1>
+  <p>Three states worth looking at: a fetched manifest, an inline manifest for
+  strict-CSP pages, and a release that cannot be restored. Click any stamp.</p>
+
+  <div class="case">
+    <h2>1 — fetched manifest, panel opens upward (default)</h2>
+    <p>Reads <code>changelog.json</code> over the network.</p>
+    <version-changelog src="changelog.json"></version-changelog>
+  </div>
+
+  <div class="case">
+    <h2>2 — inline manifest, panel opens downward</h2>
+    <p>No fetch, so it works inside a Claude artifact. Note the disabled restore
+    on the release with a database migration behind it.</p>
+    <version-changelog drop="down">{
+      "title": "Acme API",
+      "stampLabel": "v{id} · {date}",
+      "releases": [
+        {
+          "id": "2.1.0", "title": "Saved views", "date": "2026-08-18",
+          "highlights": ["Save a filter set and come back to it", "Faster first paint on the dashboard"],
+          "rollback": { "available": false, "reason": "This is the version you are viewing." }
+        },
+        {
+          "id": "2.0.0", "title": "New dashboard", "date": "2026-07-30",
+          "highlights": ["Rebuilt dashboard", "Keyboard navigation throughout"],
+          "rollback": { "available": false, "reason": "Restoring 2.0.0 would need the pre-migration database schema, so it cannot be reopened from here." }
+        },
+        {
+          "id": "1.9.2", "title": "Export fixes", "date": "2026-07-11",
+          "highlights": ["CSV export keeps column order", "Long report titles no longer truncate"],
+          "rollback": { "available": true, "url": "https://example.com/deploy/1-9-2/" }
+        }
+      ]
+    }</version-changelog>
+  </div>
+
+  <div class="case">
+    <h2>3 — host intercepts the restore</h2>
+    <p>Listens for <code>changelog:rollback</code> and calls
+    <code>preventDefault()</code>, so nothing navigates. Watch the console.</p>
+    <version-changelog id="guarded" drop="down">{
+      "title": "Guarded",
+      "releases": [
+        { "id": "3.0.0", "title": "Current", "date": "2026-08-20", "highlights": ["You are here"],
+          "rollback": { "available": false, "reason": "This is the version you are viewing." } },
+        { "id": "2.9.0", "title": "Previous", "date": "2026-08-01", "highlights": ["The one before"],
+          "rollback": { "available": true, "url": "https://example.com/deploy/2-9-0/" } }
+      ]
+    }</version-changelog>
+  </div>
+</div>
+
+<script type="module" src="../../addons/version_changelog/common/assets/version-changelog.js"></script>
+<script>
+  document.getElementById("guarded").addEventListener("changelog:rollback", (e) => {
+    e.preventDefault();
+    console.log("host intercepted rollback to", e.detail.release.id, "— navigation suppressed");
+    alert(`Host intercepted: would restore ${e.detail.release.id} after confirming unsaved work.`);
+  });
+</script>
+</body>
+</html>

--- a/firestarter.config.json
+++ b/firestarter.config.json
@@ -23,6 +23,7 @@
   "include_local_ollama": ["no", "yes"],
   "include_encrypted_local_areas": ["no", "yes"],
   "include_convergent_deploy": ["no", "yes"],
+  "include_version_changelog": ["no", "yes"],
 
   "db_name": "{{ project_slug }}",
   "commit_scopes": "backend frontend migrations docs ci build",

--- a/tests/test_version_changelog_contract.py
+++ b/tests/test_version_changelog_contract.py
@@ -124,6 +124,33 @@ class CurationGate(unittest.TestCase):
         self.assertNotIn("_default_reason", by_id)
 
 
+class Placement(unittest.TestCase):
+    """A pinned stamp must open its panel away from the edge it is pinned to, or the
+    panel runs off-screen — the failure mode you only notice on someone else's laptop."""
+
+    def setUp(self):
+        self.src = (ADDON / "assets" / "version-changelog.js").read_text()
+
+    def test_all_modes_present(self):
+        for mode in ("float", "header", "footer", "side"):
+            self.assertIn(f'placement="{mode}"', self.src, f"{mode} placement missing")
+
+    def test_pinned_modes_position_themselves(self):
+        self.assertRegex(self.src, r':host\(\[placement="float"\]\)[^{]*,?[\s\S]{0,200}?position:\s*fixed')
+
+    def test_panel_opens_away_from_the_pinned_edge(self):
+        # top-pinned opens downward
+        self.assertIn(':host([placement="header"]) .panel { bottom: auto; top:', self.src)
+        # right-pinned aligns right so it cannot overflow the viewport
+        self.assertIn("left: auto; right: 0;", self.src)
+        # side opens leftward
+        self.assertIn(':host([placement="side"]) .panel { right: calc(100% + .5rem)', self.src)
+
+    def test_placement_is_observed_at_runtime(self):
+        self.assertIn('"placement"', self.src)
+        self.assertIn('"corner"', self.src)
+
+
 class ComponentSurface(unittest.TestCase):
     def test_escapes_and_never_mutates(self):
         src = (ADDON / "assets" / "version-changelog.js").read_text()

--- a/tests/test_version_changelog_contract.py
+++ b/tests/test_version_changelog_contract.py
@@ -1,0 +1,139 @@
+"""Generator + curation contract for the version_changelog add-on.
+
+Proves the add-on is off by default, stamps for every declared stack with no token
+leaks, and — the part that matters — that the changelog generator refuses to publish
+anything a human has not read. The heuristic that proposes entries is deliberately
+fallible; these tests pin the gate that stands behind it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON = ROOT / "addons" / "version_changelog" / "common"
+GENERATOR = ROOT / "bin" / "generate.py"
+CONFIG = json.loads((ROOT / "firestarter.config.json").read_text())
+GEN = ADDON / "scripts" / "changelog-gen.py"
+
+LEAK = re.compile(r"\{\{")
+
+
+def _stamp(output: Path, stack: str, *, enable: bool) -> None:
+    args = [
+        sys.executable, str(GENERATOR), "--defaults",
+        "--set", f"stack={stack}",
+        "--output", str(output),
+    ]
+    if enable:
+        args += ["--set", "include_version_changelog=yes"]
+    subprocess.run(args, check=True, capture_output=True, text=True)
+
+
+class GeneratorContract(unittest.TestCase):
+    def test_registered_and_off_by_default(self):
+        choices = CONFIG["include_version_changelog"]
+        self.assertEqual(choices[0], "no", "add-on must be opt-in")
+        self.assertIn("yes", choices)
+
+    def test_absent_unless_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "proj"
+            _stamp(out, CONFIG["stack"][0], enable=False)
+            self.assertFalse(list(out.rglob("version-changelog.js")))
+            self.assertFalse(list(out.rglob("VERSION_CHANGELOG.md")))
+
+    def test_stamps_for_every_stack_without_leaks(self):
+        for stack in CONFIG["stack"]:
+            with self.subTest(stack=stack), tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp) / "proj"
+                _stamp(out, stack, enable=True)
+                for name in ("version-changelog.js", "VERSION_CHANGELOG.md", "changelog-gen.py"):
+                    hits = list(out.rglob(name))
+                    self.assertTrue(hits, f"{name} missing for stack {stack}")
+                    for hit in hits:
+                        self.assertIsNone(LEAK.search(hit.read_text()),
+                                          f"unsubstituted token in {hit}")
+
+
+class CurationGate(unittest.TestCase):
+    """The generator must fail closed. These are the rules that keep an internal
+    sentence out of a customer-facing changelog."""
+
+    def _publish(self, draft: dict, tmp: Path, rollback: dict | None = None):
+        dpath = tmp / "draft.json"
+        dpath.write_text(json.dumps(draft))
+        args = [sys.executable, str(GEN), "publish",
+                "--draft", str(dpath), "--out", str(tmp / "out.json")]
+        if rollback is not None:
+            rpath = tmp / "rollback.json"
+            rpath.write_text(json.dumps(rollback))
+            args += ["--rollback-map", str(rpath)]
+        return subprocess.run(args, capture_output=True, text=True)
+
+    def test_unreviewed_release_is_never_published(self):
+        draft = {"releases": [{"id": "v1", "reviewed": False,
+                               "notes": [{"include": True, "text": "Something"}]}]}
+        with tempfile.TemporaryDirectory() as tmp:
+            res = self._publish(draft, Path(tmp))
+        self.assertNotEqual(res.returncode, 0, "unreviewed release must not publish")
+        self.assertIn("reviewed", res.stderr)
+
+    def test_excluded_notes_do_not_reach_output(self):
+        draft = {"releases": [{
+            "id": "v1", "reviewed": True,
+            "notes": [
+                {"include": True, "text": "Faster export"},
+                {"include": False, "text": "Audio drifted from its beat", "_commit": "abc123"},
+            ],
+        }]}
+        with tempfile.TemporaryDirectory() as tmp:
+            res = self._publish(draft, Path(tmp))
+            self.assertEqual(res.returncode, 0, res.stderr)
+            out = json.loads((Path(tmp) / "out.json").read_text())
+        highlights = out["releases"][0]["highlights"]
+        self.assertEqual(highlights, ["Faster export"])
+        blob = json.dumps(out)
+        self.assertNotIn("drifted", blob)
+        self.assertNotIn("abc123", blob, "commit hashes are internal")
+
+    def test_rollback_disabled_unless_url_supplied(self):
+        draft = {"releases": [
+            {"id": "v2", "reviewed": True, "notes": [{"include": True, "text": "New"}]},
+            {"id": "v1", "reviewed": True, "notes": [{"include": True, "text": "Old"}]},
+        ]}
+        rollback = {"_default_reason": "Predates the archive.",
+                    "v1": {"url": "https://example.com/deploy/v1/"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            res = self._publish(draft, Path(tmp), rollback)
+            self.assertEqual(res.returncode, 0, res.stderr)
+            out = json.loads((Path(tmp) / "out.json").read_text())
+        by_id = {r["id"]: r for r in out["releases"]}
+        self.assertFalse(by_id["v2"]["rollback"]["available"])
+        self.assertTrue(by_id["v2"]["rollback"]["reason"], "a disabled entry must explain itself")
+        self.assertTrue(by_id["v1"]["rollback"]["available"])
+        self.assertEqual(by_id["v1"]["rollback"]["url"], "https://example.com/deploy/v1/")
+        # the map's own private key must not surface as a release
+        self.assertNotIn("_default_reason", by_id)
+
+
+class ComponentSurface(unittest.TestCase):
+    def test_escapes_and_never_mutates(self):
+        src = (ADDON / "assets" / "version-changelog.js").read_text()
+        self.assertIn("escapeHtml", src)
+        self.assertIn("cancelable: true", src)
+        # rendering paths must go through the escaper, so a note cannot inject markup
+        self.assertNotRegex(src, r"innerHTML\s*=\s*`?\$\{(?!head)[a-z]", )
+        for prop in ("--changelog-ink", "--changelog-surface", "--changelog-accent"):
+            self.assertIn(prop, src, f"{prop} must be themeable by the host")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Every project prints a version somewhere — a footer, an about box, a build hash in a corner — and it is almost always dead text. This makes it answer the three questions a reader actually has: what am I looking at, what changed, and can I go back to the one that worked.

## What

A dependency-free Web Component (`version-changelog.js`, Shadow DOM) plus a generator that builds its manifest from git.

**Placement is configurable**, because "where does the version live" differs per project: `inline` (default), `float` (a support-launcher-style pill, any corner), `header`, `footer`, `side`. Header *and* footer at once is just two mounts reading the same manifest. Pinned placements open their panel away from the edge they are pinned to — otherwise the panel runs off-screen, which is the kind of thing you only discover on someone else's laptop.

## The part that matters: curation fails closed

Commit subjects are written by engineers for engineers. Ours have included *"audio drifted from its beat when a beat was inserted"* and *"render script screenshotted a stale slide"* — accurate, useful internally, and not what a collaborator should read in a product changelog.

So the pipeline is `draft` → human reads it → `publish`, and **`publish` refuses any release still marked `reviewed: false`**. The heuristic that proposes entries is deliberately fallible — it once proposed the audio-drift line above for publication — so the gate stands behind it rather than in place of it. Internal `_`-prefixed fields (commit hashes) are stripped.

## Rollback is never guessed

A release is restorable **only** if the project supplies an immutable URL for it. Per-deployment aliases from Pages/Netlify/Vercel/S3 versioning are the natural source. Anything backed by server state — a migration, a changed API contract — stays **disabled with the reason shown to the reader**. A greyed button that explains itself beats one that half-works.

The component never mutates anything: it navigates, or emits a cancelable `changelog:rollback` event and lets the host decide.

## Testing

11 contract tests: registered and off by default, stamps cleanly for every declared stack with no token leaks, unreviewed releases never publish, excluded notes and commit hashes never reach output, rollback disabled without a URL, pinned panels position away from their edge, all rendering goes through the escaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)