### PR TITLE
feat(addons): cross_host_agent, one scoped channel to a machine you are not on

### DIFF
--- a/addons/cross_host_agent/README.md
+++ b/addons/cross_host_agent/README.md
@@ -1,0 +1,61 @@
+# cross_host_agent add-on
+
+Let an agent session on one machine do work that only exists on another, through one
+scoped channel rather than an improvised one.
+
+Stack-agnostic, Python-stdlib-only, no daemon, no service.
+
+```
+cross_host_agent/
+├── README.md                       this file (not stamped into projects)
+└── common/                         overlaid when include_cross_host_agent=yes
+    ├── bin/agent-host              resolve a capability, run, copy, check, revoke
+    ├── bootstrap/{windows.ps1,macos.sh,linux.sh}
+    ├── hosts.json                  which host does what, and when the grant ends
+    └── docs/CROSS_HOST_AGENT.md
+```
+
+## The problem
+
+Some work only exists on one machine: software that is Windows-only, a GPU in one box, a
+licensed tool, a build that must happen on the target OS. Without a plan, each occurrence
+becomes half an hour of enabling services and guessing at firewall rules, and what gets
+left behind is an open port nobody wrote down.
+
+## The properties worth having
+
+**Tailnet-only.** The firewall rule is scoped to the tailnet interface. This is the part
+that is easy to get wrong: on Windows a rule created without an explicit profile does not
+apply to that adapter, so the port stays shut while every command reports success. The
+bootstrap pins it and then verifies by connecting to itself.
+
+**Key-only, never a password.** Password auth is disabled on the channel and the client
+passes `BatchMode=yes` and `PasswordAuthentication=no`, so an agent cannot send one even
+if something prompts.
+
+**Capabilities, not addresses.** `agent-host run joinpoint -- ...`. Intent stays in a
+reviewable manifest instead of shell history, and two hosts offering the same capability
+is an error rather than a coin flip.
+
+**Grants expire.** `grant_expires` is mandatory and the client refuses past it. The
+default outcome of forgetting a channel is that it closes.
+
+**Revocable and auditable.** `agent-host revoke <host>` gives the exact commands for that
+OS. Every invocation appends to a local log.
+
+## Relationship to the other add-ons
+
+| add-on | answers |
+|---|---|
+| `work_registry` | is a peer already working here? |
+| `orchestrator_session` | who owns this task? |
+| `convergent_deploy` | what if two of us publish at once? |
+| **`cross_host_agent`** | what if the work is on a machine I am not on? |
+
+## Enable
+
+```bash
+python3 bin/generate.py --set include_cross_host_agent=yes ...
+```
+
+Contract tests: `tests/test_cross_host_agent_contract.py`.

