### PR TITLE
fix(addons): pin bounded runner marker to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # repository renormalization.
 *.sh        text eol=lf
 .githooks/* text eol=lf
+.bounded-runner-root text eol=lf

--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -6,3 +6,4 @@
 # Scoped narrowly (not a blanket `* text=auto`) to avoid renormalizing the tree.
 *.sh        text eol=lf
 .githooks/* text eol=lf
+.bounded-runner-root text eol=lf

--- a/tests/test_bounded_runner_contract.py
+++ b/tests/test_bounded_runner_contract.py
@@ -549,6 +549,8 @@ class BoundedRunnerStaticContract(unittest.TestCase):
             self.assertFalse((root / "ran").exists())
 
     def test_every_stack_stamps_exact_addon_and_default_stays_clean(self) -> None:
+        for attributes in (ROOT / ".gitattributes", ROOT / "template" / ".gitattributes"):
+            self.assertIn(".bounded-runner-root text eol=lf", attributes.read_text())
         polluted = [
             path for path in ADDON.rglob("*")
             if path.name == "__pycache__" or path.suffix in {".pyc", ".pyo"}
@@ -577,7 +579,14 @@ class BoundedRunnerStaticContract(unittest.TestCase):
                         if source.is_file():
                             stamped = enabled / source.relative_to(ADDON)
                             self.assertTrue(stamped.is_file(), stamped)
-                            self.assertEqual(stamped.read_bytes(), source.read_bytes(), stamped)
+                            # The generator intentionally reads/writes text, so a
+                            # Windows checkout's CRLF source normalizes to LF in
+                            # stamped output. Compare semantic text, not host EOL.
+                            self.assertEqual(
+                                stamped.read_text(encoding="utf-8"),
+                                source.read_text(encoding="utf-8"),
+                                stamped,
+                            )
                     self.assertEqual(list(enabled.rglob("__pycache__")), [])
                     compiled = subprocess.run(
                         [sys.executable, "-B", "-m", "py_compile",


### PR DESCRIPTION
Follow-up to #136 / #124.

Merged-master verification on the real Windows checkout caught a platform-only failure: `.bounded-runner-root` was checked out as CRLF, so the Git-Bash wrapper's exact marker check could reject it. Hosted Linux CI stayed green and therefore could not expose the checkout conversion.

## Fix
- pin `.bounded-runner-root text eol=lf` in Firestarter's own and stamped `.gitattributes`
- make the every-stack test compare generator-normalized semantic text instead of host-specific source EOL bytes
- assert both attribute contracts directly

## Proof
- all 18 adversarial tests pass from the actual Windows checkout under Docker `--init`
- every declared stack stamps successfully
- Windows/Git-Bash wrapper preflight succeeds end to end