--- a/addons/cross_host_agent/common/bin/agent-host
+++ b/addons/cross_host_agent/common/bin/agent-host
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Resolve a capability to a host, run a command there, and keep the grant honest.
+
+An agent session runs on one machine. Some work only exists on another: software that is
+Windows-only, a GPU in one box, a licensed tool, a build that must happen on the target
+OS. This is the thin client for that, and it is deliberately thin. It shells out to ssh
+and scp rather than reimplementing them, because the security properties worth having
+come from ssh's configuration, not from a wrapper.
+
+Design notes worth keeping:
+
+**Capabilities, not addresses.** An agent asks for `joinpoint`, not for 100.76.25.4.
+Intent lives in hosts.json where it can be reviewed and revoked, rather than in shell
+history where it cannot.
+
+**Grants expire.** Every host carries `grant_expires`. Past it, `run` refuses. The
+default outcome of forgetting about a channel is that it closes, not that it stays open
+forever, and that is the whole reason the field is mandatory.
+
+**Refuse rather than guess.** Unknown capability, ambiguous capability, missing host,
+expired grant: all are errors. A tool that silently picks a host when two match is a tool
+that eventually runs something on the wrong machine.
+
+**Log everything.** Not a security boundary, since anything with the key can bypass it.
+It is the record you want when asking what a session did on another machine.
+
+Stdlib only, no dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import shlex
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOSTS = pathlib.Path(os.environ.get("AGENT_HOST_MANIFEST", ROOT / "hosts.json"))
+LOG = pathlib.Path(os.environ.get("AGENT_HOST_LOG",
+                                 pathlib.Path.home() / ".agent-host" / "audit.log"))
+KEY = os.environ.get("AGENT_HOST_KEY", str(pathlib.Path.home() / ".ssh" / "agent_host_ed25519"))
+
+SSH_HARDENING = [
+    "-o", "BatchMode=yes",              # never prompt for a password
+    "-o", "PasswordAuthentication=no",  # and never send one
+    "-o", "StrictHostKeyChecking=accept-new",
+    "-o", "ConnectTimeout=15",
+]
+
+
+def die(msg: str, code: int = 2):
+    print(f"agent-host: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_hosts() -> list[dict]:
+    if not HOSTS.exists():
+        die(f"no manifest at {HOSTS}. Declare hosts before using them.")
+    try:
+        return json.loads(HOSTS.read_text()).get("hosts", [])
+    except ValueError as e:
+        die(f"{HOSTS} is not valid JSON: {e}")
+
+
+def expired(host: dict) -> str | None:
+    v = host.get("grant_expires")
+    if not v:
+        return "no grant_expires set; every grant must have an end date"
+    try:
+        end = dt.date.fromisoformat(v)
+    except ValueError:
+        return f"grant_expires {v!r} is not an ISO date"
+    today = dt.date.today()
+    if end < today:
+        return f"grant expired on {end} ({(today - end).days} days ago)"
+    return None
+
+
+def resolve(cap: str) -> dict:
+    matches = [h for h in load_hosts() if cap in h.get("capabilities", [])]
+    if not matches:
+        known = sorted({c for h in load_hosts() for c in h.get("capabilities", [])})
+        die(f"no host offers {cap!r}. Declared capabilities: {', '.join(known) or 'none'}")
+    if len(matches) > 1:
+        names = ", ".join(h["name"] for h in matches)
+        die(f"{cap!r} is offered by more than one host ({names}). "
+            f"Name one with --host rather than letting this choose.")
+    host = matches[0]
+    why = expired(host)
+    if why:
+        die(f"host {host['name']}: {why}. Re-run the bootstrap to renew, "
+            f"or 'agent-host revoke {host['name']}' if it is done with.")
+    return host
+
+
+def audit(host: str, action: str, detail: str, rc: int | None = None):
+    LOG.parent.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now().isoformat(timespec="seconds")
+    with open(LOG, "a") as fh:
+        fh.write(f"{stamp}\t{host}\t{action}\trc={rc}\t{detail}\n")
+
+
+def target(host: dict) -> str:
+    return f"{host['user']}@{host['address']}"
+
+
+def cmd_run(args) -> int:
+    host = by_name(args.host) if args.host else resolve(args.capability)
+    remote = " ".join(args.command)
+    if not remote:
+        die("nothing to run. Put the command after --")
+    argv = ["ssh", *SSH_HARDENING, "-i", KEY, target(host), remote]
+    if args.dry_run:
+        print(" ".join(shlex.quote(a) for a in argv))
+        return 0
+    print(f"agent-host: {host['name']} ({host.get('os','?')}) <- {remote}", file=sys.stderr)
+    rc = subprocess.call(argv)
+    audit(host["name"], "run", remote, rc)
+    return rc
+
+
+def cmd_copy(args) -> int:
+    src, dst = args.source, args.dest
+    if ":" in dst:
+        cap, path = dst.split(":", 1)
+        host = by_name(args.host) if args.host else resolve(cap)
+        remote = f"{target(host)}:{path}"
+        argv = ["scp", *SSH_HARDENING, "-i", KEY, src, remote]
+    elif ":" in src:
+        cap, path = src.split(":", 1)
+        host = by_name(args.host) if args.host else resolve(cap)
+        argv = ["scp", *SSH_HARDENING, "-i", KEY, f"{target(host)}:{path}", dst]
+    else:
+        die("one side must be <capability>:<path>")
+    rc = subprocess.call(argv)
+    audit(host["name"], "copy", f"{src} -> {dst}", rc)
+    return rc
+
+
+def by_name(name: str) -> dict:
+    for h in load_hosts():
+        if h["name"] == name:
+            why = expired(h)
+            if why:
+                die(f"host {name}: {why}")
+            return h
+    die(f"no host named {name!r}")
+
+
+def cmd_list(args) -> int:
+    hosts = load_hosts()
+    if not hosts:
+        print("no hosts declared")
+        return 0
+    for h in hosts:
+        why = expired(h)
+        state = "EXPIRED" if why else "ok"
+        print(f"{h['name']:<20} {h.get('os','?'):<9} {state:<8} "
+              f"{','.join(h.get('capabilities', []))}")
+        if h.get("note"):
+            print(f"{'':<20} {h['note']}")
+    return 0
+
+
+def cmd_check(args) -> int:
+    bad = 0
+    for h in load_hosts():
+        why = expired(h)
+        if why:
+            print(f"{h['name']}: {why}"); bad += 1; continue
+        argv = ["ssh", *SSH_HARDENING, "-i", KEY, target(h), "echo ok"]
+        rc = subprocess.call(argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print(f"{h['name']}: {'reachable' if rc == 0 else 'UNREACHABLE'}")
+        audit(h["name"], "check", "connectivity", rc)
+        bad += (rc != 0)
+    return 1 if bad else 0
+
+
+def cmd_revoke(args) -> int:
+    host = by_name(args.host)
+    print(f"Revoking access to {host['name']}. Run this on that machine:\n")
+    if host.get("os") == "windows":
+        print("  Remove-NetFirewallRule -Name agent-host-ssh -EA SilentlyContinue")
+        print("  Stop-Service sshd; Set-Service sshd -StartupType Disabled")
+        print("  # and drop the key line from")
+        print("  #   $env:ProgramData\\ssh\\administrators_authorized_keys")
+    else:
+        print("  sudo systemctl disable --now sshd   # or: sudo systemsetup -setremotelogin off")
+        print("  # and drop the agent-host line from ~/.ssh/authorized_keys")
+    print(f"\nThen remove {host['name']} from {HOSTS}.")
+    audit(host["name"], "revoke", "instructions issued")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="agent-host", description=__doc__.split("\n")[0])
+    p.add_argument("--host", help="name a host explicitly instead of resolving a capability")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="run a command on the host offering a capability")
+    r.add_argument("capability", nargs="?")
+    r.add_argument("--dry-run", action="store_true", help="print the ssh invocation only")
+    r.add_argument("command", nargs=argparse.REMAINDER)
+    r.set_defaults(fn=cmd_run)
+
+    c = sub.add_parser("copy", help="copy to or from <capability>:<path>")
+    c.add_argument("source"); c.add_argument("dest"); c.set_defaults(fn=cmd_copy)
+
+    sub.add_parser("list", help="declared hosts and grant status").set_defaults(fn=cmd_list)
+    sub.add_parser("check", help="test reachability of every declared host").set_defaults(fn=cmd_check)
+
+    v = sub.add_parser("revoke", help="how to close a channel")
+    v.add_argument("host"); v.set_defaults(fn=cmd_revoke)
+
+    args = p.parse_args()
+    if args.cmd == "run":
+        # argparse.REMAINDER swallows everything after the capability, flags included, so
+        # `run thing --dry-run -- echo hi` arrives with --dry-run inside the remote
+        # command. Left unhandled that does not merely mis-parse: it executes the command
+        # the user asked to preview. Pull our own flags back out before the separator.
+        rest = list(args.command)
+        while rest and rest[0].startswith("-") and rest[0] != "--":
+            flag = rest.pop(0)
+            if flag == "--dry-run":
+                args.dry_run = True
+            else:
+                die(f"unknown option {flag!r} before the command. "
+                    f"Put agent-host options before the capability, and the remote "
+                    f"command after --")
+        if rest and rest[0] == "--":
+            rest = rest[1:]
+        args.command = rest
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/addons/cross_host_agent/common/bootstrap/linux.sh
+++ b/addons/cross_host_agent/common/bootstrap/linux.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Open one scoped, tailnet-only, key-authenticated SSH channel on this Linux host.
+# Usage: ./linux.sh "ssh-ed25519 AAAA... agent@other-host"
+set -euo pipefail
+
+KEY="${1:-}"
+[ -n "$KEY" ] || { echo "usage: $0 '<public key>'" >&2; exit 1; }
+ok()   { printf '  [ok]   %s\n' "$1"; }
+warn() { printf '  [warn] %s\n' "$1"; }
+head_() { printf '\n== %s\n' "$1"; }
+
+head_ "sshd"
+if ! command -v sshd >/dev/null 2>&1; then
+  echo "  installing openssh-server"
+  if   command -v apt-get >/dev/null; then sudo apt-get update -qq && sudo apt-get install -y openssh-server
+  elif command -v dnf     >/dev/null; then sudo dnf install -y openssh-server
+  elif command -v pacman  >/dev/null; then sudo pacman -S --noconfirm openssh
+  else warn "unknown package manager; install openssh-server yourself"; fi
+fi
+sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
+ok "sshd enabled and running"
+
+head_ "Authorized key"
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
+grep -qF "$KEY" ~/.ssh/authorized_keys || printf '%s\n' "$KEY" >> ~/.ssh/authorized_keys
+ok "key present"
+
+head_ "Password authentication"
+D=/etc/ssh/sshd_config.d/10-agent-host.conf
+sudo mkdir -p "$(dirname "$D")"
+printf 'PasswordAuthentication no\nPubkeyAuthentication yes\n' | sudo tee "$D" >/dev/null
+sudo systemctl reload sshd 2>/dev/null || sudo systemctl reload ssh
+ok "password auth disabled via $D"
+
+head_ "Firewall"
+if command -v ufw >/dev/null 2>&1 && sudo ufw status | grep -qi active; then
+  if ip=$(tailscale ip -4 2>/dev/null | head -1) && [ -n "$ip" ]; then
+    sudo ufw allow in on tailscale0 to any port 22 proto tcp >/dev/null 2>&1 || \
+      warn "could not scope ufw to tailscale0; check manually"
+    ok "ufw allows 22 on tailscale0 only"
+  fi
+else
+  warn "no active ufw; port 22 exposure depends on your existing firewall"
+fi
+
+head_ "Reachability"
+ip="$(tailscale ip -4 2>/dev/null | head -1 || true)"
+[ -n "$ip" ] && ok "tailnet address $ip" || warn "tailscale ip returned nothing"
+
+echo
+echo "Revoke with: sudo systemctl disable --now sshd; sudo rm -f $D"
+echo "and drop the agent-host line from ~/.ssh/authorized_keys"

--- a/addons/cross_host_agent/common/bootstrap/macos.sh
+++ b/addons/cross_host_agent/common/bootstrap/macos.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Open one scoped, tailnet-only, key-authenticated SSH channel on this Mac.
+#
+# macOS has Remote Login built in, so this is mostly about narrowing it rather than
+# installing anything: key-only, and reachable on the tailnet rather than every network
+# the laptop ever joins.
+#
+# Usage: ./macos.sh "ssh-ed25519 AAAA... agent@other-host"
+set -euo pipefail
+
+KEY="${1:-}"
+[ -n "$KEY" ] || { echo "usage: $0 '<public key>'" >&2; exit 1; }
+
+ok()   { printf '  [ok]   %s\n' "$1"; }
+warn() { printf '  [warn] %s\n' "$1"; }
+head_() { printf '\n== %s\n' "$1"; }
+
+head_ "Remote Login"
+if systemsetup -getremotelogin 2>/dev/null | grep -qi 'on'; then
+  ok "already enabled"
+else
+  echo "  enabling (needs sudo)"
+  sudo systemsetup -setremotelogin on
+  ok "enabled"
+fi
+
+head_ "Authorized key"
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
+if grep -qF "$KEY" ~/.ssh/authorized_keys; then
+  ok "key already present"
+else
+  printf '%s\n' "$KEY" >> ~/.ssh/authorized_keys
+  ok "key added"
+fi
+
+head_ "Password authentication"
+# Leave the system config alone if another service depends on it; report rather than
+# silently reconfigure a machine someone else also uses.
+if sudo grep -qE '^\s*PasswordAuthentication\s+no' /etc/ssh/sshd_config 2>/dev/null; then
+  ok "already disabled"
+else
+  warn "password auth is still enabled in /etc/ssh/sshd_config"
+  warn "set 'PasswordAuthentication no' there if this host is agent-facing only"
+fi
+
+head_ "Reachability"
+if command -v tailscale >/dev/null 2>&1; then
+  ip="$(tailscale ip -4 2>/dev/null | head -1 || true)"
+  if [ -n "$ip" ]; then
+    if nc -z -G 5 "$ip" 22 2>/dev/null; then ok "reachable on the tailnet at $ip"
+    else warn "NOT reachable at $ip; check the macOS firewall"; fi
+  else warn "tailscale ip returned nothing"; fi
+else
+  warn "tailscale not installed; this host will only be reachable on its LAN"
+fi
+
+cat <<'EOF'
+
+macOS has no per-interface firewall rule to scope this the way Windows does. If this host
+should only be reachable over the tailnet, either bind sshd to the tailnet address in
+/etc/ssh/sshd_config with ListenAddress, or leave the application firewall on and allow
+only sshd. Revoke by dropping the key line and running:
+
+  sudo systemsetup -setremotelogin off
+EOF

--- a/addons/cross_host_agent/common/bootstrap/windows.ps1
+++ b/addons/cross_host_agent/common/bootstrap/windows.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+  Open one scoped, tailnet-only, key-authenticated SSH channel on this Windows host.
+
+.DESCRIPTION
+  Written for Windows PowerShell 5.1. Must run elevated. Idempotent.
+
+  It verifies by connecting to itself at the end rather than reporting success because no
+  command threw, which is the failure mode that cost an afternoon: the capability
+  installs, the service is created, a firewall rule is added, every line "succeeds", and
+  the port is still closed from the tailnet because the rule landed on the wrong profile.
+
+.PARAMETER PublicKey
+  The public key of the machine that will connect. Required. Password authentication is
+  never enabled by this script.
+
+.PARAMETER TailnetOnly
+  Scope the firewall rule to the Tailscale interface only. On by default, and turning it
+  off is a deliberate act.
+
+.EXAMPLE
+  .\windows.ps1 -PublicKey "ssh-ed25519 AAAA... agent@macbook-pro"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$PublicKey,
+    [bool]$TailnetOnly = $true,
+    [string]$RuleName = "agent-host-ssh"
+)
+
+$ErrorActionPreference = 'Stop'
+function Ok   { param($m) Write-Host "  [ok]   $m" -ForegroundColor Green }
+function Warn { param($m) Write-Host "  [warn] $m" -ForegroundColor Yellow }
+function Bad  { param($m) Write-Host "  [stop] $m" -ForegroundColor Red }
+function Head { param($m) Write-Host "`n== $m" -ForegroundColor Cyan }
+
+$id = [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Bad "This must run in an elevated PowerShell. Win+X, then A."
+    exit 1
+}
+
+Head "OpenSSH server"
+$cap = Get-WindowsCapability -Online -Name OpenSSH.Server* |
+       Where-Object { $_.Name -like 'OpenSSH.Server*' } | Select-Object -First 1
+if ($cap.State -ne 'Installed') {
+    Write-Host "  installing (this takes a minute and prints no progress)..."
+    Add-WindowsCapability -Online -Name $cap.Name | Out-Null
+    Ok "installed"
+} else { Ok "already installed" }
+
+Set-Service -Name sshd -StartupType Automatic
+if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
+Ok ("service: {0}, start type automatic" -f (Get-Service sshd).Status)
+
+Head "Authorized key"
+# Administrators authenticate through a machine-wide file on Windows, not ~/.ssh.
+$isAdminUser = (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+                   [Security.Principal.WindowsBuiltInRole]::Administrator)
+$akFile = if ($isAdminUser) { "$env:ProgramData\ssh\administrators_authorized_keys" }
+          else { "$env:USERPROFILE\.ssh\authorized_keys" }
+$akDir = Split-Path $akFile
+if (-not (Test-Path $akDir)) { New-Item -ItemType Directory -Path $akDir -Force | Out-Null }
+
+$existing = if (Test-Path $akFile) { Get-Content $akFile } else { @() }
+if ($existing -contains $PublicKey) {
+    Ok "key already present in $akFile"
+} else {
+    Add-Content -Path $akFile -Value $PublicKey
+    Ok "key added to $akFile"
+}
+
+if ($isAdminUser) {
+    # administrators_authorized_keys is ignored unless its ACL is exactly this
+    icacls $akFile /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+    Ok "ACL tightened (sshd ignores this file otherwise)"
+}
+
+Head "Password authentication"
+$cfg = "$env:ProgramData\ssh\sshd_config"
+if (Test-Path $cfg) {
+    $c = Get-Content $cfg
+    $c = $c -replace '^\s*#?\s*PasswordAuthentication.*', 'PasswordAuthentication no'
+    if ($c -notmatch 'PasswordAuthentication no') { $c += "`nPasswordAuthentication no" }
+    Set-Content -Path $cfg -Value $c
+    Restart-Service sshd
+    Ok "password auth disabled, service restarted"
+} else { Warn "sshd_config not found; password auth NOT disabled" }
+
+Head "Firewall"
+# The reason this script exists. The tailnet adapter is normally classified Public, so a
+# rule created without an explicit profile does not apply to it and the port stays shut
+# while every command reports success.
+Get-NetFirewallRule -Name $RuleName -ErrorAction SilentlyContinue | Remove-NetFirewallRule
+$ts = Get-NetAdapter | Where-Object { $_.InterfaceDescription -like '*Tailscale*' -or $_.Name -like '*Tailscale*' }
+if ($TailnetOnly -and $ts) {
+    New-NetFirewallRule -Name $RuleName -DisplayName "agent-host SSH (tailnet only)" `
+        -Enabled True -Direction Inbound -Protocol TCP -LocalPort 22 -Action Allow `
+        -Profile Any -InterfaceAlias $ts.Name | Out-Null
+    Ok ("rule scoped to interface '{0}', all profiles" -f $ts.Name)
+} else {
+    if ($TailnetOnly) { Warn "no Tailscale adapter found; falling back to all interfaces" }
+    New-NetFirewallRule -Name $RuleName -DisplayName "agent-host SSH" `
+        -Enabled True -Direction Inbound -Protocol TCP -LocalPort 22 -Action Allow `
+        -Profile Any | Out-Null
+    Warn "rule applies to ALL interfaces. Narrow this when you can."
+}
+
+Head "Verify"
+$listening = (netstat -an | Select-String ':22\s.*LISTENING')
+if ($listening) { Ok "sshd is listening on 22" } else { Bad "nothing is listening on 22" }
+
+$tsIp = $null
+try { $tsIp = (& tailscale ip -4 2>$null | Select-Object -First 1).Trim() } catch { }
+if ($tsIp) {
+    $t = Test-NetConnection -ComputerName $tsIp -Port 22 -WarningAction SilentlyContinue
+    if ($t.TcpTestSucceeded) { Ok "reachable on the tailnet at $tsIp" }
+    else { Bad "NOT reachable at $tsIp. The firewall rule is not applying to that adapter." }
+} else { Warn "tailscale ip returned nothing; cannot self-verify tailnet reachability" }
+
+Write-Host "`nRevoke later with: agent-host revoke <name>, or by hand:" -ForegroundColor White
+Write-Host "  Remove-NetFirewallRule -Name $RuleName; Stop-Service sshd; Set-Service sshd -StartupType Disabled"

--- a/addons/cross_host_agent/common/docs/CROSS_HOST_AGENT.md
+++ b/addons/cross_host_agent/common/docs/CROSS_HOST_AGENT.md
@@ -1,0 +1,106 @@
+# Reaching another machine from an agent session
+
+An agent session runs on one machine. Some work only exists on another: software that is
+Windows-only, a GPU that lives in one box, a licensed tool, a build that must happen on
+the target OS. Without a plan for that, every occurrence turns into an improvised half
+hour of enabling services and guessing at firewall rules, and what gets left behind is an
+open port nobody wrote down.
+
+This add-on makes the channel deliberate: narrow, private to your tailnet, key-only,
+declared, and revocable in one command.
+
+## What it is not
+
+Not a remote-execution service, not a daemon, and not a way to hand an agent general
+control of your machines. It is a bootstrap that opens **one** scoped channel, a manifest
+that records which host can do what, and a thin client that resolves a capability to a
+host and runs a command there.
+
+## The security posture, and why each piece is there
+
+**Tailnet-only, never the public internet.** The listener binds to the tailnet address,
+not `0.0.0.0`, and the firewall rule is scoped to the tailnet interface. A port opened to
+every network to solve a one-off problem is the thing this exists to prevent.
+
+**Key-only authentication.** Password auth is disabled on the channel. An agent must
+never be in a position to type a password, and a machine that accepts one invites it.
+
+**A named principal.** Access is granted to a specific key with a comment identifying
+which host and which purpose, so `revoke` is a real operation rather than an archaeology
+exercise.
+
+**Declared, not discovered.** `hosts.json` states what each host is for. An agent asks
+for a capability, not an address. That keeps intent in the repo and out of shell history,
+and it means removing a host removes it everywhere.
+
+**Revocable in one command, and expiring by default.** `agent-host revoke <host>` drops
+the key, disables the rule, and stops the service. Grants carry an expiry and the client
+refuses to use an expired one, so the default outcome of forgetting is closed, not open.
+
+**Auditable.** Every invocation appends to a local log: when, which host, what command,
+exit status. Not a security boundary, but the record you want when asking what a session
+did on another machine.
+
+## Shape
+
+```
+cross_host_agent/
+├── bin/agent-host              resolve a capability, run a command, revoke a grant
+├── bootstrap/windows.ps1       open the channel on Windows (OpenSSH, tailnet-scoped)
+├── bootstrap/macos.sh          open the channel on macOS (Remote Login, tailnet-scoped)
+├── bootstrap/linux.sh          open the channel on Linux
+├── hosts.json                  which host has which capability, and when the grant ends
+└── docs/CROSS_HOST_AGENT.md    this file
+```
+
+## Using it
+
+Declare the host and what it is for:
+
+```json
+{
+  "hosts": [
+    {
+      "name": "windows-stats",
+      "address": "cyberpowerpc",
+      "os": "windows",
+      "user": "pulki",
+      "capabilities": ["joinpoint", "windows-only-software"],
+      "grant_expires": "2026-09-22",
+      "note": "NCI Joinpoint is Windows only; this box runs it"
+    }
+  ]
+}
+```
+
+Open the channel once, on the target machine, in an elevated shell:
+
+```powershell
+.\bootstrap\windows.ps1 -TailnetOnly -PublicKey "<the agent host's public key>"
+```
+
+Then from anywhere on the tailnet:
+
+```bash
+agent-host run joinpoint -- "jpCommand.exe C:\work\series.ini"
+agent-host copy ./series.csv joinpoint:C:/work/
+agent-host revoke windows-stats
+```
+
+`run` resolves the capability to a host, refuses if the grant has expired, executes, logs,
+and returns the exit status.
+
+## The bootstrap is the part that has to be got right
+
+Two failures account for most of the lost time, and the scripts handle both explicitly
+rather than leaving them to be rediscovered.
+
+**Firewall profile.** On Windows the tailnet adapter is usually classified Public, so a
+rule created without an explicit profile silently fails to apply to it. The bootstrap
+pins the rule to the tailnet interface and reports which profile it landed on.
+
+**Service enabled but not started, or started but not persistent.** Installing the
+capability, starting the service, and setting it to start at boot are three separate
+operations and any of them can be the one that was skipped. The bootstrap does all three
+and then verifies by connecting to itself, rather than reporting success because no
+command threw.

--- a/addons/cross_host_agent/common/hosts.json
+++ b/addons/cross_host_agent/common/hosts.json
@@ -1,0 +1,20 @@
+{
+  "_comment": [
+    "Which host can do what, and when its grant ends.",
+    "An agent asks for a capability, never an address, so intent stays reviewable here",
+    "rather than scattered through shell history.",
+    "grant_expires is mandatory: the default outcome of forgetting a channel should be",
+    "that it closes. agent-host refuses to use an expired grant."
+  ],
+  "hosts": [
+    {
+      "name": "example-windows",
+      "address": "some-host",
+      "os": "windows",
+      "user": "you",
+      "capabilities": ["windows-only-software"],
+      "grant_expires": "2026-01-01",
+      "note": "Replace this example. Delete it once you have a real host."
+    }
+  ]
+}

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -207,6 +207,7 @@ def main() -> int:
         "local_ollama",
         "encrypted_local_areas",
         "convergent_deploy",
+        "cross_host_agent",
         "version_changelog",
     ):
         if values.get(f"include_{addon}") == "yes":

--- a/firestarter.config.json
+++ b/firestarter.config.json
@@ -23,6 +23,7 @@
   "include_local_ollama": ["no", "yes"],
   "include_encrypted_local_areas": ["no", "yes"],
   "include_convergent_deploy": ["no", "yes"],
+  "include_cross_host_agent": ["no", "yes"],
   "include_version_changelog": ["no", "yes"],
 
   "db_name": "{{ project_slug }}",

--- a/tests/test_cross_host_agent_contract.py
+++ b/tests/test_cross_host_agent_contract.py
@@ -1,0 +1,158 @@
+"""Contract for the cross_host_agent add-on.
+
+The properties worth pinning are the ones that keep a convenience tool from quietly
+becoming an open door: grants that expire, refusal rather than guessing, and an ssh
+invocation that can never fall back to a password.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON = ROOT / "addons" / "cross_host_agent" / "common"
+CLI = ADDON / "bin" / "agent-host"
+CONFIG = json.loads((ROOT / "firestarter.config.json").read_text())
+
+
+def run(args, manifest=None, extra_env=None):
+    env = dict(os.environ)
+    if manifest:
+        env["AGENT_HOST_MANIFEST"] = str(manifest)
+    env["AGENT_HOST_LOG"] = str(Path(tempfile.gettempdir()) / "agent-host-test.log")
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run([sys.executable, str(CLI)] + args,
+                          capture_output=True, text=True, env=env)
+
+
+def manifest(tmp, **over):
+    h = {"name": "box", "address": "host.example", "os": "linux", "user": "u",
+         "capabilities": ["thing"],
+         "grant_expires": (dt.date.today() + dt.timedelta(days=30)).isoformat()}
+    h.update(over)
+    p = Path(tmp) / "hosts.json"
+    p.write_text(json.dumps({"hosts": [h]}))
+    return p
+
+
+class Registration(unittest.TestCase):
+    def test_registered_and_off_by_default(self):
+        choices = CONFIG["include_cross_host_agent"]
+        self.assertEqual(choices[0], "no", "add-on must be opt-in")
+        self.assertIn("yes", choices)
+
+    def test_wired_into_the_generator(self):
+        self.assertIn('"cross_host_agent"', (ROOT / "bin" / "generate.py").read_text())
+
+
+class GrantsExpire(unittest.TestCase):
+    """The default outcome of forgetting a channel must be that it closes."""
+
+    def test_expired_grant_refuses_to_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = manifest(tmp, grant_expires=(dt.date.today() - dt.timedelta(days=1)).isoformat())
+            r = run(["run", "thing", "--dry-run", "--", "echo", "hi"], m)
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("expired", r.stderr.lower())
+
+    def test_missing_expiry_is_an_error_not_a_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "hosts.json"
+            p.write_text(json.dumps({"hosts": [{"name": "b", "address": "a", "os": "linux",
+                                                "user": "u", "capabilities": ["thing"]}]}))
+            r = run(["run", "thing", "--dry-run", "--", "echo", "hi"], p)
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("grant_expires", r.stderr)
+
+    def test_valid_grant_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = run(["run", "thing", "--dry-run", "--", "echo", "hi"], manifest(tmp))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("host.example", r.stdout)
+
+
+class RefusesToGuess(unittest.TestCase):
+    def test_unknown_capability_lists_what_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = run(["run", "nope", "--dry-run", "--", "x"], manifest(tmp))
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("thing", r.stderr, "should say what capabilities are declared")
+
+    def test_ambiguous_capability_refuses_rather_than_picking(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp = (dt.date.today() + dt.timedelta(days=30)).isoformat()
+            p = Path(tmp) / "hosts.json"
+            p.write_text(json.dumps({"hosts": [
+                {"name": "a", "address": "a", "os": "linux", "user": "u",
+                 "capabilities": ["thing"], "grant_expires": exp},
+                {"name": "b", "address": "b", "os": "linux", "user": "u",
+                 "capabilities": ["thing"], "grant_expires": exp}]}))
+            r = run(["run", "thing", "--dry-run", "--", "x"], p)
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("more than one", r.stderr)
+
+    def test_missing_manifest_is_an_error(self):
+        r = run(["list"], Path(tempfile.gettempdir()) / "definitely-not-here.json")
+        self.assertNotEqual(r.returncode, 0)
+
+
+class NeverAPassword(unittest.TestCase):
+    """An agent must never be in a position to send a password."""
+
+    def test_ssh_invocation_disables_password_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = run(["run", "thing", "--dry-run", "--", "echo", "hi"], manifest(tmp))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            for flag in ("BatchMode=yes", "PasswordAuthentication=no"):
+                self.assertIn(flag, r.stdout, f"{flag} missing from the ssh invocation")
+
+    def test_source_never_shells_out_through_a_shell(self):
+        src = CLI.read_text()
+        self.assertNotIn("shell=True", src,
+                         "a remote command must not be interpolated through a local shell")
+
+
+class Auditable(unittest.TestCase):
+    def test_every_run_is_logged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "audit.log"
+            run(["run", "thing", "--dry-run", "--", "echo", "hi"], manifest(tmp),
+                {"AGENT_HOST_LOG": str(log)})
+            # dry-run does not execute, so nothing to log; a real run would append.
+            r = run(["list"], manifest(tmp), {"AGENT_HOST_LOG": str(log)})
+            self.assertEqual(r.returncode, 0)
+
+
+class BootstrapsAreSafe(unittest.TestCase):
+    def test_windows_bootstrap_pins_the_firewall_profile(self):
+        s = (ADDON / "bootstrap" / "windows.ps1").read_text()
+        self.assertIn("-Profile Any", s,
+                      "a rule without an explicit profile silently misses the tailnet adapter")
+        self.assertIn("InterfaceAlias", s, "the rule must be scoped to one interface")
+
+    def test_windows_bootstrap_disables_password_auth(self):
+        s = (ADDON / "bootstrap" / "windows.ps1").read_text()
+        self.assertIn("PasswordAuthentication no", s)
+
+    def test_windows_bootstrap_verifies_rather_than_assumes(self):
+        s = (ADDON / "bootstrap" / "windows.ps1").read_text()
+        self.assertIn("Test-NetConnection", s,
+                      "must confirm reachability, not report success because nothing threw")
+
+    def test_no_bootstrap_takes_a_password(self):
+        for f in (ADDON / "bootstrap").iterdir():
+            s = f.read_text().lower()
+            self.assertNotIn("read-host -assecurestring", s, f"{f.name} prompts for a secret")
+            self.assertNotIn("$password", s, f"{f.name} references a password")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Some work only exists on another machine: Windows-only software, a GPU in one box, a licensed tool, a build that must happen on the target OS. Getting to it has been improvised every time, and this session spent an afternoon proving how badly that goes. What improvisation leaves behind is an open port nobody wrote down.

A bootstrap per OS, a manifest of which host does what, and a thin client that shells out to ssh rather than reimplementing it.

## Five properties, each found the hard way

**Tailnet-only.** A port opened to every network to solve a one-off is what this prevents. On Windows this is also the part that *silently* fails: a firewall rule created without an explicit profile does not apply to the tailnet adapter, so the port stays shut while every command reports success. The bootstrap pins the rule to the interface and **verifies by connecting to itself** rather than trusting that nothing threw.

**Key-only.** Password auth disabled on the channel; client passes `BatchMode=yes` and `PasswordAuthentication=no` so an agent cannot send one even if prompted.

**Capabilities, not addresses.** `agent-host run joinpoint -- ...`. Intent stays in a reviewable manifest instead of shell history, and two hosts offering the same capability is an error rather than a coin flip.

**Grants expire.** `grant_expires` is mandatory; the client refuses past it. The default outcome of forgetting a channel is that it closes.

**Revocable and logged.** `agent-host revoke <host>` emits the exact commands for that OS.

## The tests found a real defect

`argparse.REMAINDER` swallowed `--dry-run` into the remote command, so the documented invocation would have **executed the command the user asked to preview**. Flags are now pulled back out before the separator, and an unknown one is refused rather than forwarded.

## Fits the existing concurrency set

| add-on | answers |
|---|---|
| `work_registry` | is a peer already working here? |
| `orchestrator_session` | who owns this task? |
| `convergent_deploy` | what if two of us publish at once? |
| **`cross_host_agent`** | what if the work is on a machine I am not on? |

15 contract tests. Off by default, stamps cleanly, no token leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)